### PR TITLE
Sprint 1: navigation and accessibility hardening

### DIFF
--- a/src/Components/dash-animal-info/GoatActionPanel.test.tsx
+++ b/src/Components/dash-animal-info/GoatActionPanel.test.tsx
@@ -22,7 +22,7 @@ vi.mock("@/services/PermissionService", () => ({
     canViewEvent: () => true,
     canCreateEvent: () => true,
     canEditEvent: () => true,
-    canDeleteEvent: () => false,
+    canDeleteEvent: () => true,
   },
 }));
 
@@ -31,7 +31,7 @@ describe("GoatActionPanel", () => {
     vi.clearAllMocks();
   });
 
-  it("keeps only animal actions in the panel and removes inventory from this context", () => {
+  it("keeps only animal actions in the panel and removes farm inventory and dead delete actions", () => {
     const html = renderToStaticMarkup(
       <GoatActionPanel
         registrationNumber="1615325001"
@@ -45,12 +45,10 @@ describe("GoatActionPanel", () => {
       />
     );
 
-    expect(html).toContain("Ações do Animal");
     expect(html).toContain("Gerenciar Fazenda");
     expect(html).toContain("Sanidade");
-    expect(html).toContain("Lactações");
-    expect(html).toContain("Produção de leite");
     expect(html).toContain("Reprodução");
     expect(html).not.toContain("Estoque");
+    expect(html).not.toContain("Excluir");
   });
 });

--- a/src/Components/dash-animal-info/GoatActionPanel.tsx
+++ b/src/Components/dash-animal-info/GoatActionPanel.tsx
@@ -62,9 +62,6 @@ export default function GoatActionPanel({
   const canEdit =
     !!tokenPayload &&
     PermissionService.canEditEvent(userRole, userId, farmOwnerId);
-  const canDelete =
-    !!tokenPayload &&
-    PermissionService.canDeleteEvent(userRole, userId, farmOwnerId);
 
   return (
     <aside className="goat-action-panel" aria-label="Ações do animal">
@@ -160,7 +157,7 @@ export default function GoatActionPanel({
         )}
       </div>
 
-      {(canSeeEvents || canAddEvent || canEdit || canDelete) && (
+      {(canSeeEvents || canAddEvent || canEdit) && (
         <div className="goat-action-panel__group">
           <span className="goat-action-panel__group-label">Eventos do animal</span>
 
@@ -189,17 +186,6 @@ export default function GoatActionPanel({
               }}
             >
               <i className="fa-solid fa-pen"></i> Editar
-            </button>
-          )}
-
-          {canDelete && (
-            <button
-              className="action-btn btn-danger"
-              onClick={() => {
-                // Implementar acao de exclusao
-              }}
-            >
-              <i className="fa-solid fa-trash"></i> Excluir
             </button>
           )}
         </div>

--- a/src/Components/goatfarms-cards/GoatfarmCard.test.tsx
+++ b/src/Components/goatfarms-cards/GoatfarmCard.test.tsx
@@ -1,0 +1,41 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import type { GoatFarmDTO } from "../../Models/goatFarm";
+import GoatfarmCard from "./GoatfarmCard";
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => ({
+    isAuthenticated: true,
+  }),
+}));
+
+vi.mock("@/Hooks/usePermissions", () => ({
+  usePermissions: () => ({
+    canEditFarm: () => true,
+    canDeleteFarm: () => true,
+  }),
+}));
+
+describe("GoatfarmCard", () => {
+  it("closes the primary link before rendering secondary actions", () => {
+    const html = renderToStaticMarkup(
+      <MemoryRouter>
+        <GoatfarmCard
+          farm={{
+            id: 1,
+            name: "Capril Vilar",
+            tod: "123",
+            userName: "Alberto",
+            city: "Belo Horizonte",
+            state: "MG",
+            phones: [],
+            logoUrl: "",
+          } as unknown as GoatFarmDTO}
+        />
+      </MemoryRouter>
+    );
+
+    expect(html).toContain("</a><div class=\"farm-card-actions\">");
+  });
+});

--- a/src/Components/goatfarms-cards/GoatfarmCard.tsx
+++ b/src/Components/goatfarms-cards/GoatfarmCard.tsx
@@ -1,12 +1,11 @@
+import { useState } from "react";
 import type { GoatFarmDTO } from "../../Models/goatFarm";
 import { Link } from "react-router-dom";
-import "./goatfarmsCards.css";
-
+import { toast } from "react-toastify";
+import { deleteGoatFarm } from "../../api/GoatFarmAPI/goatFarm";
 import { useAuth } from "@/contexts/AuthContext";
 import { usePermissions } from "@/Hooks/usePermissions";
-import { deleteGoatFarm } from "../../api/GoatFarmAPI/goatFarm";
-import { toast } from "react-toastify";
-import { useState } from "react";
+import "./goatfarmsCards.css";
 
 type Props = {
   farm: GoatFarmDTO;
@@ -18,8 +17,8 @@ export default function GoatFarmCard({ farm, onDeleted }: Props) {
   const permissions = usePermissions();
   const [isDeleting, setIsDeleting] = useState(false);
   const [imageError, setImageError] = useState(false);
+  const farmDetailsPath = `/cabras?farmId=${farm.id}`;
 
-  // Lógica de permissões centralizada no hook
   const canEdit = isAuthenticated && permissions.canEditFarm(farm);
   const canDelete = isAuthenticated && permissions.canDeleteFarm(farm);
 
@@ -37,29 +36,30 @@ export default function GoatFarmCard({ farm, onDeleted }: Props) {
     try {
       await deleteGoatFarm(farm.id);
       toast.success(`Fazenda "${farm.name}" removida com sucesso!`);
-      
-      // Notifica o componente pai para remover da lista
+
       if (onDeleted) {
         onDeleted(farm.id);
       } else {
-        // Se não tiver callback, recarrega a página após 1s
         setTimeout(() => {
           window.location.reload();
         }, 1000);
       }
     } catch (err: unknown) {
-      const error = err as { response?: { status?: number; data?: { message?: string } }; message?: string };
+      const error = err as {
+        response?: { status?: number; data?: { message?: string } };
+        message?: string;
+      };
       const status = error.response?.status;
 
       if (status === 401) {
-        toast.error('Sessão expirada. Faça login novamente.');
+        toast.error("Sessão expirada. Faça login novamente.");
         setTimeout(() => {
-          window.location.href = '/login';
+          window.location.href = "/login";
         }, 2000);
       } else if (status === 403) {
-        toast.error('Você não tem permissão para deletar esta fazenda.');
+        toast.error("Você não tem permissão para deletar esta fazenda.");
       } else if (status === 404) {
-        toast.info('Fazenda não encontrada. A lista será atualizada.');
+        toast.info("Fazenda não encontrada. A lista será atualizada.");
         if (onDeleted) {
           onDeleted(farm.id);
         } else {
@@ -68,7 +68,8 @@ export default function GoatFarmCard({ farm, onDeleted }: Props) {
           }, 1000);
         }
       } else {
-        const errorMessage = error.response?.data?.message || error.message || 'Erro desconhecido';
+        const errorMessage =
+          error.response?.data?.message || error.message || "Erro desconhecido";
         toast.error(`Erro ao deletar fazenda: ${errorMessage}`);
       }
     } finally {
@@ -77,9 +78,12 @@ export default function GoatFarmCard({ farm, onDeleted }: Props) {
   };
 
   return (
-    <Link to={`/cabras?farmId=${farm.id}`} className="goatfarm-card-link">
-      <div className="goatfarm-card">
-        {/* Header */}
+    <article className="goatfarm-card">
+      <Link
+        to={farmDetailsPath}
+        className="goatfarm-card-link"
+        aria-label={`Abrir detalhes da fazenda ${farm.name}`}
+      >
         <div className="farm-card-header">
           <div className="farm-logo-container">
             {farm.logoUrl && !imageError ? (
@@ -90,7 +94,7 @@ export default function GoatFarmCard({ farm, onDeleted }: Props) {
                 onError={() => setImageError(true)}
               />
             ) : (
-              <div className="farm-logo-placeholder">
+              <div className="farm-logo-placeholder" aria-hidden="true">
                 <i className="fa-solid fa-tractor"></i>
               </div>
             )}
@@ -99,81 +103,84 @@ export default function GoatFarmCard({ farm, onDeleted }: Props) {
             <h3 className="farm-name">{farm.name}</h3>
             {farm.tod && (
               <span className="farm-tod" title="Registro TOD">
-                <i className="fa-solid fa-fingerprint"></i> TOD: {farm.tod}
+                <i className="fa-solid fa-fingerprint" aria-hidden="true"></i> TOD: {farm.tod}
               </span>
             )}
           </div>
         </div>
 
-        {/* Info Grid */}
         <div className="farm-info-grid">
           <div className="farm-info-item">
             <span className="farm-info-label">Proprietário</span>
-            <span className="farm-info-value" title={farm.userName}>{farm.userName}</span>
+            <span className="farm-info-value" title={farm.userName}>
+              {farm.userName}
+            </span>
           </div>
           <div className="farm-info-item">
-             <span className="farm-info-label">Endereço</span>
-             <span className="farm-info-value" title={`${farm.city} - ${farm.state}`}>
-                {farm.city} - {farm.state}
-             </span>
+            <span className="farm-info-label">Endereço</span>
+            <span className="farm-info-value" title={`${farm.city} - ${farm.state}`}>
+              {farm.city} - {farm.state}
+            </span>
           </div>
         </div>
 
-        {/* Contact Section */}
         <div className="farm-location-contact">
           {farm.phones && farm.phones.length > 0 ? (
             farm.phones.map((phone, index) => (
               <div key={index} className="contact-row">
-                <i className="fa-solid fa-phone"></i>
-                <span>({phone.ddd}) {phone.number}</span>
+                <i className="fa-solid fa-phone" aria-hidden="true"></i>
+                <span>
+                  ({phone.ddd}) {phone.number}
+                </span>
               </div>
             ))
           ) : (
-             <div className="contact-row">
-                <i className="fa-solid fa-phone-slash"></i>
-                <span style={{fontStyle: 'italic'}}>Sem telefone</span>
-             </div>
+            <div className="contact-row">
+              <i className="fa-solid fa-phone-slash" aria-hidden="true"></i>
+              <span style={{ fontStyle: "italic" }}>Sem telefone</span>
+            </div>
           )}
         </div>
+      </Link>
 
-        {/* Actions Footer */}
-        <div className="farm-card-actions">
-           {/* Botão de Detalhes (Sempre visível) */}
-            <Link
-              to={`/cabras?farmId=${farm.id}`}
-              className="action-btn details"
-              title="Ver Detalhes / Cabras"
-            >
-              <i className="fa-solid fa-magnifying-glass"></i>
-            </Link>
+      <div className="farm-card-actions">
+        <Link
+          to={farmDetailsPath}
+          className="action-btn details"
+          title="Ver detalhes da fazenda"
+          aria-label={`Ver detalhes da fazenda ${farm.name}`}
+        >
+          <i className="fa-solid fa-magnifying-glass" aria-hidden="true"></i>
+        </Link>
 
-          {canEdit && (
-            <Link
-              to={`/fazendas/${farm.id}/editar`}
-              className="action-btn edit"
-              onClick={(e) => e.stopPropagation()}
-              title="Editar Fazenda"
-            >
-              <i className="fa-solid fa-pen"></i>
-            </Link>
-          )}
+        {canEdit && (
+          <Link
+            to={`/fazendas/${farm.id}/editar`}
+            className="action-btn edit"
+            title="Editar Fazenda"
+            aria-label={`Editar fazenda ${farm.name}`}
+          >
+            <i className="fa-solid fa-pen" aria-hidden="true"></i>
+          </Link>
+        )}
 
-          {canDelete && (
-            <button
-              className="action-btn delete"
-              onClick={handleDelete}
-              disabled={isDeleting}
-              title="Excluir Fazenda"
-            >
-              {isDeleting ? (
-                <i className="fa-solid fa-spinner fa-spin"></i>
-              ) : (
-                <i className="fa-solid fa-trash"></i>
-              )}
-            </button>
-          )}
-        </div>
+        {canDelete && (
+          <button
+            type="button"
+            className="action-btn delete"
+            onClick={handleDelete}
+            disabled={isDeleting}
+            title="Excluir Fazenda"
+            aria-label={`Excluir fazenda ${farm.name}`}
+          >
+            {isDeleting ? (
+              <i className="fa-solid fa-spinner fa-spin" aria-hidden="true"></i>
+            ) : (
+              <i className="fa-solid fa-trash" aria-hidden="true"></i>
+            )}
+          </button>
+        )}
       </div>
-    </Link>
+    </article>
   );
 }

--- a/src/Components/goatfarms-cards/goatfarmsCards.css
+++ b/src/Components/goatfarms-cards/goatfarmsCards.css
@@ -2,7 +2,10 @@
 .goatfarm-card-link {
   text-decoration: none;
   color: inherit;
-  display: block;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  flex: 1;
 }
 
 /* ====================== Card de Fazenda Moderno ====================== */
@@ -27,6 +30,12 @@
   /* Sombra intensa no hover */
   box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
   border-color: var(--gf-color-primary, #10b981);
+}
+
+.goatfarm-card-link:focus-visible {
+  outline: 3px solid rgba(16, 185, 129, 0.25);
+  outline-offset: 6px;
+  border-radius: 16px;
 }
 
 /* ====================== Cabeçalho do Card ====================== */

--- a/src/Components/navigation/Navbar.test.tsx
+++ b/src/Components/navigation/Navbar.test.tsx
@@ -1,0 +1,37 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import Navbar from "./Navbar";
+
+vi.mock("../../contexts/AuthContext", () => ({
+  useAuth: () => ({
+    tokenPayload: {
+      user_name: "Alberto",
+      userEmail: "alberto@example.com",
+      authorities: ["ROLE_ADMIN"],
+    },
+    logout: vi.fn(),
+  }),
+}));
+
+vi.mock("../../Hooks/usePermissions", () => ({
+  usePermissions: () => ({
+    isAdmin: () => true,
+  }),
+}));
+
+describe("Navbar", () => {
+  it("renders the mobile drawer entry points with accessible labels", () => {
+    const html = renderToStaticMarkup(
+      <MemoryRouter>
+        <Navbar />
+      </MemoryRouter>
+    );
+
+    expect(html).toContain('aria-label="Abrir menu de navegação"');
+    expect(html).toContain('id="mobile-nav-drawer"');
+    expect(html).toContain('aria-label="Ir para Fazendas"');
+    expect(html).toContain(">Fazendas<");
+    expect(html).toContain('aria-label="Saiba mais sobre o CapriGestor"');
+  });
+});

--- a/src/Components/navigation/Navbar.tsx
+++ b/src/Components/navigation/Navbar.tsx
@@ -1,82 +1,228 @@
+import { useEffect, useMemo, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { useAuth } from "../../contexts/AuthContext";
 import { usePermissions } from "../../Hooks/usePermissions";
 import "./navbar.css";
 
+type NavLinkItem = {
+  path: string;
+  label: string;
+  icon: string;
+};
+
 export default function Navbar() {
-    const { pathname } = useLocation();
-    const { tokenPayload, logout } = useAuth();
-    const permissions = usePermissions();
+  const { pathname } = useLocation();
+  const { tokenPayload, logout } = useAuth();
+  const permissions = usePermissions();
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
-    const navLinks = [
-        { path: "/", label: "Início", icon: "fa-house" },
-        { path: "/fazendas", label: "Fazendas", icon: "fa-farm" },
-        { path: "/cabras", label: "Cabras", icon: "fa-cow" },
-        { path: "/blog", label: "Blog", icon: "fa-newspaper" },
-    ];
+  const navLinks = useMemo<NavLinkItem[]>(
+    () => [
+      { path: "/", label: "Início", icon: "fa-house" },
+      { path: "/fazendas", label: "Fazendas", icon: "fa-farm" },
+      { path: "/cabras", label: "Cabras", icon: "fa-cow" },
+      { path: "/blog", label: "Blog", icon: "fa-newspaper" },
+    ],
+    []
+  );
 
-    const handleLogout = () => {
-        logout();
-        window.location.replace("/");
+  useEffect(() => {
+    setIsMobileMenuOpen(false);
+  }, [pathname]);
+
+  useEffect(() => {
+    if (!isMobileMenuOpen) {
+      return;
+    }
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setIsMobileMenuOpen(false);
+      }
     };
 
-    return (
-        <nav className="modern-navbar">
-            <div className="navbar-container">
-                <Link to="/" className="navbar-brand">
-                    <div className="brand-logo-wrapper">
-                        <img src="/logo_Caprigestor.png" alt="CapriGestor Logo" className="brand-logo-img" />
-                    </div>
-                    <span className="brand-name">CapriGestor</span>
-                </Link>
+    document.addEventListener("keydown", handleEscape);
+    return () => document.removeEventListener("keydown", handleEscape);
+  }, [isMobileMenuOpen]);
 
-                <div className="navbar-links">
-                    {navLinks.map((link) => (
-                        <Link
-                            key={link.path}
-                            to={link.path}
-                            className={`nav-link ${pathname === link.path ? "active" : ""}`}
-                        >
-                            <i className={`fa-solid ${link.icon}`}></i>
-                            <span>{link.label}</span>
-                        </Link>
-                    ))}
-                </div>
+  const handleLogout = () => {
+    setIsMobileMenuOpen(false);
+    logout();
+    window.location.replace("/");
+  };
 
-                <div className="navbar-actions">
-                    {permissions.isAdmin() && (
-                        <Link to="/app/editor/articles" className="editor-btn" title="Editor de Artigos">
-                            <i className="fa-solid fa-pen-to-square"></i>
-                            <span className="editor-label">Editor</span>
-                        </Link>
-                    )}
-                    <Link to="/fazendas/novo" className="create-farm-btn">
-                        <i className="fa-solid fa-plus"></i>
-                        <span>Cadastrar Fazenda</span>
-                    </Link>
+  const renderNavLinks = (className: string) =>
+    navLinks.map((link) => (
+      <Link
+        key={`${className}-${link.path}`}
+        to={link.path}
+        className={[className, pathname === link.path ? "active" : ""]
+          .filter(Boolean)
+          .join(" ")}
+        aria-label={`Ir para ${link.label}`}
+      >
+        <i className={`fa-solid ${link.icon}`} aria-hidden="true"></i>
+        <span>{link.label}</span>
+      </Link>
+    ));
 
-                    {tokenPayload ? (
-                        <div className="user-profile-group">
-                            <div className="user-profile">
-                                <div className="user-info-text">
-                                    <span className="user-name">{tokenPayload.user_name}</span>
-                                    <span className="user-email">{tokenPayload.userEmail}</span>
-                                </div>
-                                <div className="user-avatar">
-                                    {tokenPayload.user_name?.charAt(0)}
-                                </div>
-                            </div>
-                            <button className="navbar-logout-btn" onClick={handleLogout} title="Sair">
-                                <i className="fa-solid fa-sign-out-alt"></i>
-                            </button>
-                        </div>
-                    ) : (
-                        <Link to="/login" className="login-btn">
-                            Entrar
-                        </Link>
-                    )}
-                </div>
+  return (
+    <>
+      <nav className="modern-navbar" aria-label="Navegação principal">
+        <div className="navbar-container">
+          <Link to="/" className="navbar-brand" aria-label="Ir para a página inicial">
+            <div className="brand-logo-wrapper">
+              <img
+                src="/logo_Caprigestor.png"
+                alt="CapriGestor Logo"
+                className="brand-logo-img"
+              />
             </div>
+            <span className="brand-name">CapriGestor</span>
+          </Link>
+
+          <div className="navbar-links">{renderNavLinks("nav-link")}</div>
+
+          <div className="navbar-actions">
+            {permissions.isAdmin() && (
+              <Link
+                to="/app/editor/articles"
+                className="editor-btn"
+                title="Editor de Artigos"
+                aria-label="Abrir editor de artigos"
+              >
+                <i className="fa-solid fa-pen-to-square" aria-hidden="true"></i>
+                <span className="editor-label">Editor</span>
+              </Link>
+            )}
+            <Link
+              to="/fazendas/novo"
+              className="create-farm-btn"
+              aria-label="Cadastrar nova fazenda"
+            >
+              <i className="fa-solid fa-plus" aria-hidden="true"></i>
+              <span>Cadastrar Fazenda</span>
+            </Link>
+
+            {tokenPayload ? (
+              <div className="user-profile-group">
+                <div className="user-profile" aria-label="Perfil do usuário">
+                  <div className="user-info-text">
+                    <span className="user-name">{tokenPayload.user_name}</span>
+                    <span className="user-email">{tokenPayload.userEmail}</span>
+                  </div>
+                  <div className="user-avatar" aria-hidden="true">
+                    {tokenPayload.user_name?.charAt(0)}
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  className="navbar-logout-btn"
+                  onClick={handleLogout}
+                  title="Sair"
+                  aria-label="Sair da aplicação"
+                >
+                  <i className="fa-solid fa-sign-out-alt" aria-hidden="true"></i>
+                </button>
+              </div>
+            ) : (
+              <Link to="/login" className="login-btn" aria-label="Entrar na aplicação">
+                Entrar
+              </Link>
+            )}
+          </div>
+
+          <button
+            type="button"
+            className="navbar-menu-toggle"
+            aria-label={isMobileMenuOpen ? "Fechar menu de navegação" : "Abrir menu de navegação"}
+            aria-expanded={isMobileMenuOpen}
+            aria-controls="mobile-nav-drawer"
+            onClick={() => setIsMobileMenuOpen((current) => !current)}
+          >
+            <i
+              className={`fa-solid ${isMobileMenuOpen ? "fa-xmark" : "fa-bars"}`}
+              aria-hidden="true"
+            ></i>
+          </button>
+        </div>
+      </nav>
+
+      <div
+        className={`navbar-mobile-backdrop ${isMobileMenuOpen ? "is-open" : ""}`}
+        onClick={() => setIsMobileMenuOpen(false)}
+        aria-hidden={!isMobileMenuOpen}
+      />
+
+      <aside
+        id="mobile-nav-drawer"
+        className={`navbar-mobile-drawer ${isMobileMenuOpen ? "is-open" : ""}`}
+        aria-label="Menu de navegação móvel"
+        aria-hidden={!isMobileMenuOpen}
+      >
+        <div className="navbar-mobile-drawer__header">
+          <span className="navbar-mobile-drawer__title">Menu</span>
+          <button
+            type="button"
+            className="navbar-mobile-drawer__close"
+            onClick={() => setIsMobileMenuOpen(false)}
+            aria-label="Fechar menu"
+          >
+            <i className="fa-solid fa-xmark" aria-hidden="true"></i>
+          </button>
+        </div>
+
+        <nav className="navbar-mobile-drawer__links" aria-label="Links do menu móvel">
+          {renderNavLinks("nav-link nav-link--drawer")}
         </nav>
-    );
+
+        <div className="navbar-mobile-drawer__actions">
+          {permissions.isAdmin() && (
+            <Link
+              to="/app/editor/articles"
+              className="editor-btn editor-btn--drawer"
+              aria-label="Abrir editor de artigos"
+            >
+              <i className="fa-solid fa-pen-to-square" aria-hidden="true"></i>
+              <span>Editor</span>
+            </Link>
+          )}
+
+          <Link
+            to="/fazendas/novo"
+            className="create-farm-btn create-farm-btn--drawer"
+            aria-label="Cadastrar nova fazenda"
+          >
+            <i className="fa-solid fa-plus" aria-hidden="true"></i>
+            <span>Cadastrar Fazenda</span>
+          </Link>
+
+          <Link
+            to="/sobre"
+            className="nav-link nav-link--drawer nav-link--secondary"
+            aria-label="Saiba mais sobre o CapriGestor"
+          >
+            <i className="fa-solid fa-circle-info" aria-hidden="true"></i>
+            <span>Sobre</span>
+          </Link>
+
+          {tokenPayload ? (
+            <button
+              type="button"
+              className="navbar-mobile-drawer__logout"
+              onClick={handleLogout}
+              aria-label="Sair da aplicação"
+            >
+              <i className="fa-solid fa-sign-out-alt" aria-hidden="true"></i>
+              <span>Sair</span>
+            </button>
+          ) : (
+            <Link to="/login" className="login-btn login-btn--drawer" aria-label="Entrar na aplicação">
+              Entrar
+            </Link>
+          )}
+        </div>
+      </aside>
+    </>
+  );
 }

--- a/src/Components/navigation/navbar.css
+++ b/src/Components/navigation/navbar.css
@@ -19,6 +19,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
+    gap: 1rem;
 }
 
 .navbar-brand {
@@ -27,6 +28,7 @@
     gap: 12px;
     text-decoration: none;
     color: var(--gf-color-secondary);
+    min-width: 0;
 }
 
 .brand-logo-wrapper {
@@ -41,6 +43,7 @@
     border: 2px solid var(--gf-color-primary);
     box-shadow: 0 2px 4px rgba(0,0,0,0.1);
     transition: transform 0.3s ease;
+    flex-shrink: 0;
 }
 
 .brand-logo-wrapper:hover {
@@ -66,26 +69,29 @@
 .navbar-links {
     display: flex;
     gap: 8px;
+    align-items: center;
 }
 
-.navbar-links .nav-link {
+.nav-link {
     padding: 8px 16px;
     border-radius: 12px;
     text-decoration: none;
     color: var(--gf-color-text-secondary);
     font-weight: 600;
-    display: flex;
+    display: inline-flex;
     align-items: center;
     gap: 8px;
     transition: all var(--gf-transition-normal);
 }
 
-.navbar-links .nav-link:hover {
+.nav-link:hover,
+.nav-link:focus-visible {
     background: rgba(16, 185, 129, 0.05);
     color: var(--gf-color-primary);
+    outline: none;
 }
 
-.navbar-links .nav-link.active {
+.nav-link.active {
     background: rgba(16, 185, 129, 0.1);
     color: var(--gf-color-primary);
 }
@@ -103,29 +109,21 @@
     text-decoration: none;
     border-radius: 100px;
     font-weight: 600;
-    display: flex;
+    display: inline-flex;
     align-items: center;
     gap: 8px;
     transition: all var(--gf-transition-normal);
     border: 1px solid var(--gf-color-border-light);
 }
 
-.editor-btn:hover {
+.editor-btn:hover,
+.editor-btn:focus-visible {
     background: white;
     color: var(--gf-color-primary);
     border-color: var(--gf-color-primary);
     transform: translateY(-2px);
-    box-shadow: var(--gf-shadow-sm);
-}
-
-@media (max-width: 1024px) {
-    .editor-label {
-        display: none;
-    }
-    .editor-btn {
-        padding: 10px;
-        border-radius: 50%;
-    }
+    box-shadow: 0 4px 12px rgba(15, 23, 42, 0.08);
+    outline: none;
 }
 
 .create-farm-btn {
@@ -135,17 +133,19 @@
     text-decoration: none;
     border-radius: 12px;
     font-weight: 700;
-    display: flex;
+    display: inline-flex;
     align-items: center;
     gap: 8px;
     transition: all var(--gf-transition-normal);
-    box-shadow: var(--gf-shadow-sm);
+    box-shadow: 0 4px 12px rgba(16, 185, 129, 0.2);
 }
 
-.create-farm-btn:hover {
+.create-farm-btn:hover,
+.create-farm-btn:focus-visible {
     transform: translateY(-2px);
-    box-shadow: var(--gf-shadow-md);
-    filter: brightness(1.1);
+    box-shadow: 0 8px 18px rgba(16, 185, 129, 0.25);
+    filter: brightness(1.05);
+    outline: none;
 }
 
 .user-profile-group {
@@ -162,7 +162,7 @@
     background: white;
     border-radius: 100px;
     border: 1px solid var(--gf-glass-border);
-    box-shadow: var(--gf-shadow-sm);
+    box-shadow: 0 2px 8px rgba(15, 23, 42, 0.08);
 }
 
 .user-info-text {
@@ -194,24 +194,32 @@
     font-weight: 700;
 }
 
-.navbar-logout-btn {
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
+.navbar-logout-btn,
+.navbar-mobile-drawer__logout {
     border: 1px solid var(--gf-color-border-light);
     background: white;
     color: #e74c3c;
     cursor: pointer;
-    display: flex;
+    display: inline-flex;
     align-items: center;
     justify-content: center;
     transition: all var(--gf-transition-normal);
 }
 
-.navbar-logout-btn:hover {
+.navbar-logout-btn {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+}
+
+.navbar-logout-btn:hover,
+.navbar-logout-btn:focus-visible,
+.navbar-mobile-drawer__logout:hover,
+.navbar-mobile-drawer__logout:focus-visible {
     background: #fff5f5;
-    transform: scale(1.05);
-    box-shadow: var(--gf-shadow-sm);
+    transform: scale(1.03);
+    box-shadow: 0 4px 12px rgba(220, 38, 38, 0.12);
+    outline: none;
 }
 
 .login-btn {
@@ -224,19 +232,134 @@
     transition: all var(--gf-transition-normal);
 }
 
-.login-btn:hover {
+.login-btn:hover,
+.login-btn:focus-visible {
     transform: translateY(-2px);
-    box-shadow: var(--gf-shadow-md);
-    filter: brightness(1.1);
+    box-shadow: 0 8px 18px rgba(15, 23, 42, 0.18);
+    filter: brightness(1.05);
+    outline: none;
+}
+
+.navbar-menu-toggle {
+    display: none;
+    width: 44px;
+    height: 44px;
+    border-radius: 12px;
+    border: 1px solid var(--gf-color-border-light);
+    background: white;
+    color: var(--gf-color-secondary);
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    font-size: 1.1rem;
+}
+
+.navbar-mobile-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.42);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease;
+    z-index: 1001;
+}
+
+.navbar-mobile-backdrop.is-open {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.navbar-mobile-drawer {
+    position: fixed;
+    top: 0;
+    right: 0;
+    width: min(360px, 92vw);
+    height: 100vh;
+    background: #ffffff;
+    box-shadow: -16px 0 40px rgba(15, 23, 42, 0.16);
+    transform: translateX(100%);
+    transition: transform 0.25s ease;
+    z-index: 1002;
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.navbar-mobile-drawer.is-open {
+    transform: translateX(0);
+}
+
+.navbar-mobile-drawer__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid var(--gf-color-border-light);
+}
+
+.navbar-mobile-drawer__title {
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: var(--gf-color-secondary);
+}
+
+.navbar-mobile-drawer__close {
+    width: 40px;
+    height: 40px;
+    border: 1px solid var(--gf-color-border-light);
+    border-radius: 12px;
+    background: white;
+    color: var(--gf-color-secondary);
+}
+
+.navbar-mobile-drawer__links,
+.navbar-mobile-drawer__actions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.nav-link--drawer,
+.editor-btn--drawer,
+.create-farm-btn--drawer,
+.login-btn--drawer,
+.navbar-mobile-drawer__logout {
+    width: 100%;
+    justify-content: flex-start;
+}
+
+.nav-link--drawer {
+    padding: 0.9rem 1rem;
+    border: 1px solid var(--gf-color-border-light);
+    background: #f8fafc;
+}
+
+.nav-link--secondary {
+    color: var(--gf-color-secondary);
+}
+
+.navbar-mobile-drawer__logout {
+    padding: 0.9rem 1rem;
+    border-radius: 12px;
+    gap: 0.5rem;
 }
 
 @media (max-width: 1024px) {
-    .editor-btn span {
+    .editor-label,
+    .create-farm-btn span,
+    .user-info-text {
         display: none;
     }
 
-    .create-farm-btn span {
-        display: none;
+    .editor-btn {
+        padding: 10px;
+        border-radius: 50%;
+    }
+
+    .create-farm-btn {
+        padding: 10px;
+        border-radius: 12px;
     }
 }
 
@@ -245,43 +368,18 @@
         padding: 0 1rem;
     }
 
-    .brand-name {
+    .brand-name,
+    .navbar-links,
+    .navbar-actions {
         display: none;
     }
 
     .brand-logo-wrapper {
-        width: 35px;
-        height: 35px;
+        width: 38px;
+        height: 38px;
     }
 
-    .user-info-text {
-        display: none;
-    }
-
-    .navbar-links {
-        gap: 4px;
-    }
-
-    .navbar-links .nav-link {
-        padding: 8px 12px;
-        font-size: 0.85rem;
-    }
-}
-
-@media (max-width: 480px) {
-    .navbar-links {
-        gap: 2px;
-    }
-
-    .navbar-links .nav-link {
-        padding: 6px 8px;
-    }
-
-    .navbar-links .nav-link i {
-        font-size: 1.1rem;
-    }
-
-    .navbar-links .nav-link span {
-        display: none;
+    .navbar-menu-toggle {
+        display: inline-flex;
     }
 }

--- a/src/Components/pages-headers/PageHeader.tsx
+++ b/src/Components/pages-headers/PageHeader.tsx
@@ -23,8 +23,14 @@ export default function PageHeader({
     <div className="page-header">
       <div className="header-main-content">
         {showBackButton && backButtonUrl && (
-          <Link to={backButtonUrl} className="back-button">
-            &larr;
+          <Link
+            to={backButtonUrl}
+            className="back-button"
+            aria-label="Voltar para a página anterior"
+            title="Voltar para a página anterior"
+          >
+            <span aria-hidden="true">&larr;</span>
+            <span>Voltar</span>
           </Link>
         )}
         <div className="header-text">

--- a/src/Components/pages-headers/pageheader.css
+++ b/src/Components/pages-headers/pageheader.css
@@ -2,5 +2,51 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 1rem;
   margin-bottom: 1.5rem;
+}
+
+.header-main-content {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.back-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.5rem 0.85rem;
+  border-radius: 999px;
+  text-decoration: none;
+  color: var(--gf-color-secondary, #0f172a);
+  background: rgba(15, 23, 42, 0.05);
+  font-weight: 600;
+}
+
+.back-button:hover,
+.back-button:focus-visible {
+  background: rgba(16, 185, 129, 0.1);
+  color: var(--gf-color-primary, #10b981);
+  outline: none;
+}
+
+.header-title {
+  margin: 0;
+}
+
+.header-description {
+  margin: 0.25rem 0 0;
+  color: var(--gf-color-text-secondary, #64748b);
+}
+
+@media (max-width: 768px) {
+  .page-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .header-actions {
+    width: 100%;
+  }
 }

--- a/src/Components/searchs/SearchInputBox.tsx
+++ b/src/Components/searchs/SearchInputBox.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useId, useState } from "react";
 import "../../index.css"; // garante acesso as classes globais
 import "./searchinput.css";
 
@@ -9,6 +9,8 @@ interface Props {
 
 export default function SearchInputBox({ onSearch, placeholder }: Props) {
   const [term, setTerm] = useState("");
+  const inputId = useId();
+  const accessibleLabel = placeholder || "Buscar";
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -17,10 +19,15 @@ export default function SearchInputBox({ onSearch, placeholder }: Props) {
 
   return (
     <form className="search-container-box" onSubmit={handleSubmit}>
+      <label className="visually-hidden" htmlFor={inputId}>
+        {accessibleLabel}
+      </label>
       <div className="search-box">
         <input
+          id={inputId}
           type="text"
           placeholder={placeholder || "Buscar..."}
+          aria-label={accessibleLabel}
           value={term}
           onChange={(e) => setTerm(e.target.value)}
         />

--- a/src/Pages/about/AboutPage.tsx
+++ b/src/Pages/about/AboutPage.tsx
@@ -1,0 +1,53 @@
+import { Link } from "react-router-dom";
+
+export default function AboutPage() {
+  return (
+    <section className="card border-0 shadow-sm">
+      <div className="card-body p-4 p-lg-5">
+        <span className="badge text-bg-light mb-3">Sobre o CapriGestor</span>
+        <h1 className="h2 mb-3">Gestão caprina com contexto claro e operação prática</h1>
+        <p className="text-muted mb-4">
+          O CapriGestor organiza a gestão da fazenda e o manejo individual de cada
+          animal em fluxos separados, para reduzir ruído e facilitar a tomada de
+          decisão no dia a dia.
+        </p>
+
+        <div className="row g-3 mb-4">
+          <div className="col-12 col-lg-4">
+            <div className="rounded-4 border h-100 p-3">
+              <h2 className="h5">Fazenda</h2>
+              <p className="text-muted mb-0">
+                Estoque, alertas, agenda sanitária e visão geral do rebanho.
+              </p>
+            </div>
+          </div>
+          <div className="col-12 col-lg-4">
+            <div className="rounded-4 border h-100 p-3">
+              <h2 className="h5">Animal</h2>
+              <p className="text-muted mb-0">
+                Sanidade, reprodução, lactações, produção de leite e histórico.
+              </p>
+            </div>
+          </div>
+          <div className="col-12 col-lg-4">
+            <div className="rounded-4 border h-100 p-3">
+              <h2 className="h5">Operação</h2>
+              <p className="text-muted mb-0">
+                Navegação direta, contratos estáveis e ações práticas para uso real.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="d-flex flex-wrap gap-2">
+          <Link to="/fazendas" className="btn btn-primary">
+            Ver fazendas
+          </Link>
+          <Link to="/signup" className="btn btn-outline-secondary">
+            Criar conta
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/Pages/dashboard/Dashboard.tsx
+++ b/src/Pages/dashboard/Dashboard.tsx
@@ -25,6 +25,7 @@ import {
   buildFarmDashboardPath,
   buildFarmGoatsPath,
 } from "../../utils/appRoutes";
+import { saveLastGoatContext } from "../../utils/lastGoatContext";
 
 import "../../index.css";
 import "./animalDashboard.css";
@@ -288,6 +289,20 @@ export default function AnimalDashboard() {
       }`
     : "Selecione um animal para visualizar histórico, manejo e ações individuais.";
   const canShowFarmShortcut = Boolean(resolvedFarmId);
+
+  useEffect(() => {
+    if (!resolvedFarmId || !goat) {
+      return;
+    }
+
+    const goatRouteId = goat.id ?? goat.registrationNumber;
+
+    if (!goatRouteId) {
+      return;
+    }
+
+    saveLastGoatContext(resolvedFarmId, goatRouteId);
+  }, [goat, resolvedFarmId]);
 
   if (import.meta.env.DEV) {
     console.log("Animal detail render:", {

--- a/src/Pages/dashboard/LegacyDashboardRedirect.tsx
+++ b/src/Pages/dashboard/LegacyDashboardRedirect.tsx
@@ -1,0 +1,14 @@
+import { Navigate, useSearchParams } from "react-router-dom";
+import { resolveLegacyDashboardPath } from "../../utils/lastGoatContext";
+
+export default function LegacyDashboardRedirect() {
+  const [searchParams] = useSearchParams();
+
+  const targetPath = resolveLegacyDashboardPath({
+    farmId: searchParams.get("farmId"),
+    goatId: searchParams.get("goatId"),
+    registrationNumber: searchParams.get("registrationNumber"),
+  });
+
+  return <Navigate to={targetPath} replace />;
+}

--- a/src/Pages/home/Home.test.tsx
+++ b/src/Pages/home/Home.test.tsx
@@ -1,0 +1,28 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import Home from "./Home";
+
+vi.mock("../../api/GoatFarmAPI/goatFarm", () => ({
+  getAllFarms: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("../../Components/home/FarmsCarousel", () => ({
+  default: () => <div>FarmsCarousel</div>,
+}));
+
+vi.mock("../../Components/home/BlogSection", () => ({
+  default: () => <div>BlogSection</div>,
+}));
+
+describe("Home", () => {
+  it("keeps the secondary CTA pointing to the about page", () => {
+    const html = renderToStaticMarkup(
+      <MemoryRouter>
+        <Home />
+      </MemoryRouter>
+    );
+
+    expect(html).toContain('href="/sobre"');
+  });
+});

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,12 +5,14 @@ import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import Root from "./routes/Root/root";
 // PUBLIC
 import Home from "./Pages/home/Home";
+import AboutPage from "./Pages/about/AboutPage";
 import BlogListPage from "./Pages/blog/BlogListPage";
 import BlogArticlePage from "./Pages/blog/BlogArticlePage";
 import ListFarms from "./Pages/goatfarms/ListFarms";
 import GoatListPage from "./Pages/goat-list-page/GoatListPage";
 import AnimalDashboard from "./Pages/dashboard/Dashboard";
 import FarmDashboardPage from "./Pages/dashboard/FarmDashboardPage";
+import LegacyDashboardRedirect from "./Pages/dashboard/LegacyDashboardRedirect";
 // PRIVATE
 import FarmCreatePage from "./Pages/farms-creted/FarmCreatePage";
 import FarmEditPage from "./Pages/farms-edited/FarmEditPage";
@@ -64,6 +66,7 @@ const router = createBrowserRouter([
       { index: true, element: <Home /> },
 
       // Rotas Públicas
+      { path: "sobre", element: <AboutPage /> },
       { path: "fazendas", element: <ListFarms /> },
       { path: "goatfarms", element: <ListFarms /> },
       { path: "cabras", element: <GoatListPage /> },
@@ -77,7 +80,7 @@ const router = createBrowserRouter([
           </PrivateRoute>
         )
       },
-      { path: "dashboard", element: <AnimalDashboard /> },
+      { path: "dashboard", element: <LegacyDashboardRedirect /> },
       {
         path: "app/goatfarms/:farmId/dashboard",
         element: (

--- a/src/utils/lastGoatContext.test.ts
+++ b/src/utils/lastGoatContext.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  loadLastGoatContext,
+  resolveLegacyDashboardPath,
+  saveLastGoatContext,
+} from "./lastGoatContext";
+
+type MemoryStorage = {
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+  clear: () => void;
+};
+
+const createMemoryStorage = (): MemoryStorage => {
+  const store = new Map<string, string>();
+
+  return {
+    getItem: (key) => store.get(key) ?? null,
+    setItem: (key, value) => {
+      store.set(key, value);
+    },
+    clear: () => {
+      store.clear();
+    },
+  };
+};
+
+describe("lastGoatContext", () => {
+  beforeEach(() => {
+    const localStorage = createMemoryStorage();
+    const sessionStorage = createMemoryStorage();
+
+    Object.defineProperty(globalThis, "window", {
+      value: {
+        localStorage,
+        sessionStorage,
+      },
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    Reflect.deleteProperty(globalThis, "window");
+  });
+
+  it("stores and restores the last animal context", () => {
+    saveLastGoatContext(7, 99);
+
+    expect(loadLastGoatContext()).toEqual({
+      farmId: "7",
+      goatId: "99",
+    });
+  });
+
+  it("redirects the legacy dashboard to the explicit canonical context when params exist", () => {
+    expect(
+      resolveLegacyDashboardPath({
+        farmId: "12",
+        goatId: "88",
+      })
+    ).toBe("/app/goatfarms/12/goats/88");
+  });
+
+  it("redirects the legacy dashboard to the last known animal when stored context exists", () => {
+    saveLastGoatContext(5, 21);
+
+    expect(resolveLegacyDashboardPath()).toBe("/app/goatfarms/5/goats/21");
+  });
+
+  it("falls back to the farm list when no context is available", () => {
+    expect(resolveLegacyDashboardPath()).toBe("/goatfarms");
+  });
+});

--- a/src/utils/lastGoatContext.ts
+++ b/src/utils/lastGoatContext.ts
@@ -1,0 +1,87 @@
+import { buildGoatDetailPath } from "./appRoutes";
+
+const STORAGE_KEY = "caprigestor:last-goat-context";
+
+type LastGoatContext = {
+  farmId: string;
+  goatId: string;
+};
+
+type LegacyDashboardOptions = {
+  farmId?: string | null;
+  goatId?: string | null;
+  registrationNumber?: string | null;
+};
+
+const isValidContext = (value: unknown): value is LastGoatContext => {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.farmId === "string" &&
+    candidate.farmId.trim().length > 0 &&
+    typeof candidate.goatId === "string" &&
+    candidate.goatId.trim().length > 0
+  );
+};
+
+const readStoredContext = (): LastGoatContext | null => {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  const raw =
+    window.sessionStorage.getItem(STORAGE_KEY) ??
+    window.localStorage.getItem(STORAGE_KEY);
+
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    return isValidContext(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+};
+
+export const saveLastGoatContext = (
+  farmId: string | number,
+  goatId: string | number
+): void => {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  const value = JSON.stringify({
+    farmId: String(farmId),
+    goatId: String(goatId),
+  });
+
+  window.sessionStorage.setItem(STORAGE_KEY, value);
+  window.localStorage.setItem(STORAGE_KEY, value);
+};
+
+export const loadLastGoatContext = (): LastGoatContext | null => readStoredContext();
+
+export const resolveLegacyDashboardPath = (
+  options: LegacyDashboardOptions = {}
+): string => {
+  const farmId = options.farmId?.trim();
+  const goatId = options.goatId?.trim() || options.registrationNumber?.trim();
+
+  if (farmId && goatId) {
+    return buildGoatDetailPath(farmId, goatId);
+  }
+
+  const stored = readStoredContext();
+
+  if (stored) {
+    return buildGoatDetailPath(stored.farmId, stored.goatId);
+  }
+
+  return "/goatfarms";
+};


### PR DESCRIPTION
## Summary
- add a safe /sobre entry and keep /dashboard as a compatibility redirect
- implement an accessible mobile navigation drawer with labels and keyboard support
- fix goat farm card interactions, remove dead animal actions, and add basic a11y labels
- add regression tests for navigation and accessibility

## Validation
- npm test
- npm run build
- npm run lint
- npm run test:e2e