### PR TITLE
feat: migrate frontend to canonical /api/v1

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,8 @@
 VITE_CLIENT_ID=myclientid
 VITE_CLIENT_SECRET=myclientsecret
-# URL da API do backend - altere conforme necessário
-VITE_API_BASE_URL=/api
+# URL canonica da API do backend (/api/v1)
+VITE_API_BASE_URL=/api/v1
+# Fallback legado temporario para /api (DEPRECATED)
+VITE_ENABLE_DEPRECATED_API_FALLBACK=false
 # Modo de desenvolvimento - permite funcionar sem backend
 VITE_DEV_MODE=true

--- a/README.md
+++ b/README.md
@@ -156,8 +156,9 @@ yarn install
 Crie um arquivo `.env` na raiz:
 
 ```env
-VITE_API_BASE_URL=http://localhost:8080/api
+VITE_API_BASE_URL=http://localhost:8080/api/v1
 VITE_DEV_MODE=true
+VITE_ENABLE_DEPRECATED_API_FALLBACK=false
 ```
 
 ### 4️⃣ Execute em desenvolvimento
@@ -184,8 +185,9 @@ http://localhost:5173
 
 | Variável | Descrição | Exemplo |
 |----------|-----------|---------|
-| `VITE_API_BASE_URL` | URL base da API backend | `http://localhost:8080/api` |
+| `VITE_API_BASE_URL` | URL base da API backend (canonica) | `http://localhost:8080/api/v1` |
 | `VITE_DEV_MODE` | Habilita modo desenvolvedor | `true` ou `false` |
+| `VITE_ENABLE_DEPRECATED_API_FALLBACK` | Fallback legado temporario para `/api` em 404 | `false` |
 
 ### 🏗️ Build para Produção
 

--- a/docs/ALERTS_CONTRACT.md
+++ b/docs/ALERTS_CONTRACT.md
@@ -7,7 +7,7 @@ Este documento descreve o contrato usado pelo frontend do Alert Center para evit
 
 ### 1) Diagnostico de prenhez
 - Metodo: `GET`
-- Rota: `/api/goatfarms/{farmId}/reproduction/alerts/pregnancy-diagnosis`
+- Rota: `/api/v1/goatfarms/{farmId}/reproduction/alerts/pregnancy-diagnosis`
 - Query:
   - `referenceDate` (opcional)
   - `page` (default frontend: `0`)
@@ -18,7 +18,7 @@ Este documento descreve o contrato usado pelo frontend do Alert Center para evit
 
 ### 2) Secagem (lactacao)
 - Metodo: `GET`
-- Rota: `/api/goatfarms/{farmId}/milk/alerts/dry-off`
+- Rota: `/api/v1/goatfarms/{farmId}/milk/alerts/dry-off`
 - Query:
   - `referenceDate` (opcional)
   - `page` (default frontend: `0`)
@@ -34,7 +34,7 @@ Este documento descreve o contrato usado pelo frontend do Alert Center para evit
 
 ### 3) Agenda sanitaria
 - Metodo: `GET`
-- Rota: `/api/goatfarms/{farmId}/health-events/alerts`
+- Rota: `/api/v1/goatfarms/{farmId}/health-events/alerts`
 - Query:
   - `windowDays` (default frontend: `7`)
 - Campos esperados:

--- a/src/api/BlogAPI/publicArticles.ts
+++ b/src/api/BlogAPI/publicArticles.ts
@@ -1,19 +1,16 @@
 import axios from "axios";
 import type { PaginatedResponse } from "../../types/api";
 import type { ArticlePublicDTO, ArticlePublicDetailDTO } from "../../Models/ArticleDTOs";
+import { resolvePublicBaseUrl } from "../../utils/apiConfig";
 
 const getPublicBaseURL = () => {
-  const envBaseURL = import.meta.env.VITE_API_BASE_URL;
-  if (envBaseURL) {
-    // Reverte para o comportamento anterior: remove /api do final
-    // O backend expõe endpoints públicos na raiz /public, fora do contexto /api
-    return envBaseURL.replace(/\/api\/?$/, "");
-  }
-  return "http://localhost:8080";
+  const base = resolvePublicBaseUrl();
+  return base || "";
 };
 
+const publicBaseURL = getPublicBaseURL();
 const publicClient = axios.create({
-  baseURL: `${getPublicBaseURL()}/public`,
+  baseURL: publicBaseURL ? `${publicBaseURL}/public` : "/public",
   timeout: 10000,
 });
 

--- a/src/api/GoatAPI/goat.ts
+++ b/src/api/GoatAPI/goat.ts
@@ -154,7 +154,7 @@ export async function findGoatsByFarmAndName(
   farmId: number,
   term: string
 ): Promise<GoatResponseDTO[]> {
-  // Backend validado: /api/goatfarms/{id}/goats/search?name=...&page=0&size=12
+  // Backend validado: /api/v1/goatfarms/{id}/goats/search?name=...&page=0&size=12
   const { data } = await requestBackEnd.get(`/goatfarms/${farmId}/goats/search`, {
     params: { name: term, page: 0, size: 12 },
   });

--- a/src/api/GoatFarmAPI/milkProduction.ts
+++ b/src/api/GoatFarmAPI/milkProduction.ts
@@ -6,15 +6,8 @@ import type {
 } from "../../Models/MilkProductionDTOs";
 import type { PaginatedResponse } from "../../types/api";
 
-const ensureApiPrefix = (path: string) => {
-  const baseUrl = `${requestBackEnd.defaults.baseURL ?? ""}`;
-  return /\/api\/?$/i.test(baseUrl) ? path : `/api${path}`;
-};
-
 const getBaseUrl = (farmId: number, goatId: string) =>
-  ensureApiPrefix(
-    `/goatfarms/${farmId}/goats/${encodeURIComponent(goatId)}/milk-productions`
-  );
+  `/goatfarms/${farmId}/goats/${encodeURIComponent(goatId)}/milk-productions`;
 
 export async function createMilkProduction(
   farmId: number,

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -1,83 +1,107 @@
-// src/api/apiClient.ts
-import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
-import { ApiError } from '../types/api';
+import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from "axios";
+import { ApiError, ValidationError } from "../types/api";
+import { resolveApiBaseUrl } from "../utils/apiConfig";
+
+type BackendErrorPayload = {
+  message?: string;
+  error?: string;
+  code?: string;
+  status?: number;
+  timestamp?: string;
+  path?: string;
+  errors?: Array<{ fieldName?: string; field?: string; message?: string }>;
+};
+
+const toValidationErrors = (
+  values: BackendErrorPayload["errors"]
+): ValidationError[] | undefined => {
+  if (!Array.isArray(values) || values.length === 0) {
+    return undefined;
+  }
+
+  return values.map((entry) => ({
+    fieldName: entry.fieldName ?? entry.field,
+    message: entry.message ?? "Valor invalido",
+  }));
+};
 
 class ApiClient {
   private instance: AxiosInstance;
 
   constructor() {
-    const baseURL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080/api';
-    
+    const baseURL = resolveApiBaseUrl();
+
     this.instance = axios.create({
       baseURL,
       timeout: 10000,
       headers: {
-        'Content-Type': 'application/json',
+        "Content-Type": "application/json",
       },
     });
-    
-    if (import.meta.env.VITE_DEV_MODE === 'true') {
-      console.log('🔧 ApiClient configurado com baseURL:', baseURL);
+
+    if (import.meta.env.VITE_DEV_MODE === "true") {
+      console.log("[ApiClient] baseURL:", baseURL);
     }
 
     this.setupInterceptors();
   }
 
   private setupInterceptors(): void {
-    // Request interceptor to add auth token
     this.instance.interceptors.request.use(
       (config) => {
-        const token = localStorage.getItem('authToken');
+        const token = localStorage.getItem("authToken");
         if (token) {
           config.headers.Authorization = `Bearer ${token}`;
         }
         return config;
       },
-      (error) => {
-        return Promise.reject(error);
-      }
+      (error) => Promise.reject(error)
     );
 
-    // Response interceptor to handle errors
     this.instance.interceptors.response.use(
       (response) => response,
       async (error) => {
         const originalRequest = error.config;
 
-        // Handle 401 errors (unauthorized)
-        if (error.response?.status === 401 && !originalRequest._retry) {
+        if (error.response?.status === 401 && !originalRequest?._retry) {
           originalRequest._retry = true;
 
           try {
-            const refreshToken = localStorage.getItem('refreshToken');
+            const refreshToken = localStorage.getItem("refreshToken");
             if (refreshToken) {
-              const response = await this.instance.post('/auth/refresh', {
+              const response = await this.instance.post("/auth/refresh", {
                 refreshToken,
               });
 
-              const { token } = response.data;
-              localStorage.setItem('authToken', token);
+              const { token, accessToken, access_token } = response.data ?? {};
+              const nextToken = token || accessToken || access_token;
 
-              // Retry the original request with new token
-              originalRequest.headers.Authorization = `Bearer ${token}`;
+              if (!nextToken) {
+                throw new Error("No access token in refresh response");
+              }
+
+              localStorage.setItem("authToken", nextToken);
+              originalRequest.headers.Authorization = `Bearer ${nextToken}`;
               return this.instance(originalRequest);
             }
           } catch (refreshError) {
-            // Refresh failed, redirect to login
-            localStorage.removeItem('authToken');
-            localStorage.removeItem('refreshToken');
-            localStorage.removeItem('user');
-            window.location.href = '/login';
+            localStorage.removeItem("authToken");
+            localStorage.removeItem("refreshToken");
+            localStorage.removeItem("user");
+            window.location.href = "/login";
             return Promise.reject(refreshError);
           }
         }
 
-        // Transform error to our custom format
+        const payload = (error.response?.data ?? {}) as BackendErrorPayload;
         const apiError: ApiError = {
-          message: error.response?.data?.message || error.message || 'An error occurred',
-          code: error.response?.data?.code || 'UNKNOWN_ERROR',
-          timestamp: new Date().toISOString(),
-          path: error.config?.url || '',
+          message: payload.message || payload.error || error.message || "An error occurred",
+          code: payload.code || payload.error || error.code || "UNKNOWN_ERROR",
+          timestamp: payload.timestamp || new Date().toISOString(),
+          path: payload.path || error.config?.url || "",
+          status: error.response?.status,
+          error: payload.error,
+          errors: toValidationErrors(payload.errors),
         };
 
         return Promise.reject(apiError);

--- a/src/services/address-service.ts
+++ b/src/services/address-service.ts
@@ -1,9 +1,10 @@
 import axios, { AxiosResponse } from 'axios';
 import { AddressRequestDTO, AddressResponseDTO, AddressValidationErrors } from '../types/address.types';
 import { ApiError, ErrorCodes } from './goat-farm-service';
+import { resolveApiBaseUrl } from '../utils/apiConfig';
 
 // Configuração da API
-const API_BASE_URL = 'http://localhost:8080';
+const API_BASE_URL = resolveApiBaseUrl();
 const ADDRESS_ENDPOINT = '/addresses';
 
 console.log('🔧 Address Service - API Base URL:', API_BASE_URL);
@@ -183,6 +184,19 @@ export const handleAddressError = (error: unknown): ApiError => {
           409,
           ErrorCodes.DUPLICATE_ENTRY
         );
+      case 404:
+        return createApiError(
+          data?.message || 'Recurso nao encontrado',
+          404,
+          ErrorCodes.INVALID_DATA
+        );
+      case 422:
+        return createApiError(
+          data?.message || 'Regra de negocio violada. Revise os dados enviados.',
+          422,
+          ErrorCodes.VALIDATION_ERROR,
+          data?.errors
+        );
       case 500:
         return createApiError(
           `Erro interno do servidor. Verifique se o backend está rodando em ${API_BASE_URL}`,
@@ -227,3 +241,4 @@ const createApiError = (
     details,
   };
 };
+

--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -4,6 +4,7 @@ import { jwtDecode } from "jwt-decode";
 
 import { CredentialsDTO, AccessTokenPayloadDTO, RoleEnum } from "../Models/auth";
 import { requestBackEnd } from "../utils/request";
+import { resolveApiBaseUrl } from "../utils/apiConfig";
 import * as accessTokenRepository from "../localstorage/access-token-repository";
 
 interface UserFormData {
@@ -147,7 +148,7 @@ export async function registerUser(formData: UserFormData): Promise<ApiResponse<
 
     // Cria instância axios para requisições públicas
     const publicApi = axios.create({
-      baseURL: 'http://localhost:8080',
+      baseURL: resolveApiBaseUrl(),
       headers: {
         'Content-Type': 'application/json'
       },
@@ -231,6 +232,20 @@ function handleRegistrationError(error: unknown): ApiError {
           data?.message || 'Dados inválidos. Verifique as informações.',
           400,
           ErrorCodes.INVALID_DATA,
+          data
+        );
+      case 404:
+        return createApiError(
+          data?.message || 'Recurso nao encontrado.',
+          404,
+          ErrorCodes.INVALID_DATA,
+          data
+        );
+      case 422:
+        return createApiError(
+          data?.message || 'Regra de negocio violada. Revise os campos enviados.',
+          422,
+          ErrorCodes.VALIDATION_ERROR,
           data
         );
       case 500:

--- a/src/services/goat-farm-service.ts
+++ b/src/services/goat-farm-service.ts
@@ -6,10 +6,11 @@ import {
   GoatFarmResponse, 
   GoatFarmValidationError
 } from '../types/goat-farm.types';
+import { resolveApiBaseUrl } from '../utils/apiConfig';
 // import { getAccessToken } from './auth-service'; // Removido temporariamente para testes
 
 // Configuração base da API
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080';
+const API_BASE_URL = resolveApiBaseUrl();
 const GOAT_FARMS_ENDPOINT = '/goatfarms';
 
 // Log da configuração da API
@@ -395,6 +396,20 @@ function handleGoatFarmError(error: unknown): ApiError {
         );
       }
       
+      case 404:
+        return createApiError(
+          data?.message || 'Recurso nao encontrado',
+          404,
+          ErrorCodes.INVALID_DATA,
+          data
+        );
+      case 422:
+        return createApiError(
+          data?.message || 'Regra de negocio violada. Revise os dados enviados.',
+          422,
+          ErrorCodes.VALIDATION_ERROR,
+          data?.errors || data
+        );
       case 500:
         return createApiError(
           'Erro interno do servidor. Tente novamente mais tarde.',
@@ -439,3 +454,4 @@ function createApiError(message: string, status?: number, code?: ErrorCodes, det
 
 // Exportar tipos e enums para uso em outros arquivos
 export { ErrorCodes, type ApiError, type ApiResponse };
+

--- a/src/services/phone-service.ts
+++ b/src/services/phone-service.ts
@@ -1,9 +1,10 @@
 import axios, { AxiosResponse } from 'axios';
 import { PhoneRequestDTO, PhoneResponseDTO, PhoneValidationErrors, PhoneType } from '../types/phone.types';
 import { ApiError, ErrorCodes } from './goat-farm-service';
+import { resolveApiBaseUrl } from '../utils/apiConfig';
 
 // Configuração da API
-const API_BASE_URL = 'http://localhost:8080';
+const API_BASE_URL = resolveApiBaseUrl();
 const PHONE_ENDPOINT = '/phones';
 
 console.log('🔧 Phone Service - API Base URL:', API_BASE_URL);
@@ -165,6 +166,19 @@ export const handlePhoneError = (error: unknown): ApiError => {
           409,
           ErrorCodes.DUPLICATE_ENTRY
         );
+      case 404:
+        return createApiError(
+          data?.message || 'Recurso nao encontrado',
+          404,
+          ErrorCodes.INVALID_DATA
+        );
+      case 422:
+        return createApiError(
+          data?.message || 'Regra de negocio violada. Revise os dados enviados.',
+          422,
+          ErrorCodes.VALIDATION_ERROR,
+          data?.errors
+        );
       case 500:
         return createApiError(
           `Erro interno do servidor. Verifique se o backend está rodando em ${API_BASE_URL}`,
@@ -209,3 +223,4 @@ const createApiError = (
     details,
   };
 };
+

--- a/src/services/user-service.ts
+++ b/src/services/user-service.ts
@@ -1,9 +1,10 @@
 import axios, { AxiosResponse } from 'axios';
 import { UserRequestDTO, UserResponseDTO, UserValidationErrors } from '../types/user.types';
 import { ApiError, ErrorCodes } from './goat-farm-service';
+import { resolveApiBaseUrl } from '../utils/apiConfig';
 
 // Configuração da API
-const API_BASE_URL = 'http://localhost:8080';
+const API_BASE_URL = resolveApiBaseUrl();
 const USER_ENDPOINT = '/users';
 
 console.log('🔧 User Service - API Base URL:', API_BASE_URL);
@@ -178,6 +179,19 @@ export const handleUserError = (error: unknown): ApiError => {
           409,
           ErrorCodes.DUPLICATE_ENTRY
         );
+      case 404:
+        return createApiError(
+          data?.message || 'Recurso nao encontrado',
+          404,
+          ErrorCodes.INVALID_DATA
+        );
+      case 422:
+        return createApiError(
+          data?.message || 'Regra de negocio violada. Revise os dados enviados.',
+          422,
+          ErrorCodes.VALIDATION_ERROR,
+          data?.errors
+        );
       case 500:
         return createApiError(
           `Erro interno do servidor. Verifique se o backend está rodando em ${API_BASE_URL}`,
@@ -222,3 +236,4 @@ const createApiError = (
     details,
   };
 };
+

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -134,13 +134,18 @@ export interface RefreshTokenResponseDTO {
 // Error types
 export interface ApiError {
   message: string;
-  code: string;
-  timestamp: string;
-  path: string;
+  code?: string;
+  timestamp?: string;
+  path?: string;
+  status?: number;
+  error?: string;
+  details?: unknown;
+  errors?: ValidationError[];
 }
 
 export interface ValidationError {
-  field: string;
+  fieldName?: string;
+  field?: string;
   message: string;
 }
 

--- a/src/utils/apiConfig.test.ts
+++ b/src/utils/apiConfig.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveApiBaseUrl,
+  resolveLegacyApiBaseUrl,
+  resolvePublicBaseUrl,
+} from "./apiConfig";
+
+describe("apiConfig", () => {
+  it("normalizes canonical base from legacy /api", () => {
+    expect(resolveApiBaseUrl("/api")).toBe("/api/v1");
+    expect(resolveApiBaseUrl("http://localhost:8080/api")).toBe("http://localhost:8080/api/v1");
+  });
+
+  it("keeps canonical base when /api/v1 is already configured", () => {
+    expect(resolveApiBaseUrl("/api/v1")).toBe("/api/v1");
+    expect(resolveApiBaseUrl("http://localhost:8080/api/v1")).toBe("http://localhost:8080/api/v1");
+  });
+
+  it("builds legacy base as controlled deprecated fallback", () => {
+    expect(resolveLegacyApiBaseUrl("/api/v1")).toBe("/api");
+    expect(resolveLegacyApiBaseUrl("http://localhost:8080/api/v1")).toBe("http://localhost:8080/api");
+  });
+
+  it("keeps public base outside API versioning", () => {
+    expect(resolvePublicBaseUrl("/api/v1")).toBe("");
+    expect(resolvePublicBaseUrl("http://localhost:8080/api/v1")).toBe("http://localhost:8080");
+  });
+});

--- a/src/utils/apiConfig.ts
+++ b/src/utils/apiConfig.ts
@@ -1,2 +1,50 @@
-// Removido BASE_URL absoluta - usar requestBackEnd do request.ts ou apiClient
-// export const BASE_URL = "http://localhost:8080";
+const DEFAULT_API_ORIGIN = "http://localhost:8080";
+export const API_PREFIX = "/api/v1";
+export const LEGACY_API_PREFIX = "/api"; // DEPRECATED: remove after 2026-06-30
+
+const trimTrailingSlash = (value: string): string => value.replace(/\/+$/, "");
+
+const stripKnownApiSuffix = (value: string): string =>
+  value.replace(/\/api(?:\/v\d+)?$/i, "");
+
+const normalizeBaseInput = (value?: string): string => {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return DEFAULT_API_ORIGIN;
+  }
+  return trimTrailingSlash(trimmed);
+};
+
+const withApiPrefix = (base: string, prefix: string): string => {
+  const normalizedBase = trimTrailingSlash(base);
+
+  if (!normalizedBase || normalizedBase === "/") {
+    return prefix;
+  }
+
+  if (normalizedBase.endsWith(prefix)) {
+    return normalizedBase;
+  }
+
+  const withoutSuffix = stripKnownApiSuffix(normalizedBase);
+  if (withoutSuffix !== normalizedBase) {
+    return `${withoutSuffix}${prefix}`;
+  }
+
+  return `${normalizedBase}${prefix}`;
+};
+
+export const resolveApiBaseUrl = (
+  baseUrl: string | undefined = import.meta.env.VITE_API_BASE_URL
+): string => withApiPrefix(normalizeBaseInput(baseUrl), API_PREFIX);
+
+export const resolveLegacyApiBaseUrl = (
+  baseUrl: string | undefined = import.meta.env.VITE_API_BASE_URL
+): string => withApiPrefix(normalizeBaseInput(baseUrl), LEGACY_API_PREFIX);
+
+export const resolvePublicBaseUrl = (
+  baseUrl: string | undefined = import.meta.env.VITE_API_BASE_URL
+): string => stripKnownApiSuffix(normalizeBaseInput(baseUrl));
+
+export const isDeprecatedApiFallbackEnabled = (): boolean =>
+  import.meta.env.VITE_ENABLE_DEPRECATED_API_FALLBACK === "true";

--- a/src/utils/apiError.test.ts
+++ b/src/utils/apiError.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { getApiErrorMessage, parseApiError } from "./apiError";
+
+const asAxiosLikeError = (status: number, data: Record<string, unknown>) => ({
+  response: {
+    status,
+    data,
+  },
+});
+
+describe("apiError", () => {
+  it("parses backend validation payload and maps 422 message", () => {
+    const parsed = parseApiError(
+      asAxiosLikeError(422, {
+        error: "Regra de negocio violada",
+        errors: [{ fieldName: "quantity", message: "Saldo insuficiente" }],
+      })
+    );
+
+    expect(parsed.status).toBe(422);
+    expect(parsed.fieldErrors).toEqual([{ fieldName: "quantity", message: "Saldo insuficiente" }]);
+    expect(getApiErrorMessage(parsed)).toBe("Saldo insuficiente");
+  });
+
+  it("maps required status messages for migration contract", () => {
+    expect(
+      getApiErrorMessage(
+        parseApiError(asAxiosLikeError(400, { message: "Payload invalido" }))
+      )
+    ).toBe("Payload invalido");
+
+    expect(
+      getApiErrorMessage(
+        parseApiError(asAxiosLikeError(404, { message: "Nao encontrado" }))
+      )
+    ).toBe("Nao encontrado");
+
+    expect(
+      getApiErrorMessage(
+        parseApiError(asAxiosLikeError(409, { message: "Registro duplicado" }))
+      )
+    ).toBe("Registro duplicado");
+  });
+});

--- a/src/utils/apiError.ts
+++ b/src/utils/apiError.ts
@@ -1,33 +1,81 @@
 export type ParsedApiError = {
   status?: number;
   message?: string;
+  error?: string;
+  path?: string;
   details?: unknown;
+  fieldErrors?: Array<{ fieldName?: string; message: string }>;
+};
+
+type RawFieldError = {
+  fieldName?: string;
+  field?: string;
+  message?: string;
+};
+
+const collectFieldErrors = (
+  values: RawFieldError[] | undefined
+): ParsedApiError["fieldErrors"] => {
+  if (!Array.isArray(values) || values.length === 0) {
+    return undefined;
+  }
+
+  return values
+    .filter((entry) => Boolean(entry?.message))
+    .map((entry) => ({
+      fieldName: entry.fieldName ?? entry.field,
+      message: entry.message ?? "Valor invalido",
+    }));
 };
 
 export const parseApiError = (error: unknown): ParsedApiError => {
   const err = error as {
     message?: string;
-    response?: { status?: number; data?: { message?: string; error?: string; details?: unknown } };
+    response?: {
+      status?: number;
+      data?: {
+        message?: string;
+        error?: string;
+        path?: string;
+        details?: unknown;
+        errors?: RawFieldError[];
+      };
+    };
   };
+
+  const responseData = err?.response?.data;
+  const fieldErrors = collectFieldErrors(responseData?.errors);
 
   return {
     status: err?.response?.status,
-    message: err?.response?.data?.message || err?.response?.data?.error || err?.message,
-    details: err?.response?.data?.details,
+    message: responseData?.message || responseData?.error || err?.message,
+    error: responseData?.error,
+    path: responseData?.path,
+    details: responseData?.details,
+    fieldErrors,
   };
+};
+
+const buildFieldErrorMessage = (parsed: ParsedApiError): string | undefined => {
+  if (!parsed.fieldErrors || parsed.fieldErrors.length === 0) return undefined;
+  return parsed.fieldErrors.map((entry) => entry.message).join(" ");
 };
 
 export const getApiErrorMessage = (parsed: ParsedApiError): string => {
   const message = parsed.message?.trim();
+  const fieldErrors = buildFieldErrorMessage(parsed);
+
   switch (parsed.status) {
-    case 422:
-      return `Verifique os dados: ${message || "campos inválidos ou incompletos."}`;
-    case 409:
-      return `Ação bloqueada: ${message || "conflito de dados (já existe?)."}`;
-    case 403:
-      return "Acesso negado. Apenas proprietário ou admin podem realizar esta ação.";
+    case 400:
+      return message || fieldErrors || "Requisicao invalida. Revise os dados enviados.";
     case 404:
-      return "Recurso não encontrado. Tente atualizar a página.";
+      return message || "Recurso nao encontrado. Atualize a pagina e tente novamente.";
+    case 409:
+      return message || "Conflito de dados. Pode existir registro duplicado.";
+    case 422:
+      return fieldErrors || message || "Regra de negocio violada. Revise os campos.";
+    case 403:
+      return "Acesso negado. Apenas proprietario ou admin podem realizar esta acao.";
     default:
       return message || "Erro inesperado. Tente novamente.";
   }

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -1,39 +1,63 @@
-import axios, { AxiosError, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig, AxiosHeaders } from "axios";
+import axios, {
+  AxiosError,
+  AxiosHeaders,
+  AxiosRequestConfig,
+  AxiosResponse,
+  InternalAxiosRequestConfig,
+} from "axios";
+import { toast } from "react-toastify";
 import { getAuthHeaders, isPublicEndpoint } from "../services/auth-service";
 import { isPublicEndpoint as permissionIsPublic } from "../services/PermissionService";
-import { toast } from "react-toastify";
+import {
+  API_PREFIX,
+  isDeprecatedApiFallbackEnabled,
+  resolveApiBaseUrl,
+  resolveLegacyApiBaseUrl,
+} from "./apiConfig";
 
-// Configuração base do axios
-const getBaseURL = () => {
-  const envBaseURL = import.meta.env.VITE_API_BASE_URL;
-  const devMode = import.meta.env.VITE_DEV_MODE === 'true';
-  
-  if (devMode && !envBaseURL) {
-    console.warn('⚠️ MODO DESENVOLVIMENTO: Backend não configurado. Usando URL padrão.');
-  }
-  
-  // Se houver VITE_API_BASE_URL, use-o diretamente. Caso contrário, use localhost.
-  // IMPORTANTE: Se a URL base já contiver /api (como http://localhost:8080/api), 
-  // as chamadas subsequentes NÃO devem adicionar /api novamente.
-  return envBaseURL || "http://localhost:8080";
+type RequestWithRetryFlags = InternalAxiosRequestConfig & {
+  _retry?: boolean;
+  _legacyRetry?: boolean;
 };
+
+const getBaseURL = () => resolveApiBaseUrl();
+const getDeprecatedLegacyBaseURL = () => resolveLegacyApiBaseUrl();
+const getRefreshUrl = () => `${getBaseURL()}/auth/refresh`;
+
+const shouldUseLegacyFallback = (
+  error: AxiosError,
+  originalRequest: RequestWithRetryFlags
+): boolean => {
+  if (!isDeprecatedApiFallbackEnabled()) return false;
+  if (originalRequest._legacyRetry) return false;
+  if (error.response?.status !== 404) return false;
+
+  const baseURL = `${originalRequest.baseURL ?? getBaseURL()}`;
+  return baseURL.includes(API_PREFIX);
+};
+
+const withLegacyBaseURL = (
+  originalRequest: RequestWithRetryFlags
+): RequestWithRetryFlags => ({
+  ...originalRequest,
+  baseURL: getDeprecatedLegacyBaseURL(),
+  _legacyRetry: true,
+});
 
 export const requestBackEnd = axios.create({
   baseURL: getBaseURL(),
   timeout: 15000,
   headers: {
-    'Content-Type': 'application/json',
+    "Content-Type": "application/json",
   },
 });
 
-// Flag para evitar múltiplas tentativas de refresh
 let isRefreshing = false;
 let failedQueue: Array<{
   resolve: (value: unknown) => void;
   reject: (error: unknown) => void;
 }> = [];
 
-// Processa a fila de requisições após refresh do token
 const processQueue = (error: unknown, token: string | null = null) => {
   failedQueue.forEach(({ resolve, reject }) => {
     if (error) {
@@ -42,26 +66,23 @@ const processQueue = (error: unknown, token: string | null = null) => {
       resolve(token);
     }
   });
-  
+
   failedQueue = [];
 };
 
-// Interceptor de requisição - adiciona token automaticamente
 requestBackEnd.interceptors.request.use(
   (config: InternalAxiosRequestConfig) => {
-    const url = config.url || '';
-    const method = config.method?.toUpperCase() || 'GET';
-    
-    // Verifica se é endpoint público usando ambos os serviços
+    const url = config.url || "";
+    const method = config.method?.toUpperCase() || "GET";
+
     const isPublicAuth = isPublicEndpoint(url, method);
     const isPublicPermission = permissionIsPublic(url, method);
     const isPublic = isPublicAuth || isPublicPermission;
-    
+
     if (import.meta.env.DEV) {
       console.log(`[RequestBackend] ${method} ${url} - Public: ${isPublic}`);
     }
-    
-    // Obtém headers de autenticação apenas para endpoints privados
+
     if (!isPublic) {
       const authHeaders = getAuthHeaders(url, method);
       const mergedHeaders = new AxiosHeaders(config.headers);
@@ -69,196 +90,171 @@ requestBackEnd.interceptors.request.use(
         if (value) mergedHeaders.set(key, value);
       });
       config.headers = mergedHeaders;
-      
+
       if (import.meta.env.DEV && authHeaders.Authorization) {
-        console.log('[RequestBackend] Token adicionado');
+        console.log("[RequestBackend] Token adicionado");
       }
     }
-    
+
     return config;
   },
   (error) => {
-    console.error('[RequestBackend] Erro na requisição:', error);
+    console.error("[RequestBackend] Erro na requisicao:", error);
     return Promise.reject(error);
   }
 );
 
-// Interceptor de resposta - trata erros e refresh token
 requestBackEnd.interceptors.response.use(
-  (response: AxiosResponse) => {
-    return response;
-  },
+  (response: AxiosResponse) => response,
   async (error: AxiosError) => {
-    const originalRequest = error.config as InternalAxiosRequestConfig & { _retry?: boolean };
-    
-    // Trata erro 401 (Unauthorized) - mas só para endpoints privados
+    const originalRequest = (error.config ?? {}) as RequestWithRetryFlags;
+
     if (error.response?.status === 401 && !originalRequest._retry) {
-      const url = originalRequest.url || '';
-      const method = originalRequest.method?.toUpperCase() || 'GET';
-      
-      // Verifica se é endpoint público - se for, não tenta refresh
+      const url = originalRequest.url || "";
+      const method = originalRequest.method?.toUpperCase() || "GET";
+
       const isPublicAuth = isPublicEndpoint(url, method);
       const isPublicPermission = permissionIsPublic(url, method);
       const isPublic = isPublicAuth || isPublicPermission;
-      
+
       if (isPublic) {
-        console.log(`[RequestBackend] Erro 401 em endpoint público: ${method} ${url}`);
+        console.log(`[RequestBackend] Erro 401 em endpoint publico: ${method} ${url}`);
         return Promise.reject(error);
       }
+
       if (isRefreshing) {
-        // Se já está fazendo refresh, adiciona à fila
         return new Promise((resolve, reject) => {
           failedQueue.push({ resolve, reject });
-        }).then(() => {
-          return requestBackEnd(originalRequest);
-        }).catch(err => {
-          return Promise.reject(err);
-        });
+        })
+          .then(() => requestBackEnd(originalRequest))
+          .catch((refreshError) => Promise.reject(refreshError));
       }
 
       originalRequest._retry = true;
       isRefreshing = true;
 
       try {
-        // Tenta fazer refresh do token
-        const refreshToken = localStorage.getItem('refresh_token');
-        
+        const refreshToken = localStorage.getItem("refresh_token");
+
         if (refreshToken) {
-          const response = await axios.post('/api/auth/refresh', {
-            refreshToken
+          const response = await axios.post(getRefreshUrl(), {
+            refreshToken,
           });
-          
-          const { access_token, refresh_token: newRefreshToken } = response.data;
-          
-          // Atualiza tokens no localStorage usando auth-service
-          localStorage.setItem('authToken', access_token);
-          if (newRefreshToken) {
-            localStorage.setItem('refresh_token', newRefreshToken);
+
+          const { accessToken, access_token, refreshToken: nextRefreshToken, refresh_token } =
+            response.data ?? {};
+
+          const nextAccessToken = accessToken || access_token;
+          const nextRefresh = nextRefreshToken || refresh_token;
+
+          if (!nextAccessToken) {
+            throw new Error("No access token in refresh response");
           }
-          
-          // Processa fila de requisições pendentes
-          processQueue(null, access_token);
-          
-          // Refaz a requisição original
+
+          localStorage.setItem("authToken", nextAccessToken);
+          if (nextRefresh) {
+            localStorage.setItem("refresh_token", nextRefresh);
+          }
+
+          processQueue(null, nextAccessToken);
           return requestBackEnd(originalRequest);
-        } else {
-          throw new Error('No refresh token available');
         }
+
+        throw new Error("No refresh token available");
       } catch (refreshError) {
-        // Falha no refresh - limpa tokens e redireciona
         processQueue(refreshError, null);
-        localStorage.removeItem('authToken');
-        localStorage.removeItem('refresh_token');
-        
-        // Notifica o usuário
-        toast.error('Sessão expirada. Faça login novamente.');
-        
+        localStorage.removeItem("authToken");
+        localStorage.removeItem("refresh_token");
+        toast.error("Sessao expirada. Faca login novamente.");
         return Promise.reject(refreshError);
       } finally {
         isRefreshing = false;
       }
     }
-    
-    // Trata erro 403 (Forbidden)
+
+    if (shouldUseLegacyFallback(error, originalRequest)) {
+      if (import.meta.env.DEV) {
+        console.warn(
+          `[RequestBackend][DEPRECATED] Fallback legado ativo para ${originalRequest.method?.toUpperCase() || "GET"} ${originalRequest.url}`
+        );
+      }
+      return requestBackEnd(withLegacyBaseURL(originalRequest));
+    }
+
     if (error.response?.status === 403) {
-      toast.error('Você não tem permissão para realizar esta ação.');
-      
-      console.log('🔍 DEBUG: Interceptor detectou erro 403, mas não redirecionando automaticamente');
+      toast.error("Voce nao tem permissao para realizar esta acao.");
+      console.log("[RequestBackend] Erro 403 detectado");
     }
-    
-    // Trata outros erros de servidor
+
     if (error.response?.status && error.response.status >= 500) {
-      toast.error('Erro interno do servidor. Tente novamente mais tarde.');
+      toast.error("Erro interno do servidor. Tente novamente mais tarde.");
     }
-    
-    // Trata erros de rede
+
     if (!error.response) {
-      const devMode = import.meta.env.VITE_DEV_MODE === 'true';
+      const devMode = import.meta.env.VITE_DEV_MODE === "true";
       const baseURL = getBaseURL();
-      
-      console.error('[RequestBackend] Erro de rede - servidor indisponível');
-      
+
+      console.error("[RequestBackend] Erro de rede - servidor indisponivel");
+
       if (devMode) {
-        if (!toast.isActive('backend-offline')) {
+        if (!toast.isActive("backend-offline")) {
           toast.error(
-            `🔧 MODO DESENVOLVIMENTO: Backend não está rodando em ${baseURL}. ` +
-            'Inicie o servidor backend ou configure VITE_API_BASE_URL no arquivo .env',
-            { autoClose: 8000, toastId: 'backend-offline' }
+            `MODO DESENVOLVIMENTO: Backend nao esta rodando em ${baseURL}. ` +
+              "Inicie o backend ou configure VITE_API_BASE_URL no arquivo .env",
+            { autoClose: 8000, toastId: "backend-offline" }
           );
         }
-      } else {
-        if (!toast.isActive('backend-offline')) {
-          toast.error('Erro de conexão com o servidor. Verifique sua conexão.', {
-            autoClose: 8000,
-            toastId: 'backend-offline',
-          });
-        }
+      } else if (!toast.isActive("backend-offline")) {
+        toast.error("Erro de conexao com o servidor. Verifique sua conexao.", {
+          autoClose: 8000,
+          toastId: "backend-offline",
+        });
       }
     }
-    
+
     if (import.meta.env.DEV) {
-      console.error('[RequestBackend] Erro na resposta:', error);
+      console.error("[RequestBackend] Erro na resposta:", error);
     }
-    
+
     return Promise.reject(error);
   }
 );
 
-/**
- * Função utilitária para fazer requisições com tratamento de erros padronizado
- */
-export const makeRequest = async <T = unknown>(
-  config: AxiosRequestConfig
-): Promise<T> => {
+export const makeRequest = async <T = unknown>(config: AxiosRequestConfig): Promise<T> => {
   const response = await requestBackEnd(config);
   return response.data;
 };
 
-/**
- * Função para requisições GET
- */
 export const get = <T = unknown>(url: string, config?: AxiosRequestConfig): Promise<T> => {
-  return makeRequest<T>({ ...config, method: 'GET', url });
+  return makeRequest<T>({ ...config, method: "GET", url });
 };
 
-/**
- * Função para requisições POST
- */
 export const post = <T = unknown>(
   url: string,
   data?: unknown,
   config?: AxiosRequestConfig
 ): Promise<T> => {
-  return makeRequest<T>({ ...config, method: 'POST', url, data });
+  return makeRequest<T>({ ...config, method: "POST", url, data });
 };
 
-/**
- * Função para requisições PUT
- */
 export const put = <T = unknown>(
   url: string,
   data?: unknown,
   config?: AxiosRequestConfig
 ): Promise<T> => {
-  return makeRequest<T>({ ...config, method: 'PUT', url, data });
+  return makeRequest<T>({ ...config, method: "PUT", url, data });
 };
 
-/**
- * Função para requisições DELETE
- */
 export const del = <T = unknown>(url: string, config?: AxiosRequestConfig): Promise<T> => {
-  return makeRequest<T>({ ...config, method: 'DELETE', url });
+  return makeRequest<T>({ ...config, method: "DELETE", url });
 };
 
-/**
- * Função para requisições PATCH
- */
 export const patch = <T = unknown>(
   url: string,
   data?: unknown,
   config?: AxiosRequestConfig
 ): Promise<T> => {
-  return makeRequest<T>({ ...config, method: 'PATCH', url, data });
+  return makeRequest<T>({ ...config, method: "PATCH", url, data });
 };
 
 export default requestBackEnd;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -2,6 +2,7 @@
 
 interface ImportMetaEnv {
   readonly VITE_API_BASE_URL?: string;
+  readonly VITE_ENABLE_DEPRECATED_API_FALLBACK?: string;
   readonly VITE_DEV_MODE?: string;
   readonly VITE_CLIENT_ID?: string;
   readonly VITE_CLIENT_SECRET?: string;


### PR DESCRIPTION
## Objetivo
Migrar o frontend para consumir a API canonica `/api/v1`, mantendo fallback legado `/api` apenas de forma controlada e marcada como **DEPRECATED**.

## Checklist
- [x] Base URL centralizada com `API_PREFIX="/api/v1"` em um unico modulo (`src/utils/apiConfig.ts`)
- [x] Cliente HTTP principal atualizado para `/api/v1` (`src/utils/request.ts`)
- [x] Fallback legado `/api` implementado de forma opcional via `VITE_ENABLE_DEPRECATED_API_FALLBACK=true`
- [x] Hardcodes de `/api/...` removidos do frontend
- [x] Rotas publicas `/public/...` preservadas fora de versionamento (`src/api/BlogAPI/publicArticles.ts`)
- [x] Tratamento de erro alinhado ao contrato backend para `400/404/409/422`
- [x] Mocks/testes atualizados (novos testes para `apiConfig` e `apiError`)
- [x] Build/testes executados

## Rotas principais migradas
- Auth: `/api/v1/auth/*` (incluindo refresh)
- GoatFarm/Goat/Reproduction/Lactation/Milk/Health/Genealogy/Events: agora resolvidas via base canonica `/api/v1`
- Articles admin: `/api/v1/articles*`
- Users: `/api/v1/users*`
- Public blog: mantido em `/public/articles*`

## Evidencias
- `npm run lint`: OK (warnings pre-existentes, sem erros)
- `npm test`: OK (`3` arquivos, `9` testes passando)
- `npm run build`: OK
- `npm run test:e2e`: OK (`alerts-dryoff.spec.ts`)

## Configuracao `.env`
```env
VITE_API_BASE_URL=/api/v1
VITE_ENABLE_DEPRECATED_API_FALLBACK=false
VITE_DEV_MODE=true
```

## Pendencias / Proxima remocao
- Remover fallback legado `/api` apos observabilidade confirmar zero uso de legado no frontend (alvo backend: remocao em 2026-06-30 / v2.0.0).
