### PR TITLE
UI: separate farm dashboard and goat detail contexts

### DIFF
--- a/src/Components/GoatCard-to-list/goatCard.tsx
+++ b/src/Components/GoatCard-to-list/goatCard.tsx
@@ -5,6 +5,7 @@ import { Link } from "react-router-dom";
 import { statusDisplayMap } from "../../utils/Translate-Map/statusDisplayMap";
 import { genderDisplayMap } from "../../utils/Translate-Map/genderDisplayMap";
 import { categoryDisplayMap } from '../../utils/Translate-Map/categoryDisplayMap';
+import { buildGoatDetailPath } from "../../utils/appRoutes";
 
 import "./goatCardList.css";
 
@@ -29,6 +30,8 @@ export default function GoatCard({ goat, onEdit, farmOwnerId }: Props) {
 
   const canEdit = isAuthenticated && (permissions.canEditGoat(goat) || isFarmOwner);
   const canDelete = isAuthenticated && (permissions.canDeleteGoat(goat) || isFarmOwner);
+  const goatRouteId = goat.id ?? goat.registrationNumber;
+  const detailPath = buildGoatDetailPath(goat.farmId, goatRouteId);
 
   // Função auxiliar para formatar data curta
   const formatDate = (dateString?: string) => {
@@ -50,7 +53,7 @@ export default function GoatCard({ goat, onEdit, farmOwnerId }: Props) {
 
   return (
     <Link
-      to="/dashboard"
+      to={detailPath}
       state={{
         goat,
         farmId: goat.farmId,
@@ -106,7 +109,7 @@ export default function GoatCard({ goat, onEdit, farmOwnerId }: Props) {
         {/* Ações */}
         <div className="card-actions" onClick={(e) => e.stopPropagation()}>
           <Link 
-            to="/dashboard" 
+            to={detailPath}
             state={{
               goat,
               farmId: goat.farmId,

--- a/src/Components/dash-animal-info/GoatActionPanel.test.tsx
+++ b/src/Components/dash-animal-info/GoatActionPanel.test.tsx
@@ -1,0 +1,56 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import GoatActionPanel from "./GoatActionPanel";
+
+const navigateSpy = vi.fn();
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => navigateSpy,
+}));
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => ({
+    tokenPayload: {
+      userId: 7,
+      authorities: ["ROLE_FARM_OWNER"],
+    },
+  }),
+}));
+
+vi.mock("@/services/PermissionService", () => ({
+  PermissionService: {
+    canViewEvent: () => true,
+    canCreateEvent: () => true,
+    canEditEvent: () => true,
+    canDeleteEvent: () => false,
+  },
+}));
+
+describe("GoatActionPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("keeps only animal actions in the panel and removes inventory from this context", () => {
+    const html = renderToStaticMarkup(
+      <GoatActionPanel
+        registrationNumber="1615325001"
+        goatId={99}
+        farmId={12}
+        canAccessModules={true}
+        gender="FEMALE"
+        resourceOwnerId={7}
+        onShowGenealogy={() => {}}
+        onShowEventForm={() => {}}
+      />
+    );
+
+    expect(html).toContain("Ações do Animal");
+    expect(html).toContain("Gerenciar Fazenda");
+    expect(html).toContain("Sanidade");
+    expect(html).toContain("Lactações");
+    expect(html).toContain("Produção de leite");
+    expect(html).toContain("Reprodução");
+    expect(html).not.toContain("Estoque");
+  });
+});

--- a/src/Components/dash-animal-info/animaldashboard.css
+++ b/src/Components/dash-animal-info/animaldashboard.css
@@ -8,6 +8,39 @@
   gap: 0.75rem;
 }
 
+.goat-action-panel__group {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.goat-action-panel__group--context {
+  margin-top: 0.25rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--gf-color-border, #e2e8f0);
+}
+
+.goat-action-panel__title {
+  margin: 0;
+  color: #0f172a;
+  font-size: 1.05rem;
+  font-weight: 800;
+}
+
+.goat-action-panel__subtitle {
+  margin: 0;
+  color: #64748b;
+  font-size: 0.92rem;
+  line-height: 1.6;
+}
+
+.goat-action-panel__group-label {
+  color: #64748b;
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
 /* ========================= Botões ========================= */
 /* Botões do painel: Design System Clean */
 .goat-action-panel .action-btn {
@@ -46,6 +79,11 @@
   width: 20px;
   text-align: center;
   color: var(--gf-color-primary);
+}
+
+.goat-action-panel .action-btn--context {
+  background: linear-gradient(135deg, rgba(15, 118, 110, 0.08) 0%, rgba(16, 185, 129, 0.12) 100%);
+  border-color: rgba(15, 118, 110, 0.18);
 }
 
 /* Botão de Perigo */

--- a/src/Components/pages-headers/ContextBreadcrumb.css
+++ b/src/Components/pages-headers/ContextBreadcrumb.css
@@ -1,0 +1,40 @@
+.context-breadcrumb {
+  margin: 0 0 1rem;
+}
+
+.context-breadcrumb__list {
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem;
+  list-style: none;
+}
+
+.context-breadcrumb__item,
+.context-breadcrumb__separator {
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.context-breadcrumb__link,
+.context-breadcrumb__label {
+  color: #64748b;
+  text-decoration: none;
+}
+
+.context-breadcrumb__link:hover,
+.context-breadcrumb__link:focus-visible {
+  color: var(--gf-color-primary);
+  text-decoration: underline;
+}
+
+.context-breadcrumb__label--current {
+  color: #0f172a;
+  font-weight: 700;
+}
+
+.context-breadcrumb__separator {
+  color: #94a3b8;
+}

--- a/src/Components/pages-headers/ContextBreadcrumb.tsx
+++ b/src/Components/pages-headers/ContextBreadcrumb.tsx
@@ -1,0 +1,54 @@
+import { Fragment } from "react";
+import { Link } from "react-router-dom";
+import "./ContextBreadcrumb.css";
+
+export type BreadcrumbItem = {
+  label: string;
+  to?: string;
+};
+
+interface Props {
+  items: BreadcrumbItem[];
+}
+
+export default function ContextBreadcrumb({ items }: Props) {
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <nav className="context-breadcrumb" aria-label="Breadcrumb">
+      <ol className="context-breadcrumb__list">
+        {items.map((item, index) => {
+          const isLast = index === items.length - 1;
+
+          return (
+            <Fragment key={`${item.label}-${index}`}>
+              <li className="context-breadcrumb__item">
+                {item.to && !isLast ? (
+                  <Link to={item.to} className="context-breadcrumb__link">
+                    {item.label}
+                  </Link>
+                ) : (
+                  <span
+                    className={`context-breadcrumb__label${
+                      isLast ? " context-breadcrumb__label--current" : ""
+                    }`}
+                    aria-current={isLast ? "page" : undefined}
+                  >
+                    {item.label}
+                  </span>
+                )}
+              </li>
+              {!isLast && (
+                <li className="context-breadcrumb__separator" aria-hidden="true">
+                  /
+                </li>
+              )}
+            </Fragment>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/src/Pages/alerts/FarmAlertsPage.tsx
+++ b/src/Pages/alerts/FarmAlertsPage.tsx
@@ -4,6 +4,7 @@ import type { AlertItem } from "../../services/alerts/AlertRegistry";
 import { FarmAlertsProvider, useFarmAlerts } from "../../contexts/alerts/FarmAlertsContext";
 import GoatFarmHeader from "../../Components/pages-headers/GoatFarmHeader";
 import PageHeader from "../../Components/pages-headers/PageHeader";
+import { buildFarmDashboardPath } from "../../utils/appRoutes";
 import "../../index.css";
 import "./FarmAlertsPage.css";
 
@@ -105,7 +106,7 @@ function FarmAlertsContent() {
         title="Alertas e Pendencias"
         description="Gerencie as pendencias da fazenda"
         showBackButton={true}
-        backButtonUrl={`/app/goatfarms/${farmId}/dashboard`}
+        backButtonUrl={buildFarmDashboardPath(farmIdNumber)}
       />
 
       <div className="card-container">

--- a/src/Pages/dashboard/FarmDashboardPage.css
+++ b/src/Pages/dashboard/FarmDashboardPage.css
@@ -1,0 +1,235 @@
+.farm-dashboard-page__content {
+  width: min(100%, var(--gf-max-width));
+  margin: 0 auto;
+  padding: 0 1.5rem 2rem;
+}
+
+.farm-dashboard-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 1.5rem;
+  align-items: center;
+  padding: 1.5rem;
+  border-radius: 1.25rem;
+  background:
+    radial-gradient(circle at top right, rgba(16, 185, 129, 0.18), transparent 40%),
+    linear-gradient(135deg, #ffffff 0%, #f8fafc 100%);
+  border: 1px solid #dbe4ee;
+  box-shadow: 0 16px 36px rgba(15, 23, 42, 0.08);
+}
+
+.farm-dashboard-hero__eyebrow {
+  display: inline-flex;
+  margin-bottom: 0.65rem;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #0f766e;
+}
+
+.farm-dashboard-hero__title {
+  margin: 0;
+  font-size: clamp(2rem, 3vw, 2.8rem);
+  line-height: 1.05;
+  color: #0f172a;
+}
+
+.farm-dashboard-hero__description {
+  margin: 0.75rem 0 0;
+  max-width: 44rem;
+  font-size: 1rem;
+  line-height: 1.7;
+  color: #475569;
+}
+
+.farm-dashboard-hero__cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 12rem;
+  padding: 0.95rem 1.35rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #10b981 0%, #059669 100%);
+  color: #ffffff;
+  font-weight: 700;
+  text-decoration: none;
+  box-shadow: 0 14px 28px rgba(5, 150, 105, 0.28);
+}
+
+.farm-dashboard-hero__cta:hover,
+.farm-dashboard-hero__cta:focus-visible {
+  color: #ffffff;
+  filter: brightness(1.03);
+  transform: translateY(-1px);
+}
+
+.farm-dashboard-metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+  margin-top: 1.25rem;
+}
+
+.farm-dashboard-metric-card {
+  padding: 1.15rem 1.2rem;
+  border-radius: 1rem;
+  background-color: #ffffff;
+  border: 1px solid #dbe4ee;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.05);
+}
+
+.farm-dashboard-metric-card__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.35rem;
+  height: 2.35rem;
+  margin-bottom: 0.75rem;
+  border-radius: 999px;
+  background-color: rgba(16, 185, 129, 0.12);
+  color: var(--gf-color-primary);
+}
+
+.farm-dashboard-metric-card__label {
+  display: block;
+  margin-bottom: 0.35rem;
+  font-size: 0.85rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #64748b;
+}
+
+.farm-dashboard-metric-card__value {
+  font-size: 1rem;
+  color: #0f172a;
+}
+
+.farm-dashboard-actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+  margin-top: 1.25rem;
+}
+
+.farm-dashboard-action-card {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 1rem;
+  align-items: center;
+  padding: 1.25rem;
+  border-radius: 1rem;
+  text-decoration: none;
+  border: 1px solid #dbe4ee;
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.06);
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+}
+
+.farm-dashboard-action-card:hover,
+.farm-dashboard-action-card:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.09);
+}
+
+.farm-dashboard-action-card--primary {
+  background: linear-gradient(135deg, #0f766e 0%, #0f9d8a 100%);
+  border-color: transparent;
+}
+
+.farm-dashboard-action-card--primary h2,
+.farm-dashboard-action-card--primary p,
+.farm-dashboard-action-card--primary .farm-dashboard-action-card__arrow {
+  color: #ffffff;
+}
+
+.farm-dashboard-action-card--secondary {
+  background-color: #ffffff;
+}
+
+.farm-dashboard-action-card--secondary h2 {
+  color: #0f172a;
+}
+
+.farm-dashboard-action-card--secondary p,
+.farm-dashboard-action-card--secondary .farm-dashboard-action-card__arrow {
+  color: #475569;
+}
+
+.farm-dashboard-action-card__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 0.9rem;
+  font-size: 1.2rem;
+}
+
+.farm-dashboard-action-card--primary .farm-dashboard-action-card__icon {
+  background-color: rgba(255, 255, 255, 0.18);
+  color: #ffffff;
+}
+
+.farm-dashboard-action-card--secondary .farm-dashboard-action-card__icon {
+  background-color: rgba(16, 185, 129, 0.12);
+  color: var(--gf-color-primary);
+}
+
+.farm-dashboard-action-card__content h2 {
+  margin: 0 0 0.35rem;
+  font-size: 1.15rem;
+}
+
+.farm-dashboard-action-card__content p {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.55;
+}
+
+.farm-dashboard-action-card__arrow {
+  font-size: 1rem;
+}
+
+.farm-dashboard-loading {
+  margin-top: 1rem;
+  padding: 0.95rem 1rem;
+  border-radius: 0.85rem;
+  background-color: #eff6ff;
+  color: #1d4ed8;
+  font-weight: 600;
+}
+
+@media (max-width: 960px) {
+  .farm-dashboard-metrics,
+  .farm-dashboard-actions {
+    grid-template-columns: 1fr;
+  }
+
+  .farm-dashboard-hero {
+    grid-template-columns: 1fr;
+  }
+
+  .farm-dashboard-hero__cta {
+    width: 100%;
+  }
+}
+
+@media (max-width: 640px) {
+  .farm-dashboard-page__content {
+    padding: 0 1rem 1.5rem;
+  }
+
+  .farm-dashboard-hero,
+  .farm-dashboard-action-card {
+    padding: 1rem;
+  }
+
+  .farm-dashboard-action-card {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .farm-dashboard-action-card__arrow {
+    display: none;
+  }
+}

--- a/src/Pages/dashboard/FarmDashboardPage.tsx
+++ b/src/Pages/dashboard/FarmDashboardPage.tsx
@@ -1,0 +1,208 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import { getGoatFarmById } from "../../api/GoatFarmAPI/goatFarm";
+import { findGoatsByFarmIdPaginated } from "../../api/GoatAPI/goat";
+import GoatFarmHeader from "../../Components/pages-headers/GoatFarmHeader";
+import ContextBreadcrumb from "../../Components/pages-headers/ContextBreadcrumb";
+import type { GoatFarmDTO } from "../../Models/goatFarm";
+import {
+  buildFarmAlertsPath,
+  buildFarmGoatsPath,
+  buildFarmHealthAgendaPath,
+  buildFarmInventoryPath,
+} from "../../utils/appRoutes";
+import "./FarmDashboardPage.css";
+
+type FarmMetric = {
+  label: string;
+  value: string;
+  icon: string;
+};
+
+type FarmActionCard = {
+  title: string;
+  description: string;
+  icon: string;
+  to: string;
+  tone: "primary" | "secondary";
+};
+
+export default function FarmDashboardPage() {
+  const { farmId } = useParams<{ farmId: string }>();
+  const farmIdNumber = useMemo(() => Number(farmId), [farmId]);
+  const [farmData, setFarmData] = useState<GoatFarmDTO | null>(null);
+  const [totalGoats, setTotalGoats] = useState<number | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (Number.isNaN(farmIdNumber)) {
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    const loadContext = async () => {
+      try {
+        const [farm, goatPage] = await Promise.all([
+          getGoatFarmById(farmIdNumber),
+          findGoatsByFarmIdPaginated(farmIdNumber, 0, 1),
+        ]);
+
+        if (cancelled) {
+          return;
+        }
+
+        setFarmData(farm);
+        setTotalGoats(goatPage.totalElements ?? goatPage.content.length);
+      } catch (error) {
+        console.error("Erro ao carregar o dashboard da fazenda", error);
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void loadContext();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [farmIdNumber]);
+
+  if (Number.isNaN(farmIdNumber)) {
+    return (
+      <div className="farm-dashboard-page">
+        <div className="alert alert-danger">Identificador da fazenda inválido.</div>
+      </div>
+    );
+  }
+
+  const farmName = farmData?.name || "Fazenda";
+  const metrics: FarmMetric[] = [
+    {
+      label: "Rebanho",
+      value: totalGoats == null ? "..." : `${totalGoats}`,
+      icon: "fa-solid fa-cow",
+    },
+    {
+      label: "Contexto",
+      value: "Gestão da propriedade",
+      icon: "fa-solid fa-tractor",
+    },
+    {
+      label: "Acesso rápido",
+      value: "Estoque, alertas e agenda",
+      icon: "fa-solid fa-bolt",
+    },
+  ];
+
+  const actionCards: FarmActionCard[] = [
+    {
+      title: "Estoque",
+      description: "Cadastre produtos, acompanhe saldos e registre movimentações da fazenda.",
+      icon: "fa-solid fa-boxes-stacked",
+      to: buildFarmInventoryPath(farmIdNumber),
+      tone: "primary",
+    },
+    {
+      title: "Rebanho",
+      description: "Acesse a lista de animais da fazenda e entre no detalhe de cada cabra.",
+      icon: "fa-solid fa-goat",
+      to: buildFarmGoatsPath(farmIdNumber),
+      tone: "secondary",
+    },
+    {
+      title: "Alertas",
+      description: "Concentre pendências de reprodução, leite e sanidade em um só lugar.",
+      icon: "fa-solid fa-bell",
+      to: buildFarmAlertsPath(farmIdNumber),
+      tone: "secondary",
+    },
+    {
+      title: "Agenda da Fazenda",
+      description: "Acompanhe compromissos sanitários e próximos eventos do rebanho.",
+      icon: "fa-solid fa-calendar-days",
+      to: buildFarmHealthAgendaPath(farmIdNumber),
+      tone: "secondary",
+    },
+  ];
+
+  return (
+    <div className="farm-dashboard-page">
+      <GoatFarmHeader
+        name={farmName}
+        logoUrl={farmData?.logoUrl}
+        farmId={farmIdNumber}
+      />
+
+      <div className="farm-dashboard-page__content">
+        <ContextBreadcrumb
+          items={[
+            { label: "Fazendas", to: "/goatfarms" },
+            { label: farmName, to: buildFarmGoatsPath(farmIdNumber) },
+            { label: "Dashboard da Fazenda" },
+          ]}
+        />
+
+        <section className="farm-dashboard-hero" aria-label="Resumo da fazenda">
+          <div>
+            <span className="farm-dashboard-hero__eyebrow">Gerir a Fazenda</span>
+            <h1 className="farm-dashboard-hero__title">{farmName}</h1>
+            <p className="farm-dashboard-hero__description">
+              Use este hub para ações da propriedade. Estoque, agenda, alertas e
+              gestão do rebanho ficam aqui, separados do manejo de cada animal.
+            </p>
+          </div>
+
+          <Link
+            to={buildFarmInventoryPath(farmIdNumber)}
+            className="farm-dashboard-hero__cta"
+          >
+            Abrir Estoque
+          </Link>
+        </section>
+
+        <section className="farm-dashboard-metrics" aria-label="Indicadores da fazenda">
+          {metrics.map((metric) => (
+            <article key={metric.label} className="farm-dashboard-metric-card">
+              <span className="farm-dashboard-metric-card__icon" aria-hidden="true">
+                <i className={metric.icon}></i>
+              </span>
+              <span className="farm-dashboard-metric-card__label">{metric.label}</span>
+              <strong className="farm-dashboard-metric-card__value">{metric.value}</strong>
+            </article>
+          ))}
+        </section>
+
+        <section className="farm-dashboard-actions" aria-label="Ações da fazenda">
+          {actionCards.map((card) => (
+            <Link
+              key={card.title}
+              to={card.to}
+              className={`farm-dashboard-action-card farm-dashboard-action-card--${card.tone}`}
+            >
+              <span className="farm-dashboard-action-card__icon" aria-hidden="true">
+                <i className={card.icon}></i>
+              </span>
+              <div className="farm-dashboard-action-card__content">
+                <h2>{card.title}</h2>
+                <p>{card.description}</p>
+              </div>
+              <span className="farm-dashboard-action-card__arrow" aria-hidden="true">
+                <i className="fa-solid fa-arrow-right"></i>
+              </span>
+            </Link>
+          ))}
+        </section>
+
+        {loading && (
+          <div className="farm-dashboard-loading" role="status">
+            Carregando dados da fazenda...
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/Pages/dashboard/animalDashboard.css
+++ b/src/Pages/dashboard/animalDashboard.css
@@ -2,6 +2,69 @@
   width: 100%;
 }
 
+.animal-context-page {
+  padding: 0 1.5rem 2rem;
+}
+
+.animal-context-hero {
+  margin: 0 0 1.5rem;
+  padding: 1.35rem 1.5rem;
+  border: 1px solid #dbe4ee;
+  border-radius: 1.25rem;
+  background:
+    radial-gradient(circle at top right, rgba(59, 130, 246, 0.12), transparent 36%),
+    linear-gradient(135deg, #ffffff 0%, #f8fafc 100%);
+  box-shadow: 0 16px 36px rgba(15, 23, 42, 0.08);
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 1rem;
+  align-items: center;
+}
+
+.animal-context-hero__eyebrow {
+  display: inline-flex;
+  margin-bottom: 0.5rem;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #2563eb;
+}
+
+.animal-context-hero__title {
+  margin: 0;
+  font-size: clamp(1.75rem, 2.8vw, 2.45rem);
+  color: #0f172a;
+}
+
+.animal-context-hero__description {
+  margin: 0.6rem 0 0;
+  color: #475569;
+  font-size: 0.98rem;
+  line-height: 1.65;
+}
+
+.animal-context-hero__cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 12.5rem;
+  padding: 0.9rem 1.3rem;
+  border-radius: 999px;
+  text-decoration: none;
+  font-weight: 700;
+  color: #ffffff;
+  background: linear-gradient(135deg, #0f766e 0%, #10b981 100%);
+  box-shadow: 0 14px 28px rgba(15, 118, 110, 0.22);
+}
+
+.animal-context-hero__cta:hover,
+.animal-context-hero__cta:focus-visible {
+  color: #ffffff;
+  filter: brightness(1.03);
+  transform: translateY(-1px);
+}
+
 /* Painel principal da cabra */
 .goat-panel {
   background-color: var(--gf-color-white);
@@ -78,4 +141,19 @@
   font-size: 1.3rem;
   color: var(--gf-color-darkgreen);
   margin-bottom: 1rem;
+}
+
+@media (max-width: 768px) {
+  .animal-context-page {
+    padding: 0 1rem 1.5rem;
+  }
+
+  .animal-context-hero {
+    grid-template-columns: 1fr;
+    padding: 1rem;
+  }
+
+  .animal-context-hero__cta {
+    width: 100%;
+  }
 }

--- a/src/Pages/goat-events/GoatEventsPage.tsx
+++ b/src/Pages/goat-events/GoatEventsPage.tsx
@@ -1,9 +1,10 @@
-import { useParams, useNavigate, useSearchParams } from "react-router-dom";
-import { useState, useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 
 import GoatEventList from "../../Components/events/GoatEventList";
 import SearchFilter from "../../Components/searchs/SearchFilter";
 import { isAuthenticated } from "../../services/auth-service";
+import { buildGoatDetailPath, buildGoatHealthPath } from "../../utils/appRoutes";
 
 import "../../index.css";
 import "./goatEventPage.css";
@@ -19,33 +20,56 @@ export default function GoatEventsPage() {
     endDate: "",
   });
 
+  const farmId = useMemo(() => searchParams.get("farmId"), [searchParams]);
+
   useEffect(() => {
     if (!isAuthenticated()) {
-      console.log("❌ Usuário não autenticado, redirecionando para login");
+      console.log("Usuário não autenticado, redirecionando para login");
       navigate("/login");
     }
   }, [navigate]);
 
+  const healthPath =
+    registrationNumber && farmId
+      ? buildGoatHealthPath(farmId, registrationNumber)
+      : undefined;
+  const goatDetailPath =
+    registrationNumber && farmId
+      ? buildGoatDetailPath(farmId, registrationNumber)
+      : undefined;
+
   return (
     <div className="content-in">
-      {/* Cabeçalho com título e botão de voltar na mesma linha */}
       <div className="events-header-line">
         <h2 className="title">Eventos do Animal</h2>
         <div className="d-flex gap-2">
-          <button 
-              className="btn-info text-white" 
-              onClick={() => navigate(`/app/goatfarms/${searchParams.get("farmId")}/goats/${registrationNumber}/health`)}
-              title="Gestão de Saúde"
+          <button
+            className="btn-info text-white"
+            onClick={() => {
+              if (healthPath) {
+                navigate(healthPath);
+              }
+            }}
+            title="Gestão de saúde"
+            disabled={!healthPath}
           >
-              <i className="fa-solid fa-heart-pulse"></i> Saúde
+            <i className="fa-solid fa-heart-pulse"></i> Saúde
           </button>
-          <button className="btn-primary" onClick={() => navigate(-1)}>
-            🔙 Voltar para Dashboard
+          <button
+            className="btn-primary"
+            onClick={() => {
+              if (goatDetailPath) {
+                navigate(goatDetailPath);
+                return;
+              }
+              navigate(-1);
+            }}
+          >
+            🔙 Voltar para detalhes do animal
           </button>
         </div>
       </div>
 
-      {/* Filtro com largura total igual à da tabela */}
       <div className="box">
         <SearchFilter onFilter={setFilters} />
       </div>
@@ -53,13 +77,11 @@ export default function GoatEventsPage() {
       {registrationNumber ? (
         <GoatEventList
           registrationNumber={registrationNumber}
-          farmId={Number(searchParams.get("farmId"))}
+          farmId={Number(farmId)}
           filters={filters}
         />
       ) : (
-        <p className="error-text">
-          Número de registro da cabra não encontrado na URL.
-        </p>
+        <p className="error-text">Número de registro da cabra não encontrado na URL.</p>
       )}
     </div>
   );

--- a/src/Pages/goat-list-page/goatList.css
+++ b/src/Pages/goat-list-page/goatList.css
@@ -6,6 +6,64 @@
   padding: 2rem 1.5rem;
 }
 
+.farm-context-entry {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 1rem;
+  align-items: center;
+  margin-bottom: 1.5rem;
+  padding: 1.1rem 1.2rem;
+  border-radius: 1rem;
+  background:
+    radial-gradient(circle at top right, rgba(16, 185, 129, 0.12), transparent 38%),
+    linear-gradient(135deg, #ffffff 0%, #f8fafc 100%);
+  border: 1px solid #dbe4ee;
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.05);
+}
+
+.farm-context-entry__eyebrow {
+  display: inline-flex;
+  margin-bottom: 0.35rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #0f766e;
+}
+
+.farm-context-entry__title {
+  display: block;
+  color: #0f172a;
+  font-size: 1rem;
+}
+
+.farm-context-entry__description {
+  margin: 0.35rem 0 0;
+  color: #475569;
+  font-size: 0.92rem;
+  line-height: 1.55;
+}
+
+.farm-context-entry__cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 14rem;
+  padding: 0.85rem 1.25rem;
+  border-radius: 999px;
+  text-decoration: none;
+  font-weight: 700;
+  color: #ffffff;
+  background: linear-gradient(135deg, #0f766e 0%, #10b981 100%);
+  box-shadow: 0 14px 28px rgba(15, 118, 110, 0.2);
+}
+
+.farm-context-entry__cta:hover,
+.farm-context-entry__cta:focus-visible {
+  color: #ffffff;
+  filter: brightness(1.03);
+}
+
 /* Header Styling */
 .goat-header {
   display: flex;
@@ -176,6 +234,14 @@
   .btn-new-goat {
     width: 100%;
     justify-content: center;
+  }
+
+  .farm-context-entry {
+    grid-template-columns: 1fr;
+  }
+
+  .farm-context-entry__cta {
+    width: 100%;
   }
 
   .goat-cards-grid {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,6 +10,7 @@ import BlogArticlePage from "./Pages/blog/BlogArticlePage";
 import ListFarms from "./Pages/goatfarms/ListFarms";
 import GoatListPage from "./Pages/goat-list-page/GoatListPage";
 import AnimalDashboard from "./Pages/dashboard/Dashboard";
+import FarmDashboardPage from "./Pages/dashboard/FarmDashboardPage";
 // PRIVATE
 import FarmCreatePage from "./Pages/farms-creted/FarmCreatePage";
 import FarmEditPage from "./Pages/farms-edited/FarmEditPage";
@@ -77,6 +78,22 @@ const router = createBrowserRouter([
         )
       },
       { path: "dashboard", element: <AnimalDashboard /> },
+      {
+        path: "app/goatfarms/:farmId/dashboard",
+        element: (
+          <PrivateRoute roles={[RoleEnum.ROLE_FARM_OWNER, RoleEnum.ROLE_OPERATOR, RoleEnum.ROLE_ADMIN]}>
+            <FarmDashboardPage />
+          </PrivateRoute>
+        ),
+      },
+      {
+        path: "app/goatfarms/:farmId/goats/:goatId",
+        element: (
+          <PrivateRoute roles={[RoleEnum.ROLE_FARM_OWNER, RoleEnum.ROLE_OPERATOR, RoleEnum.ROLE_ADMIN]}>
+            <AnimalDashboard />
+          </PrivateRoute>
+        ),
+      },
       { path: "registro", element: <FarmCreatePage /> }, // Rota pública para registro
 
       // Rotas Privadas (exceto /fazendas/novo que agora é pública)

--- a/src/utils/appRoutes.test.ts
+++ b/src/utils/appRoutes.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildFarmAlertsPath,
+  buildFarmDashboardPath,
+  buildFarmGoatsPath,
+  buildFarmHealthAgendaPath,
+  buildFarmInventoryPath,
+  buildGoatDetailPath,
+  buildGoatEventsPath,
+  buildGoatHealthPath,
+  buildGoatLactationsPath,
+  buildGoatMilkProductionsPath,
+  buildGoatReproductionPath,
+} from "./appRoutes";
+
+describe("appRoutes", () => {
+  it("builds canonical farm context paths", () => {
+    expect(buildFarmDashboardPath(12)).toBe("/app/goatfarms/12/dashboard");
+    expect(buildFarmInventoryPath(12)).toBe("/app/goatfarms/12/inventory");
+    expect(buildFarmAlertsPath(12)).toBe("/app/goatfarms/12/alerts");
+    expect(buildFarmHealthAgendaPath(12)).toBe("/app/goatfarms/12/health-agenda");
+    expect(buildFarmGoatsPath(12)).toBe("/cabras?farmId=12");
+  });
+
+  it("builds canonical animal context paths", () => {
+    expect(buildGoatDetailPath(7, 99)).toBe("/app/goatfarms/7/goats/99");
+    expect(buildGoatHealthPath(7, 99)).toBe("/app/goatfarms/7/goats/99/health");
+    expect(buildGoatLactationsPath(7, 99)).toBe("/app/goatfarms/7/goats/99/lactations");
+    expect(buildGoatMilkProductionsPath(7, 99)).toBe("/app/goatfarms/7/goats/99/milk-productions");
+    expect(buildGoatReproductionPath(7, 99)).toBe("/app/goatfarms/7/goats/99/reproduction");
+  });
+
+  it("keeps goat events compatibility with optional farm context", () => {
+    expect(buildGoatEventsPath("1615325001")).toBe("/cabras/1615325001/eventos");
+    expect(buildGoatEventsPath("1615325001", 7)).toBe("/cabras/1615325001/eventos?farmId=7");
+  });
+
+  it("encodes path and query segments safely", () => {
+    expect(buildGoatDetailPath(7, "ABC 01")).toBe("/app/goatfarms/7/goats/ABC%2001");
+    expect(buildGoatEventsPath("ABC 01", "FARM 1")).toBe(
+      "/cabras/ABC%2001/eventos?farmId=FARM%201"
+    );
+  });
+});

--- a/src/utils/appRoutes.ts
+++ b/src/utils/appRoutes.ts
@@ -1,0 +1,60 @@
+const encodePathSegment = (value: string | number): string =>
+  encodeURIComponent(String(value));
+
+export const buildFarmDashboardPath = (farmId: string | number): string =>
+  `/app/goatfarms/${encodePathSegment(farmId)}/dashboard`;
+
+export const buildFarmInventoryPath = (farmId: string | number): string =>
+  `/app/goatfarms/${encodePathSegment(farmId)}/inventory`;
+
+export const buildFarmAlertsPath = (farmId: string | number): string =>
+  `/app/goatfarms/${encodePathSegment(farmId)}/alerts`;
+
+export const buildFarmHealthAgendaPath = (farmId: string | number): string =>
+  `/app/goatfarms/${encodePathSegment(farmId)}/health-agenda`;
+
+export const buildFarmGoatsPath = (farmId: string | number): string =>
+  `/cabras?farmId=${encodePathSegment(farmId)}`;
+
+export const buildGoatDetailPath = (
+  farmId: string | number,
+  goatId: string | number
+): string =>
+  `/app/goatfarms/${encodePathSegment(farmId)}/goats/${encodePathSegment(goatId)}`;
+
+export const buildGoatHealthPath = (
+  farmId: string | number,
+  goatId: string | number
+): string =>
+  `${buildGoatDetailPath(farmId, goatId)}/health`;
+
+export const buildGoatLactationsPath = (
+  farmId: string | number,
+  goatId: string | number
+): string =>
+  `${buildGoatDetailPath(farmId, goatId)}/lactations`;
+
+export const buildGoatMilkProductionsPath = (
+  farmId: string | number,
+  goatId: string | number
+): string =>
+  `${buildGoatDetailPath(farmId, goatId)}/milk-productions`;
+
+export const buildGoatReproductionPath = (
+  farmId: string | number,
+  goatId: string | number
+): string =>
+  `${buildGoatDetailPath(farmId, goatId)}/reproduction`;
+
+export const buildGoatEventsPath = (
+  registrationNumber: string,
+  farmId?: string | number | null
+): string => {
+  const base = `/cabras/${encodePathSegment(registrationNumber)}/eventos`;
+
+  if (farmId == null || farmId === "") {
+    return base;
+  }
+
+  return `${base}?farmId=${encodePathSegment(farmId)}`;
+};


### PR DESCRIPTION
## Summary
- separate the farm dashboard from the goat detail view while keeping the legacy /dashboard link working
- move inventory access out of the goat action panel and add contextual breadcrumb/navigation helpers
- add regression coverage to ensure the goat panel no longer exposes farm inventory actions

## Validation
- npm test
- npm run build
- npm run lint