### PR TITLE
Inventory UI: finalize idempotent retry flow

### DIFF
--- a/docs/INVENTORY_FRONTEND.md
+++ b/docs/INVENTORY_FRONTEND.md
@@ -1,0 +1,37 @@
+# Inventory no Frontend
+
+## Rota
+
+- Tela protegida: `/app/goatfarms/:farmId/inventory`
+- Endpoint canônico do backend: `POST /api/v1/goatfarms/{farmId}/inventory/movements`
+- Base URL esperada no ambiente: `VITE_API_BASE_URL=http://localhost:8080/api/v1`
+
+## Fluxo da movimentação
+
+1. O usuário preenche o formulário da movimentação.
+2. O frontend gera uma `Idempotency-Key` antes do envio.
+3. O backend responde:
+   - `201`: movimentação criada
+   - `200`: replay idempotente com a mesma chave
+4. A UI exibe `movementId`, `resultingBalance` e a chave utilizada.
+
+## Retry idempotente
+
+- Se ocorrer erro de rede ou timeout sem resposta HTTP, a mesma `Idempotency-Key` fica preservada.
+- O botão **Reenviar com a mesma chave** é habilitado para repetir o mesmo payload com segurança.
+- Se qualquer campo do payload for alterado após a falha, o frontend gera uma nova chave e invalida o reenvio anterior.
+- A última tentativa elegível para retry fica salva temporariamente em `sessionStorage`, permitindo refresh simples da página.
+
+## Tratamento de erros
+
+- `400` e `422`: exibem erros por campo (`fieldName`, `message`) e destacam inputs inválidos.
+- `404`: mostra mensagem geral de recurso não encontrado.
+- `409`: informa conflito de idempotência e orienta um novo envio com chave nova.
+
+## Como testar manualmente
+
+1. Acesse a tela em uma fazenda válida.
+2. Envie uma movimentação válida e confirme o badge `Criado` (`201`).
+3. Simule falha de rede antes da resposta e confirme que o botão de reenvio aparece.
+4. Clique em **Reenviar com a mesma chave** e valide que a resposta volta como `200` ou `201`, sem duplicidade.
+5. Altere qualquer campo após a falha e confirme que o reenvio antigo é invalidado.

--- a/src/Components/dash-animal-info/GoatActionPanel.tsx
+++ b/src/Components/dash-animal-info/GoatActionPanel.tsx
@@ -75,6 +75,24 @@ export default function GoatActionPanel({
             disabled={!farmId}
             onClick={() => {
               if (farmId) {
+                navigate(`/app/goatfarms/${farmId}/inventory`);
+              }
+            }}
+            title={
+              !farmId
+                ? "Aguardando carregamento dos dados do animal..."
+                : "Movimentacoes de estoque"
+            }
+          >
+            <i className="fa-solid fa-boxes-stacked"></i>
+            {!farmId ? "Carregando..." : "Estoque"}
+          </button>
+
+          <button
+            className="action-btn"
+            disabled={!farmId}
+            onClick={() => {
+              if (farmId) {
                 // Prefer goatId (database ID) for RESTful routes, fallback to registrationNumber if needed
                 const identifier = goatId ? goatId.toString() : registrationNumber;
                 navigate(

--- a/src/Models/InventoryDTOs.ts
+++ b/src/Models/InventoryDTOs.ts
@@ -1,0 +1,31 @@
+export type InventoryMovementType = "IN" | "OUT" | "ADJUST";
+
+export type InventoryAdjustDirection = "INCREASE" | "DECREASE";
+
+export interface InventoryMovementCreateRequestDTO {
+  type: InventoryMovementType;
+  quantity: number;
+  itemId: number;
+  lotId?: number;
+  adjustDirection?: InventoryAdjustDirection;
+  movementDate?: string;
+  reason?: string;
+}
+
+export interface InventoryMovementResponseDTO {
+  movementId: number;
+  type: InventoryMovementType;
+  quantity: number;
+  itemId: number;
+  lotId?: number | null;
+  movementDate: string;
+  resultingBalance: number;
+  createdAt: string;
+}
+
+export interface InventoryMovementCommandResult {
+  movement: InventoryMovementResponseDTO;
+  idempotencyKey: string;
+  responseStatus: number;
+  replayed: boolean;
+}

--- a/src/Pages/inventory/InventoryPage.tsx
+++ b/src/Pages/inventory/InventoryPage.tsx
@@ -1,0 +1,684 @@
+﻿import { useEffect, useMemo, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { toast } from "react-toastify";
+import { getGoatFarmById } from "../../api/GoatFarmAPI/goatFarm";
+import {
+  createInventoryIdempotencyKey,
+  createInventoryMovement,
+  createInventoryPayloadHash,
+} from "../../api/GoatFarmAPI/inventory";
+import GoatFarmHeader from "../../Components/pages-headers/GoatFarmHeader";
+import PageHeader from "../../Components/pages-headers/PageHeader";
+import { useFarmPermissions } from "../../Hooks/useFarmPermissions";
+import { usePermissions } from "../../Hooks/usePermissions";
+import type { GoatFarmDTO } from "../../Models/goatFarm";
+import type {
+  InventoryAdjustDirection,
+  InventoryMovementCommandResult,
+  InventoryMovementCreateRequestDTO,
+  InventoryMovementType,
+} from "../../Models/InventoryDTOs";
+import { getApiErrorMessage, parseApiError } from "../../utils/apiError";
+import {
+  clearInventoryRetrySnapshot,
+  createInventoryRetrySnapshot,
+  isSameInventoryRetryPayload,
+  loadInventoryRetrySnapshot,
+  saveInventoryRetrySnapshot,
+  syncInventoryDraftKey,
+  type InventoryRetrySnapshot,
+} from "./inventoryRetry";
+
+type InventoryFormState = {
+  type: InventoryMovementType;
+  quantity: string;
+  itemId: string;
+  lotId: string;
+  adjustDirection: InventoryAdjustDirection | "";
+  movementDate: string;
+  reason: string;
+};
+
+type BuildPayloadResult = {
+  payload?: InventoryMovementCreateRequestDTO;
+  error?: string;
+};
+
+const MOVEMENT_OPTIONS: Array<{ value: InventoryMovementType; label: string }> = [
+  { value: "IN", label: "Entrada" },
+  { value: "OUT", label: "Saída" },
+  { value: "ADJUST", label: "Ajuste" },
+];
+
+const ADJUST_OPTIONS: Array<{ value: InventoryAdjustDirection; label: string }> = [
+  { value: "INCREASE", label: "Aumentar saldo" },
+  { value: "DECREASE", label: "Reduzir saldo" },
+];
+
+const buildInitialForm = (): InventoryFormState => ({
+  type: "OUT",
+  quantity: "",
+  itemId: "",
+  lotId: "",
+  adjustDirection: "",
+  movementDate: new Date().toISOString().slice(0, 10),
+  reason: "",
+});
+
+const mapPayloadToForm = (
+  payload: InventoryMovementCreateRequestDTO
+): InventoryFormState => ({
+  type: payload.type,
+  quantity: `${payload.quantity}`,
+  itemId: `${payload.itemId}`,
+  lotId: payload.lotId != null ? `${payload.lotId}` : "",
+  adjustDirection: payload.type === "ADJUST" ? payload.adjustDirection ?? "" : "",
+  movementDate: payload.movementDate ?? new Date().toISOString().slice(0, 10),
+  reason: payload.reason ?? "",
+});
+
+const parsePositiveNumber = (value: string): number | null => {
+  if (!value.trim()) return null;
+  const normalized = Number(value.replace(",", "."));
+  if (!Number.isFinite(normalized) || normalized <= 0) {
+    return null;
+  }
+  return normalized;
+};
+
+const formatDateTime = (value?: string): string => {
+  if (!value) return "-";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return value;
+  return parsed.toLocaleString("pt-BR");
+};
+
+const buildPayloadFromForm = (form: InventoryFormState): BuildPayloadResult => {
+  const quantity = parsePositiveNumber(form.quantity);
+  const itemId = parsePositiveNumber(form.itemId);
+  const lotId = form.lotId.trim() ? parsePositiveNumber(form.lotId) : undefined;
+
+  if (itemId == null) {
+    return { error: "Informe um itemId válido." };
+  }
+
+  if (quantity == null) {
+    return { error: "Informe uma quantidade maior que zero." };
+  }
+
+  if (form.lotId.trim() && lotId == null) {
+    return { error: "lotId deve ser um número positivo." };
+  }
+
+  if (form.type === "ADJUST" && !form.adjustDirection) {
+    return { error: "Selecione a direção do ajuste." };
+  }
+
+  return {
+    payload: {
+      type: form.type,
+      quantity,
+      itemId,
+      ...(lotId != null ? { lotId } : {}),
+      ...(form.type === "ADJUST" && form.adjustDirection
+        ? { adjustDirection: form.adjustDirection }
+        : {}),
+      ...(form.movementDate ? { movementDate: form.movementDate } : {}),
+      ...(form.reason.trim() ? { reason: form.reason.trim() } : {}),
+    },
+  };
+};
+
+export default function InventoryPage() {
+  const { farmId } = useParams<{ farmId: string }>();
+  const navigate = useNavigate();
+  const permissions = usePermissions();
+  const farmIdNumber = useMemo(() => Number(farmId), [farmId]);
+  const { canCreateGoat, loading: loadingPermissions } = useFarmPermissions(
+    Number.isNaN(farmIdNumber) ? undefined : farmIdNumber
+  );
+
+  const [farmData, setFarmData] = useState<GoatFarmDTO | null>(null);
+  const [form, setForm] = useState<InventoryFormState>(buildInitialForm);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<Array<{ fieldName?: string; message: string }>>(
+    []
+  );
+  const [lastCommand, setLastCommand] = useState<InventoryMovementCommandResult | null>(null);
+  const [draftKey, setDraftKey] = useState<string | null>(createInventoryIdempotencyKey());
+  const [draftPayloadHash, setDraftPayloadHash] = useState<string | null>(null);
+  const [retrySnapshot, setRetrySnapshot] = useState<InventoryRetrySnapshot | null>(null);
+
+  const canManageInventory = permissions.isAdmin() || canCreateGoat;
+
+  useEffect(() => {
+    if (Number.isNaN(farmIdNumber)) {
+      return;
+    }
+
+    getGoatFarmById(farmIdNumber)
+      .then(setFarmData)
+      .catch((error) => {
+        console.error("Erro ao carregar dados da fazenda para inventory", error);
+      });
+  }, [farmIdNumber]);
+
+  useEffect(() => {
+    if (Number.isNaN(farmIdNumber)) {
+      return;
+    }
+
+    const storedRetry = loadInventoryRetrySnapshot(farmIdNumber);
+    if (!storedRetry) {
+      return;
+    }
+
+    setRetrySnapshot(storedRetry);
+    setDraftKey(storedRetry.idempotencyKey);
+    setDraftPayloadHash(storedRetry.payloadHash);
+    setForm(mapPayloadToForm(storedRetry.payload));
+  }, [farmIdNumber]);
+
+  const resetRetryState = () => {
+    if (!Number.isNaN(farmIdNumber)) {
+      clearInventoryRetrySnapshot(farmIdNumber);
+    }
+    setRetrySnapshot(null);
+  };
+
+  const syncDraftFromPayload = (
+    payload: InventoryMovementCreateRequestDTO,
+    forceNewKey = false
+  ): { idempotencyKey: string; payloadHash: string } => {
+    if (forceNewKey) {
+      const nextKey = createInventoryIdempotencyKey();
+      const nextHash = createInventoryPayloadHash(payload);
+      setDraftKey(nextKey);
+      setDraftPayloadHash(nextHash);
+      return { idempotencyKey: nextKey, payloadHash: nextHash };
+    }
+
+    const nextDraft = syncInventoryDraftKey({
+      currentKey: draftKey,
+      currentPayloadHash: draftPayloadHash,
+      nextPayload: payload,
+    });
+
+    setDraftKey(nextDraft.idempotencyKey);
+    setDraftPayloadHash(nextDraft.payloadHash);
+
+    return {
+      idempotencyKey: nextDraft.idempotencyKey,
+      payloadHash: nextDraft.payloadHash,
+    };
+  };
+
+  const updateField = <K extends keyof InventoryFormState>(key: K, value: InventoryFormState[K]) => {
+    const nextForm = {
+      ...form,
+      [key]: value,
+    } as InventoryFormState;
+
+    if (key === "type" && value !== "ADJUST") {
+      nextForm.adjustDirection = "";
+    }
+
+    setForm(nextForm);
+    setSubmitError(null);
+    setFieldErrors([]);
+
+    const built = buildPayloadFromForm(nextForm);
+
+    if (retrySnapshot) {
+      if (!built.payload || !isSameInventoryRetryPayload(retrySnapshot, built.payload)) {
+        resetRetryState();
+        if (built.payload) {
+          syncDraftFromPayload(built.payload, true);
+        } else {
+          setDraftKey(createInventoryIdempotencyKey());
+          setDraftPayloadHash(null);
+        }
+        return;
+      }
+    }
+
+    if (built.payload) {
+      syncDraftFromPayload(built.payload);
+    } else if (!draftKey) {
+      setDraftKey(createInventoryIdempotencyKey());
+      setDraftPayloadHash(null);
+    }
+  };
+
+  const getFieldMessages = (fieldName: string): string[] =>
+    fieldErrors
+      .filter((entry) => entry.fieldName === fieldName)
+      .map((entry) => entry.message);
+
+  const renderFieldFeedback = (fieldName: string) => {
+    const messages = getFieldMessages(fieldName);
+
+    if (messages.length === 0) {
+      return null;
+    }
+
+    return <div className="invalid-feedback d-block">{messages.join(" ")}</div>;
+  };
+
+  const handleSubmit = async (mode: "create" | "retry" = "create") => {
+    if (Number.isNaN(farmIdNumber)) {
+      setSubmitError("FarmId inválido.");
+      return;
+    }
+
+    const built = buildPayloadFromForm(form);
+    if (!built.payload) {
+      setSubmitError(built.error ?? "Revise os dados da movimentação.");
+      return;
+    }
+
+    if (mode === "retry" && retrySnapshot && !isSameInventoryRetryPayload(retrySnapshot, built.payload)) {
+      resetRetryState();
+      syncDraftFromPayload(built.payload, true);
+      setSubmitError("Os dados foram alterados. Gere um novo envio antes de reenviar.");
+      return;
+    }
+
+    const preparedDraft =
+      mode === "retry" && retrySnapshot
+        ? {
+            idempotencyKey: retrySnapshot.idempotencyKey,
+            payloadHash: retrySnapshot.payloadHash,
+          }
+        : syncDraftFromPayload(built.payload);
+
+    try {
+      setSubmitting(true);
+      setSubmitError(null);
+      setFieldErrors([]);
+
+      const result = await createInventoryMovement(farmIdNumber, built.payload, {
+        idempotencyKey: preparedDraft.idempotencyKey,
+      });
+
+      setLastCommand(result);
+      resetRetryState();
+
+      const nextForm = {
+        ...buildInitialForm(),
+        type: form.type,
+        itemId: form.itemId,
+        lotId: form.lotId,
+      };
+
+      setForm(nextForm);
+      const nextBuilt = buildPayloadFromForm(nextForm);
+      if (nextBuilt.payload) {
+        syncDraftFromPayload(nextBuilt.payload, true);
+      } else {
+        setDraftKey(createInventoryIdempotencyKey());
+        setDraftPayloadHash(null);
+      }
+
+      toast.success(
+        result.responseStatus === 200
+          ? "Repetição idempotente confirmada com a mesma chave."
+          : "Movimentação registrada com sucesso."
+      );
+    } catch (error) {
+      console.error("Erro ao registrar movimentação de inventory", error);
+      const parsed = parseApiError(error);
+
+      if (!parsed.status) {
+        const snapshot = createInventoryRetrySnapshot(
+          farmIdNumber,
+          built.payload,
+          preparedDraft.idempotencyKey
+        );
+        saveInventoryRetrySnapshot(snapshot);
+        setRetrySnapshot(snapshot);
+        setDraftKey(snapshot.idempotencyKey);
+        setDraftPayloadHash(snapshot.payloadHash);
+        setSubmitError(
+          "Falha de rede ou timeout. Você pode reenviar com a mesma chave de idempotência sem duplicar a movimentação."
+        );
+        toast.warning("Falha de rede. Use “Reenviar” para repetir com segurança.");
+        return;
+      }
+
+      resetRetryState();
+
+      const message =
+        parsed.status === 409
+          ? "Conflito de idempotência. Revise os dados e faça um novo envio com uma nova chave."
+          : parsed.status === 403
+            ? "Sem permissão para registrar movimentações nesta fazenda."
+            : getApiErrorMessage(parsed);
+
+      if (parsed.status === 409) {
+        syncDraftFromPayload(built.payload, true);
+      }
+
+      setSubmitError(message);
+      setFieldErrors(
+        parsed.status === 400 || parsed.status === 422 ? parsed.fieldErrors ?? [] : []
+      );
+      toast.error(message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (Number.isNaN(farmIdNumber)) {
+    return (
+      <div className="mt-5">
+        <div className="alert alert-danger">Identificador da fazenda inválido.</div>
+      </div>
+    );
+  }
+
+  const responseBadgeClass =
+    lastCommand?.responseStatus === 200 ? "text-bg-info" : "text-bg-success";
+  const responseBadgeLabel =
+    lastCommand?.responseStatus === 200 ? "Repetido (idempotência)" : "Criado";
+
+  return (
+    <div className="py-4">
+      <GoatFarmHeader
+        name={farmData?.name || "Capril"}
+        logoUrl={farmData?.logoUrl}
+        farmId={farmIdNumber}
+      />
+
+      <PageHeader
+        title="Inventory"
+        description="Registrar movimentações do ledger de estoque com retry idempotente seguro."
+        showBackButton={true}
+        backButtonUrl="/goatfarms"
+      />
+
+      <div className="alert alert-info mt-3">
+        <strong>MVP atual:</strong> o backend expõe o ledger core via comando de
+        movimentação. Item, lote e saldo detalhado ainda não possuem UI dedicada.
+      </div>
+
+      <div className="row g-4 mt-1 align-items-start">
+        <div className="col-12 col-xl-7">
+          <div className="card shadow-sm">
+            <div className="card-body">
+              <div className="d-flex justify-content-between align-items-center mb-3 flex-wrap gap-2">
+                <div>
+                  <h3 className="h5 mb-1">Nova movimentação</h3>
+                  <p className="text-muted mb-0">
+                    Endpoint: <code>/api/v1/goatfarms/{farmIdNumber}/inventory/movements</code>
+                  </p>
+                </div>
+                {!canManageInventory && !loadingPermissions && (
+                  <span className="badge text-bg-warning">Somente leitura</span>
+                )}
+              </div>
+
+              {submitError && (
+                <div className="alert alert-danger" role="alert">
+                  {submitError}
+                </div>
+              )}
+
+              {retrySnapshot && (
+                <div className="alert alert-warning" role="alert">
+                  <strong>Reenvio disponível:</strong> a mesma Idempotency-Key será reutilizada
+                  se você clicar em <strong>Reenviar</strong> sem alterar o payload.
+                </div>
+              )}
+
+              {fieldErrors.length > 0 && (
+                <div className="alert alert-warning" role="alert">
+                  <strong>Campos com erro:</strong>
+                  <ul className="mb-0 mt-2 ps-3">
+                    {fieldErrors.map((entry, index) => (
+                      <li key={`${entry.fieldName || "field"}-${index}`}>
+                        {entry.fieldName ? `${entry.fieldName}: ` : ""}
+                        {entry.message}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              <div className="row g-3">
+                <div className="col-12 col-md-6">
+                  <label className="form-label">Tipo</label>
+                  <select
+                    className={`form-select ${getFieldMessages("type").length ? "is-invalid" : ""}`}
+                    value={form.type}
+                    onChange={(event) =>
+                      updateField("type", event.target.value as InventoryMovementType)
+                    }
+                    disabled={submitting || !canManageInventory}
+                  >
+                    {MOVEMENT_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                  {renderFieldFeedback("type")}
+                </div>
+
+                <div className="col-12 col-md-6">
+                  <label className="form-label">Quantidade</label>
+                  <input
+                    className={`form-control ${getFieldMessages("quantity").length ? "is-invalid" : ""}`}
+                    type="number"
+                    min="0.001"
+                    step="0.001"
+                    value={form.quantity}
+                    onChange={(event) => updateField("quantity", event.target.value)}
+                    disabled={submitting || !canManageInventory}
+                    placeholder="Ex.: 2,500"
+                  />
+                  {renderFieldFeedback("quantity")}
+                </div>
+
+                <div className="col-12 col-md-6">
+                  <label className="form-label">itemId</label>
+                  <input
+                    className={`form-control ${getFieldMessages("itemId").length ? "is-invalid" : ""}`}
+                    type="number"
+                    min="1"
+                    step="1"
+                    value={form.itemId}
+                    onChange={(event) => updateField("itemId", event.target.value)}
+                    disabled={submitting || !canManageInventory}
+                    placeholder="Ex.: 101"
+                  />
+                  {renderFieldFeedback("itemId")}
+                </div>
+
+                <div className="col-12 col-md-6">
+                  <label className="form-label">lotId (opcional)</label>
+                  <input
+                    className={`form-control ${getFieldMessages("lotId").length ? "is-invalid" : ""}`}
+                    type="number"
+                    min="1"
+                    step="1"
+                    value={form.lotId}
+                    onChange={(event) => updateField("lotId", event.target.value)}
+                    disabled={submitting || !canManageInventory}
+                    placeholder="Ex.: 10"
+                  />
+                  {renderFieldFeedback("lotId")}
+                </div>
+
+                {form.type === "ADJUST" && (
+                  <div className="col-12">
+                    <label className="form-label">Direção do ajuste</label>
+                    <select
+                      className={`form-select ${getFieldMessages("adjustDirection").length ? "is-invalid" : ""}`}
+                      value={form.adjustDirection}
+                      onChange={(event) =>
+                        updateField(
+                          "adjustDirection",
+                          event.target.value as InventoryAdjustDirection | ""
+                        )
+                      }
+                      disabled={submitting || !canManageInventory}
+                    >
+                      <option value="">Selecione</option>
+                      {ADJUST_OPTIONS.map((option) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
+                    {renderFieldFeedback("adjustDirection")}
+                  </div>
+                )}
+
+                <div className="col-12 col-md-6">
+                  <label className="form-label">Data da movimentação</label>
+                  <input
+                    className={`form-control ${getFieldMessages("movementDate").length ? "is-invalid" : ""}`}
+                    type="date"
+                    value={form.movementDate}
+                    onChange={(event) => updateField("movementDate", event.target.value)}
+                    disabled={submitting || !canManageInventory}
+                  />
+                  {renderFieldFeedback("movementDate")}
+                </div>
+
+                <div className="col-12">
+                  <label className="form-label">Motivo / observação</label>
+                  <textarea
+                    className={`form-control ${getFieldMessages("reason").length ? "is-invalid" : ""}`}
+                    rows={3}
+                    maxLength={500}
+                    value={form.reason}
+                    onChange={(event) => updateField("reason", event.target.value)}
+                    disabled={submitting || !canManageInventory}
+                    placeholder="Ex.: Baixa por aplicação sanitária"
+                  />
+                  {renderFieldFeedback("reason")}
+                </div>
+              </div>
+
+              <div className="small text-muted mt-3">
+                Chave preparada: <code>{draftKey ?? "será gerada ao enviar"}</code>
+              </div>
+
+              <div className="d-flex gap-2 flex-wrap mt-4">
+                <button
+                  className="btn btn-primary"
+                  type="button"
+                  onClick={() => void handleSubmit("create")}
+                  disabled={submitting || !canManageInventory}
+                >
+                  {submitting ? "Enviando..." : "Registrar movimentação"}
+                </button>
+                {retrySnapshot && (
+                  <button
+                    className="btn btn-outline-warning"
+                    type="button"
+                    onClick={() => void handleSubmit("retry")}
+                    disabled={submitting || !canManageInventory}
+                  >
+                    Reenviar com a mesma chave
+                  </button>
+                )}
+                <button
+                  className="btn btn-outline-secondary"
+                  type="button"
+                  onClick={() => {
+                    const nextForm = buildInitialForm();
+                    setForm(nextForm);
+                    setSubmitError(null);
+                    setFieldErrors([]);
+                    resetRetryState();
+                    setDraftKey(createInventoryIdempotencyKey());
+                    setDraftPayloadHash(null);
+                  }}
+                  disabled={submitting}
+                >
+                  Limpar
+                </button>
+                <button
+                  className="btn btn-outline-dark"
+                  type="button"
+                  onClick={() => navigate(-1)}
+                  disabled={submitting}
+                >
+                  Voltar
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="col-12 col-xl-5">
+          <div className="card shadow-sm h-100">
+            <div className="card-body">
+              <div className="d-flex justify-content-between align-items-center gap-2 flex-wrap mb-3">
+                <h3 className="h5 mb-0">Último retorno do backend</h3>
+                {lastCommand && <span className={`badge ${responseBadgeClass}`}>{responseBadgeLabel}</span>}
+              </div>
+
+              {!lastCommand ? (
+                <p className="text-muted mb-0">
+                  Envie uma movimentação para visualizar o retorno do comando, a chave
+                  idempotente utilizada e o saldo resultante.
+                </p>
+              ) : (
+                <div className="d-grid gap-3">
+                  <div className="alert alert-success mb-0">
+                    HTTP {lastCommand.responseStatus}: {responseBadgeLabel}.
+                  </div>
+
+                  <div>
+                    <div className="text-muted small">Idempotency-Key</div>
+                    <code>{lastCommand.idempotencyKey}</code>
+                  </div>
+
+                  <div className="row g-3">
+                    <div className="col-6">
+                      <div className="text-muted small">movementId</div>
+                      <div>{lastCommand.movement.movementId}</div>
+                    </div>
+                    <div className="col-6">
+                      <div className="text-muted small">Tipo</div>
+                      <div>{lastCommand.movement.type}</div>
+                    </div>
+                    <div className="col-6">
+                      <div className="text-muted small">itemId</div>
+                      <div>{lastCommand.movement.itemId}</div>
+                    </div>
+                    <div className="col-6">
+                      <div className="text-muted small">lotId</div>
+                      <div>{lastCommand.movement.lotId ?? "-"}</div>
+                    </div>
+                    <div className="col-6">
+                      <div className="text-muted small">Quantidade</div>
+                      <div>{lastCommand.movement.quantity}</div>
+                    </div>
+                    <div className="col-6">
+                      <div className="text-muted small">Saldo resultante</div>
+                      <div>{lastCommand.movement.resultingBalance}</div>
+                    </div>
+                    <div className="col-6">
+                      <div className="text-muted small">Data da movimentação</div>
+                      <div>{lastCommand.movement.movementDate}</div>
+                    </div>
+                    <div className="col-6">
+                      <div className="text-muted small">Criado em</div>
+                      <div>{formatDateTime(lastCommand.movement.createdAt)}</div>
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/Pages/inventory/inventoryRetry.test.ts
+++ b/src/Pages/inventory/inventoryRetry.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createInventoryPayloadHash } from "../../api/GoatFarmAPI/inventory";
+import {
+  createInventoryRetrySnapshot,
+  isSameInventoryRetryPayload,
+  syncInventoryDraftKey,
+} from "./inventoryRetry";
+
+describe("inventoryRetry", () => {
+  const payload = {
+    type: "OUT" as const,
+    quantity: 2,
+    itemId: 101,
+    movementDate: "2026-02-28",
+    reason: "Baixa de teste",
+  };
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps the same key when retrying the same payload after a network failure", () => {
+    const snapshot = createInventoryRetrySnapshot(12, payload, "inventory-fixed-key");
+
+    expect(isSameInventoryRetryPayload(snapshot, { ...payload })).toBe(true);
+
+    const nextDraft = syncInventoryDraftKey({
+      currentKey: snapshot.idempotencyKey,
+      currentPayloadHash: snapshot.payloadHash,
+      nextPayload: { ...payload },
+    });
+
+    expect(nextDraft.idempotencyKey).toBe("inventory-fixed-key");
+    expect(nextDraft.payloadHash).toBe(snapshot.payloadHash);
+    expect(nextDraft.changed).toBe(false);
+  });
+
+  it("creates a new key when the payload changes", () => {
+    vi.stubGlobal("crypto", {
+      randomUUID: vi.fn().mockReturnValue("fresh-key"),
+    });
+
+    const nextDraft = syncInventoryDraftKey({
+      currentKey: "inventory-old-key",
+      currentPayloadHash: createInventoryPayloadHash(payload),
+      nextPayload: {
+        ...payload,
+        quantity: 3,
+      },
+    });
+
+    expect(nextDraft.idempotencyKey).toBe("inventory-fresh-key");
+    expect(nextDraft.payloadHash).toBe(
+      createInventoryPayloadHash({
+        ...payload,
+        quantity: 3,
+      })
+    );
+    expect(nextDraft.changed).toBe(true);
+  });
+});

--- a/src/Pages/inventory/inventoryRetry.ts
+++ b/src/Pages/inventory/inventoryRetry.ts
@@ -1,0 +1,101 @@
+import {
+  createInventoryIdempotencyKey,
+  createInventoryPayloadHash,
+} from "../../api/GoatFarmAPI/inventory";
+import type { InventoryMovementCreateRequestDTO } from "../../Models/InventoryDTOs";
+
+export type InventoryRetrySnapshot = {
+  farmId: number;
+  idempotencyKey: string;
+  payloadHash: string;
+  payload: InventoryMovementCreateRequestDTO;
+  createdAt: string;
+};
+
+type InventoryDraftKeyState = {
+  currentKey: string | null;
+  currentPayloadHash: string | null;
+  nextPayload: InventoryMovementCreateRequestDTO;
+};
+
+const STORAGE_KEY_PREFIX = "inventory-retry";
+
+const getStorageKey = (farmId: number) => `${STORAGE_KEY_PREFIX}:${farmId}`;
+
+const hasSessionStorage = () =>
+  typeof globalThis.sessionStorage !== "undefined" && globalThis.sessionStorage !== null;
+
+export const createInventoryRetrySnapshot = (
+  farmId: number,
+  payload: InventoryMovementCreateRequestDTO,
+  idempotencyKey = createInventoryIdempotencyKey()
+): InventoryRetrySnapshot => ({
+  farmId,
+  idempotencyKey,
+  payloadHash: createInventoryPayloadHash(payload),
+  payload,
+  createdAt: new Date().toISOString(),
+});
+
+export const isSameInventoryRetryPayload = (
+  snapshot: Pick<InventoryRetrySnapshot, "payloadHash">,
+  payload: InventoryMovementCreateRequestDTO
+): boolean => snapshot.payloadHash === createInventoryPayloadHash(payload);
+
+export const syncInventoryDraftKey = ({
+  currentKey,
+  currentPayloadHash,
+  nextPayload,
+}: InventoryDraftKeyState): { idempotencyKey: string; payloadHash: string; changed: boolean } => {
+  const nextPayloadHash = createInventoryPayloadHash(nextPayload);
+
+  if (currentKey && currentPayloadHash === nextPayloadHash) {
+    return {
+      idempotencyKey: currentKey,
+      payloadHash: nextPayloadHash,
+      changed: false,
+    };
+  }
+
+  return {
+    idempotencyKey: createInventoryIdempotencyKey(),
+    payloadHash: nextPayloadHash,
+    changed: true,
+  };
+};
+
+export const saveInventoryRetrySnapshot = (snapshot: InventoryRetrySnapshot): void => {
+  if (!hasSessionStorage()) return;
+  globalThis.sessionStorage.setItem(getStorageKey(snapshot.farmId), JSON.stringify(snapshot));
+};
+
+export const loadInventoryRetrySnapshot = (
+  farmId: number
+): InventoryRetrySnapshot | null => {
+  if (!hasSessionStorage()) return null;
+
+  const rawValue = globalThis.sessionStorage.getItem(getStorageKey(farmId));
+  if (!rawValue) return null;
+
+  try {
+    const parsed = JSON.parse(rawValue) as InventoryRetrySnapshot;
+    if (
+      parsed &&
+      parsed.farmId === farmId &&
+      typeof parsed.idempotencyKey === "string" &&
+      typeof parsed.payloadHash === "string" &&
+      parsed.payload
+    ) {
+      return parsed;
+    }
+  } catch {
+    // Ignore malformed session data and let the UI continue with a fresh key.
+  }
+
+  return null;
+};
+
+export const clearInventoryRetrySnapshot = (farmId: number): void => {
+  if (!hasSessionStorage()) return;
+  globalThis.sessionStorage.removeItem(getStorageKey(farmId));
+};

--- a/src/api/GoatFarmAPI/inventory.test.ts
+++ b/src/api/GoatFarmAPI/inventory.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { requestBackEnd } from "../../utils/request";
+import { createInventoryMovement } from "./inventory";
+
+vi.mock("../../utils/request", () => ({
+  requestBackEnd: {
+    post: vi.fn(),
+  },
+}));
+
+describe("Inventory API", () => {
+  const mockedPost = vi.mocked(requestBackEnd.post);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sends the movement command with Idempotency-Key and strips empty optional fields", async () => {
+    mockedPost.mockResolvedValueOnce({
+      status: 201,
+      data: {
+        movementId: 9001,
+        type: "OUT",
+        quantity: 2,
+        itemId: 101,
+        lotId: null,
+        movementDate: "2026-02-27",
+        resultingBalance: 18,
+        createdAt: "2026-02-27T12:00:00Z",
+      },
+    });
+
+    const result = await createInventoryMovement(
+      42,
+      {
+        type: "OUT",
+        quantity: 2,
+        itemId: 101,
+        movementDate: "",
+        reason: "   ",
+      },
+      { idempotencyKey: "inventory-fixed-key" }
+    );
+
+    expect(mockedPost).toHaveBeenCalledWith(
+      "/goatfarms/42/inventory/movements",
+      {
+        type: "OUT",
+        quantity: 2,
+        itemId: 101,
+      },
+      {
+        headers: {
+          "Idempotency-Key": "inventory-fixed-key",
+        },
+      }
+    );
+
+    expect(result.replayed).toBe(false);
+    expect(result.responseStatus).toBe(201);
+    expect(result.idempotencyKey).toBe("inventory-fixed-key");
+    expect(result.movement.movementId).toBe(9001);
+  });
+
+  it("preserves adjustDirection and marks replay when backend returns 200", async () => {
+    mockedPost.mockResolvedValueOnce({
+      status: 200,
+      data: {
+        movementId: 9002,
+        type: "ADJUST",
+        quantity: 1.5,
+        itemId: 202,
+        lotId: 12,
+        movementDate: "2026-02-27",
+        resultingBalance: 9.5,
+        createdAt: "2026-02-27T12:05:00Z",
+      },
+    });
+
+    const result = await createInventoryMovement(
+      7,
+      {
+        type: "ADJUST",
+        quantity: 1.5,
+        itemId: 202,
+        lotId: 12,
+        adjustDirection: "DECREASE",
+        movementDate: "2026-02-27",
+        reason: "Ajuste manual",
+      },
+      { idempotencyKey: "inventory-replay-key" }
+    );
+
+    expect(mockedPost).toHaveBeenCalledWith(
+      "/goatfarms/7/inventory/movements",
+      {
+        type: "ADJUST",
+        quantity: 1.5,
+        itemId: 202,
+        lotId: 12,
+        adjustDirection: "DECREASE",
+        movementDate: "2026-02-27",
+        reason: "Ajuste manual",
+      },
+      {
+        headers: {
+          "Idempotency-Key": "inventory-replay-key",
+        },
+      }
+    );
+
+    expect(result.replayed).toBe(true);
+    expect(result.responseStatus).toBe(200);
+    expect(result.movement.resultingBalance).toBe(9.5);
+  });
+});

--- a/src/api/GoatFarmAPI/inventory.ts
+++ b/src/api/GoatFarmAPI/inventory.ts
@@ -1,0 +1,64 @@
+import { requestBackEnd } from "../../utils/request";
+import type {
+  InventoryMovementCommandResult,
+  InventoryMovementCreateRequestDTO,
+  InventoryMovementResponseDTO,
+} from "../../Models/InventoryDTOs";
+
+type Envelope<T> = { data: T } | T;
+
+const unwrap = <T>(data: Envelope<T>): T =>
+  (data as { data?: T }).data ?? (data as T);
+
+const getBaseUrl = (farmId: number) =>
+  `/goatfarms/${farmId}/inventory/movements`;
+
+export const normalizeInventoryMovementPayload = (
+  request: InventoryMovementCreateRequestDTO
+): InventoryMovementCreateRequestDTO => ({
+  type: request.type,
+  quantity: request.quantity,
+  itemId: request.itemId,
+  ...(request.lotId != null ? { lotId: request.lotId } : {}),
+  ...(request.adjustDirection ? { adjustDirection: request.adjustDirection } : {}),
+  ...(request.movementDate ? { movementDate: request.movementDate } : {}),
+  ...(request.reason?.trim() ? { reason: request.reason.trim() } : {}),
+});
+
+export const createInventoryPayloadHash = (
+  request: InventoryMovementCreateRequestDTO
+): string => JSON.stringify(normalizeInventoryMovementPayload(request));
+
+export const createInventoryIdempotencyKey = (): string => {
+  const cryptoApi = globalThis.crypto as { randomUUID?: () => string } | undefined;
+
+  if (cryptoApi?.randomUUID) {
+    return `inventory-${cryptoApi.randomUUID()}`;
+  }
+
+  return `inventory-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+};
+
+export async function createInventoryMovement(
+  farmId: number,
+  request: InventoryMovementCreateRequestDTO,
+  options: { idempotencyKey?: string } = {}
+): Promise<InventoryMovementCommandResult> {
+  const idempotencyKey = options.idempotencyKey ?? createInventoryIdempotencyKey();
+  const response = await requestBackEnd.post(
+    getBaseUrl(farmId),
+    normalizeInventoryMovementPayload(request),
+    {
+      headers: {
+        "Idempotency-Key": idempotencyKey,
+      },
+    }
+  );
+
+  return {
+    movement: unwrap<InventoryMovementResponseDTO>(response.data),
+    idempotencyKey,
+    responseStatus: response.status,
+    replayed: response.status === 200,
+  };
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -49,6 +49,7 @@ import FarmHealthAgendaPage from "./Pages/health/FarmHealthAgendaPage";
 import HealthEventFormPage from "./Pages/health/HealthEventFormPage";
 import HealthEventDetailPage from "./Pages/health/HealthEventDetailPage";
 import FarmAlertsPage from "./Pages/alerts/FarmAlertsPage";
+import InventoryPage from "./Pages/inventory/InventoryPage";
 
 const router = createBrowserRouter([
   { path: "/login", element: <LoginPage /> },
@@ -178,6 +179,14 @@ const router = createBrowserRouter([
         element: (
           <PrivateRoute roles={[RoleEnum.ROLE_FARM_OWNER, RoleEnum.ROLE_OPERATOR, RoleEnum.ROLE_ADMIN]}>
             <FarmAlertsPage />
+          </PrivateRoute>
+        ),
+      },
+      {
+        path: "app/goatfarms/:farmId/inventory",
+        element: (
+          <PrivateRoute roles={[RoleEnum.ROLE_FARM_OWNER, RoleEnum.ROLE_OPERATOR, RoleEnum.ROLE_ADMIN]}>
+            <InventoryPage />
           </PrivateRoute>
         ),
       },


### PR DESCRIPTION
## Summary
- add the Inventory movement workflow under /app/goatfarms/:farmId/inventory
- improve idempotent retry UX with safe re-send using the same Idempotency-Key
- document the frontend Inventory flow and keep /api/v1 as the canonical base

## Validation
- npm test
- npm run build
- npm run lint