### PR TITLE
Inventory: items flow on frontend

### DIFF
--- a/docs/INVENTORY_FRONTEND.md
+++ b/docs/INVENTORY_FRONTEND.md
@@ -1,37 +1,62 @@
 # Inventory no Frontend
 
-## Rota
+## Rota e base da API
 
 - Tela protegida: `/app/goatfarms/:farmId/inventory`
-- Endpoint canônico do backend: `POST /api/v1/goatfarms/{farmId}/inventory/movements`
-- Base URL esperada no ambiente: `VITE_API_BASE_URL=http://localhost:8080/api/v1`
+- Base URL canônica: `VITE_API_BASE_URL=http://localhost:8080/api/v1`
+- Endpoints utilizados:
+  - `GET /api/v1/goatfarms/{farmId}/inventory/items?page=&size=`
+  - `POST /api/v1/goatfarms/{farmId}/inventory/items`
+  - `POST /api/v1/goatfarms/{farmId}/inventory/movements`
 
-## Fluxo da movimentação
+## Como usar o fluxo real
 
-1. O usuário preenche o formulário da movimentação.
-2. O frontend gera uma `Idempotency-Key` antes do envio.
-3. O backend responde:
-   - `201`: movimentação criada
-   - `200`: replay idempotente com a mesma chave
-4. A UI exibe `movementId`, `resultingBalance` e a chave utilizada.
+1. Clique em **Cadastrar item** para criar um item de estoque, se ele ainda não existir.
+2. Selecione o item pelo nome na lista de itens carregados da fazenda.
+3. Preencha a movimentação e envie o comando.
 
-## Retry idempotente
+## Itens de estoque
 
-- Se ocorrer erro de rede ou timeout sem resposta HTTP, a mesma `Idempotency-Key` fica preservada.
-- O botão **Reenviar com a mesma chave** é habilitado para repetir o mesmo payload com segurança.
-- Se qualquer campo do payload for alterado após a falha, o frontend gera uma nova chave e invalida o reenvio anterior.
-- A última tentativa elegível para retry fica salva temporariamente em `sessionStorage`, permitindo refresh simples da página.
+- O modal de cadastro cria o item com `name` e `trackLot`.
+- Após criar com sucesso, o item entra na lista local e fica selecionado automaticamente.
+- Se o backend responder `409`, o frontend mostra a mensagem de duplicidade no campo `name`.
+
+## Regras de `trackLot` e `lotId`
+
+- Quando o item selecionado tem `trackLot = true`, o campo `lotId` aparece e fica obrigatório na UI.
+- Quando o item selecionado tem `trackLot = false`, o campo `lotId` é ocultado e o valor anterior é limpo.
+- O frontend valida o fluxo antes do envio, mas o backend continua sendo a validação final.
+
+## Idempotência e retry seguro
+
+- Cada envio de movimentação usa `Idempotency-Key`.
+- Se ocorrer erro de rede ou timeout sem resposta HTTP, a mesma chave fica preservada para **Reenviar com a mesma chave**.
+- Se qualquer campo do payload mudar depois da falha, o frontend gera uma nova chave e invalida o retry anterior.
+- O snapshot de retry fica salvo temporariamente em `sessionStorage`, por fazenda.
+
+## Resposta do backend
+
+- `201`: exibir badge **Criado**
+- `200`: exibir badge **Repetido (idempotência)**
+
+O painel de resultado mostra:
+
+- `movementId`
+- `type`
+- `quantity`
+- `itemId`
+- `lotId`
+- `movementDate`
+- `resultingBalance`
 
 ## Tratamento de erros
 
-- `400` e `422`: exibem erros por campo (`fieldName`, `message`) e destacam inputs inválidos.
+- `400` e `422`: exibem erros por campo (`fieldName`, `message`) e destacam os inputs relevantes.
 - `404`: mostra mensagem geral de recurso não encontrado.
-- `409`: informa conflito de idempotência e orienta um novo envio com chave nova.
+- `409`: informa conflito e orienta uma nova tentativa quando necessário.
 
-## Como testar manualmente
+## Checklist manual rápido
 
-1. Acesse a tela em uma fazenda válida.
-2. Envie uma movimentação válida e confirme o badge `Criado` (`201`).
-3. Simule falha de rede antes da resposta e confirme que o botão de reenvio aparece.
-4. Clique em **Reenviar com a mesma chave** e valide que a resposta volta como `200` ou `201`, sem duplicidade.
-5. Altere qualquer campo após a falha e confirme que o reenvio antigo é invalidado.
+1. Criar um item novo no modal.
+2. Selecionar o item e confirmar o comportamento de `trackLot`.
+3. Registrar uma movimentação válida e verificar o badge de status.

--- a/src/Models/InventoryDTOs.ts
+++ b/src/Models/InventoryDTOs.ts
@@ -2,6 +2,30 @@ export type InventoryMovementType = "IN" | "OUT" | "ADJUST";
 
 export type InventoryAdjustDirection = "INCREASE" | "DECREASE";
 
+export interface InventoryItem {
+  id: number;
+  name: string;
+  trackLot: boolean;
+  active: boolean;
+}
+
+export interface InventoryItemCreateRequest {
+  name: string;
+  trackLot?: boolean;
+}
+
+export interface InventoryPageMetadata {
+  number: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+}
+
+export interface InventoryItemsPage {
+  content: InventoryItem[];
+  page: InventoryPageMetadata;
+}
+
 export interface InventoryMovementCreateRequestDTO {
   type: InventoryMovementType;
   quantity: number;

--- a/src/Pages/inventory/inventoryPageState.test.ts
+++ b/src/Pages/inventory/inventoryPageState.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildPayloadFromForm,
+  shouldRequireLotId,
+  validateInventoryItemPayload,
+  type InventoryFormState,
+} from "./inventoryPageState";
+
+const baseForm: InventoryFormState = {
+  type: "OUT",
+  quantity: "2",
+  lotId: "",
+  adjustDirection: "",
+  movementDate: "2026-02-28",
+  reason: "Baixa de teste",
+};
+
+describe("inventoryPageState", () => {
+  it("requires lotId when the selected item tracks lot", () => {
+    expect(shouldRequireLotId(true)).toBe(true);
+
+    const result = buildPayloadFromForm({
+      form: baseForm,
+      selectedItemId: "15",
+      selectedTrackLot: true,
+    });
+
+    expect(result.payload).toBeUndefined();
+    expect(result.error).toBe("Informe um lote válido para este item.");
+  });
+
+  it("does not require lotId when the selected item does not track lot", () => {
+    expect(shouldRequireLotId(false)).toBe(false);
+
+    const result = buildPayloadFromForm({
+      form: baseForm,
+      selectedItemId: "15",
+      selectedTrackLot: false,
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.payload).toMatchObject({
+      itemId: 15,
+      quantity: 2,
+    });
+    expect(result.payload?.lotId).toBeUndefined();
+  });
+
+  it("validates item creation name before submitting", () => {
+    expect(validateInventoryItemPayload({ name: "   " })).toBe("Informe o nome do item.");
+    expect(
+      validateInventoryItemPayload({
+        name: "a".repeat(121),
+      })
+    ).toBe("O nome do item deve ter no máximo 120 caracteres.");
+  });
+});

--- a/src/Pages/inventory/inventoryPageState.ts
+++ b/src/Pages/inventory/inventoryPageState.ts
@@ -1,0 +1,128 @@
+import type {
+  InventoryAdjustDirection,
+  InventoryItemCreateRequest,
+  InventoryMovementCreateRequestDTO,
+  InventoryMovementType,
+} from "../../Models/InventoryDTOs";
+
+export type InventoryFormState = {
+  type: InventoryMovementType;
+  quantity: string;
+  lotId: string;
+  adjustDirection: InventoryAdjustDirection | "";
+  movementDate: string;
+  reason: string;
+};
+
+export type InventoryItemFormState = {
+  name: string;
+  trackLot: boolean;
+};
+
+export type BuildPayloadResult = {
+  payload?: InventoryMovementCreateRequestDTO;
+  error?: string;
+};
+
+export const buildInitialForm = (): InventoryFormState => ({
+  type: "OUT",
+  quantity: "",
+  lotId: "",
+  adjustDirection: "",
+  movementDate: new Date().toISOString().slice(0, 10),
+  reason: "",
+});
+
+export const buildInitialItemForm = (): InventoryItemFormState => ({
+  name: "",
+  trackLot: false,
+});
+
+export const mapPayloadToForm = (
+  payload: InventoryMovementCreateRequestDTO
+): InventoryFormState => ({
+  type: payload.type,
+  quantity: `${payload.quantity}`,
+  lotId: payload.lotId != null ? `${payload.lotId}` : "",
+  adjustDirection: payload.type === "ADJUST" ? payload.adjustDirection ?? "" : "",
+  movementDate: payload.movementDate ?? new Date().toISOString().slice(0, 10),
+  reason: payload.reason ?? "",
+});
+
+export const parsePositiveNumber = (value: string): number | null => {
+  if (!value.trim()) return null;
+  const normalized = Number(value.replace(",", "."));
+  if (!Number.isFinite(normalized) || normalized <= 0) {
+    return null;
+  }
+  return normalized;
+};
+
+export const shouldRequireLotId = (trackLot: boolean): boolean => trackLot;
+
+export const buildPayloadFromForm = ({
+  form,
+  selectedItemId,
+  selectedTrackLot,
+}: {
+  form: InventoryFormState;
+  selectedItemId: string;
+  selectedTrackLot: boolean;
+}): BuildPayloadResult => {
+  const quantity = parsePositiveNumber(form.quantity);
+  const itemId = parsePositiveNumber(selectedItemId);
+  const requiresLotId = shouldRequireLotId(selectedTrackLot);
+  const hasLotIdValue = Boolean(form.lotId.trim());
+  const rawLotId = hasLotIdValue ? parsePositiveNumber(form.lotId) : undefined;
+  const lotId = requiresLotId ? rawLotId : undefined;
+
+  if (itemId == null) {
+    return { error: "Selecione um item de estoque." };
+  }
+
+  if (quantity == null) {
+    return { error: "Informe uma quantidade maior que zero." };
+  }
+
+  if (requiresLotId && !hasLotIdValue) {
+    return { error: "Informe um lote válido para este item." };
+  }
+
+  if (requiresLotId && lotId == null) {
+    return { error: "lotId deve ser um número positivo." };
+  }
+
+  if (form.type === "ADJUST" && !form.adjustDirection) {
+    return { error: "Selecione a direção do ajuste." };
+  }
+
+  return {
+    payload: {
+      type: form.type,
+      quantity,
+      itemId,
+      ...(lotId != null ? { lotId } : {}),
+      ...(form.type === "ADJUST" && form.adjustDirection
+        ? { adjustDirection: form.adjustDirection }
+        : {}),
+      ...(form.movementDate ? { movementDate: form.movementDate } : {}),
+      ...(form.reason.trim() ? { reason: form.reason.trim() } : {}),
+    },
+  };
+};
+
+export const validateInventoryItemPayload = (
+  request: InventoryItemCreateRequest
+): string | null => {
+  const name = request.name.trim();
+
+  if (!name) {
+    return "Informe o nome do item.";
+  }
+
+  if (name.length > 120) {
+    return "O nome do item deve ter no máximo 120 caracteres.";
+  }
+
+  return null;
+};

--- a/src/api/GoatFarmAPI/inventory.ts
+++ b/src/api/GoatFarmAPI/inventory.ts
@@ -1,5 +1,8 @@
 import { requestBackEnd } from "../../utils/request";
 import type {
+  InventoryItem,
+  InventoryItemCreateRequest,
+  InventoryItemsPage,
   InventoryMovementCommandResult,
   InventoryMovementCreateRequestDTO,
   InventoryMovementResponseDTO,
@@ -10,8 +13,17 @@ type Envelope<T> = { data: T } | T;
 const unwrap = <T>(data: Envelope<T>): T =>
   (data as { data?: T }).data ?? (data as T);
 
-const getBaseUrl = (farmId: number) =>
+const getMovementBaseUrl = (farmId: number) =>
   `/goatfarms/${farmId}/inventory/movements`;
+
+const getItemsBaseUrl = (farmId: number) => `/goatfarms/${farmId}/inventory/items`;
+
+export const normalizeInventoryItemPayload = (
+  request: InventoryItemCreateRequest
+): InventoryItemCreateRequest => ({
+  name: request.name.trim(),
+  ...(request.trackLot != null ? { trackLot: request.trackLot } : {}),
+});
 
 export const normalizeInventoryMovementPayload = (
   request: InventoryMovementCreateRequestDTO
@@ -39,6 +51,35 @@ export const createInventoryIdempotencyKey = (): string => {
   return `inventory-${Date.now()}-${Math.random().toString(16).slice(2)}`;
 };
 
+export async function listInventoryItems(
+  farmId: number,
+  page = 0,
+  size = 100,
+  activeOnly?: boolean
+): Promise<InventoryItemsPage> {
+  const response = await requestBackEnd.get<Envelope<InventoryItemsPage>>(getItemsBaseUrl(farmId), {
+    params: {
+      page,
+      size,
+      ...(activeOnly != null ? { activeOnly } : {}),
+    },
+  });
+
+  return unwrap<InventoryItemsPage>(response.data);
+}
+
+export async function createInventoryItem(
+  farmId: number,
+  request: InventoryItemCreateRequest
+): Promise<InventoryItem> {
+  const response = await requestBackEnd.post<Envelope<InventoryItem>>(
+    getItemsBaseUrl(farmId),
+    normalizeInventoryItemPayload(request)
+  );
+
+  return unwrap<InventoryItem>(response.data);
+}
+
 export async function createInventoryMovement(
   farmId: number,
   request: InventoryMovementCreateRequestDTO,
@@ -46,7 +87,7 @@ export async function createInventoryMovement(
 ): Promise<InventoryMovementCommandResult> {
   const idempotencyKey = options.idempotencyKey ?? createInventoryIdempotencyKey();
   const response = await requestBackEnd.post(
-    getBaseUrl(farmId),
+    getMovementBaseUrl(farmId),
     normalizeInventoryMovementPayload(request),
     {
       headers: {


### PR DESCRIPTION
## Summary
- add inventory items list/create client helpers
- replace manual itemId entry with item selection and create modal
- keep idempotent movement retry and document the browser flow

## Validation
- npm test
- npm run build
- npm run lint