### PR TITLE
Goat: herd summary indicators and edit preload fixes

### DIFF
--- a/src/Components/GoatCard-to-list/goatCard.tsx
+++ b/src/Components/GoatCard-to-list/goatCard.tsx
@@ -44,10 +44,11 @@ export default function GoatCard({ goat, onEdit, farmOwnerId }: Props) {
 
   // Determina classe de cor do status
   const getStatusClass = (status: string) => {
-    const s = status.toLowerCase();
-    if (s === 'ativo') return 'ativo';
-    if (s === 'vendido') return 'vendido';
-    if (s === 'falecido' || s === 'morto') return 'falecido';
+    const s = String(status ?? '').trim().toLowerCase();
+    if (s === 'ativo' || s === 'active') return 'ativo';
+    if (s === 'inativo' || s === 'inactive') return 'inativo';
+    if (s === 'vendido' || s === 'sold') return 'vendido';
+    if (s === 'falecido' || s === 'morto' || s === 'deceased') return 'falecido';
     return '';
   };
 
@@ -68,7 +69,7 @@ export default function GoatCard({ goat, onEdit, farmOwnerId }: Props) {
             <h3 className="goat-name">{goat.name}</h3>
             <span className="goat-register">Reg: {goat.registrationNumber || "N/A"}</span>
           </div>
-          <span className={`status-badge ${getStatusClass(displayedStatus)}`}>
+          <span className={`status-badge ${getStatusClass(String(goat.status ?? displayedStatus))}`}>
             {displayedStatus}
           </span>
         </div>

--- a/src/Components/GoatCard-to-list/goatCardList.css
+++ b/src/Components/GoatCard-to-list/goatCardList.css
@@ -76,18 +76,23 @@
 }
 
 .status-badge.ativo {
-  background-color: #dcfce7;
-  color: #166534;
+  background-color: rgba(16, 185, 129, 0.14);
+  color: #10b981;
+}
+
+.status-badge.inativo {
+  background-color: rgba(245, 158, 11, 0.14);
+  color: #f59e0b;
 }
 
 .status-badge.vendido {
-  background-color: #fee2e2;
-  color: #991b1b;
+  background-color: rgba(244, 63, 94, 0.14);
+  color: #f43f5e;
 }
 
 .status-badge.falecido {
-  background-color: #f1f5f9;
-  color: #475569;
+  background-color: rgba(100, 116, 139, 0.14);
+  color: #64748b;
 }
 
 /* Info Grid */

--- a/src/Components/dash-animal-info/GoatDashboardSummary.css
+++ b/src/Components/dash-animal-info/GoatDashboardSummary.css
@@ -1,8 +1,8 @@
 .goat-summary {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  padding: 1.1rem 1.15rem;
+  gap: 0.85rem;
+  padding: 0.95rem 1rem;
   border-radius: 1.15rem;
   background: linear-gradient(135deg, #ffffff 0%, #f8fafc 100%);
   border: 1px solid #dbe4ee;
@@ -18,7 +18,7 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
-  gap: 0.45rem 1rem;
+  gap: 0.35rem 0.85rem;
   align-items: end;
 }
 
@@ -34,28 +34,28 @@
 
 .goat-summary__headline {
   color: #0f172a;
-  font-size: 1rem;
+  font-size: 0.96rem;
   font-weight: 800;
 }
 
 .goat-summary__subheadline {
   margin: 0;
   color: #475569;
-  font-size: 0.92rem;
+  font-size: 0.88rem;
   font-weight: 600;
 }
 
 .goat-summary__grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(112px, 1fr));
-  gap: 0.75rem;
+  gap: 0.65rem;
 }
 
 .goat-summary__chip {
   display: flex;
   flex-direction: column;
   gap: 0.28rem;
-  padding: 0.78rem 0.86rem;
+  padding: 0.68rem 0.78rem;
   border-radius: 0.95rem;
   background: #f8fafc;
   border: 1px solid #e2e8f0;
@@ -91,7 +91,7 @@
 
 .goat-summary__value {
   color: #0f172a;
-  font-size: 1.5rem;
+  font-size: 1.35rem;
   line-height: 1;
   font-weight: 800;
 }
@@ -99,14 +99,14 @@
 .goat-summary__panels {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 0.9rem;
+  gap: 0.75rem;
 }
 
 .goat-summary__panel {
   display: flex;
   flex-direction: column;
-  gap: 0.85rem;
-  padding: 1rem;
+  gap: 0.7rem;
+  padding: 0.9rem;
   border-radius: 1rem;
   background: #fff;
   border: 1px solid #e2e8f0;
@@ -119,14 +119,14 @@
 .goat-summary__panel-header h3 {
   margin: 0;
   color: #0f172a;
-  font-size: 1rem;
+  font-size: 0.95rem;
   font-weight: 800;
 }
 
 .goat-summary__panel-header p {
   margin: 0.25rem 0 0;
   color: #64748b;
-  font-size: 0.9rem;
+  font-size: 0.86rem;
   line-height: 1.45;
 }
 
@@ -135,7 +135,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  min-height: 220px;
+  min-height: 200px;
 }
 
 .goat-summary__chart-center {
@@ -171,7 +171,7 @@
   margin: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.55rem;
+  gap: 0.45rem;
 }
 
 .goat-summary__legend-item {

--- a/src/Components/dash-animal-info/GoatDashboardSummary.css
+++ b/src/Components/dash-animal-info/GoatDashboardSummary.css
@@ -1,23 +1,30 @@
-﻿.goat-summary {
+.goat-summary {
   display: flex;
   flex-direction: column;
-  gap: 0.9rem;
-  padding: 1rem 1.1rem;
-  border-radius: 1rem;
+  gap: 1rem;
+  padding: 1.1rem 1.15rem;
+  border-radius: 1.15rem;
   background: linear-gradient(135deg, #ffffff 0%, #f8fafc 100%);
   border: 1px solid #dbe4ee;
-  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.05);
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.06);
+}
+
+.goat-summary--loading,
+.goat-summary--error {
+  align-items: flex-start;
 }
 
 .goat-summary__header {
   display: flex;
   flex-wrap: wrap;
-  align-items: baseline;
   justify-content: space-between;
-  gap: 0.4rem 1rem;
+  gap: 0.45rem 1rem;
+  align-items: end;
 }
 
 .goat-summary__eyebrow {
+  display: block;
+  margin-bottom: 0.18rem;
   font-size: 0.76rem;
   font-weight: 700;
   text-transform: uppercase;
@@ -26,50 +33,57 @@
 }
 
 .goat-summary__headline {
-  color: #334155;
-  font-size: 0.95rem;
-  font-weight: 700;
+  color: #0f172a;
+  font-size: 1rem;
+  font-weight: 800;
+}
+
+.goat-summary__subheadline {
+  margin: 0;
+  color: #475569;
+  font-size: 0.92rem;
+  font-weight: 600;
 }
 
 .goat-summary__grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
-  gap: 0.7rem;
+  grid-template-columns: repeat(auto-fit, minmax(112px, 1fr));
+  gap: 0.75rem;
 }
 
 .goat-summary__chip {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
-  padding: 0.7rem 0.8rem;
-  border-radius: 0.9rem;
+  gap: 0.28rem;
+  padding: 0.78rem 0.86rem;
+  border-radius: 0.95rem;
   background: #f8fafc;
   border: 1px solid #e2e8f0;
 }
 
 .goat-summary__chip--success {
   background: rgba(16, 185, 129, 0.08);
-  border-color: rgba(16, 185, 129, 0.18);
+  border-color: rgba(16, 185, 129, 0.2);
 }
 
 .goat-summary__chip--warning {
   background: rgba(245, 158, 11, 0.08);
-  border-color: rgba(245, 158, 11, 0.18);
+  border-color: rgba(245, 158, 11, 0.2);
 }
 
 .goat-summary__chip--danger {
   background: rgba(244, 63, 94, 0.08);
-  border-color: rgba(244, 63, 94, 0.18);
+  border-color: rgba(244, 63, 94, 0.2);
 }
 
 .goat-summary__chip--neutral {
   background: rgba(148, 163, 184, 0.1);
-  border-color: rgba(148, 163, 184, 0.2);
+  border-color: rgba(148, 163, 184, 0.22);
 }
 
 .goat-summary__label {
   color: #64748b;
-  font-size: 0.76rem;
+  font-size: 0.75rem;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -77,18 +91,137 @@
 
 .goat-summary__value {
   color: #0f172a;
-  font-size: 1.45rem;
+  font-size: 1.5rem;
   line-height: 1;
   font-weight: 800;
 }
 
+.goat-summary__panels {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.9rem;
+}
+
+.goat-summary__panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 1rem;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+}
+
+.goat-summary__panel--empty {
+  justify-content: space-between;
+}
+
+.goat-summary__panel-header h3 {
+  margin: 0;
+  color: #0f172a;
+  font-size: 1rem;
+  font-weight: 800;
+}
+
+.goat-summary__panel-header p {
+  margin: 0.25rem 0 0;
+  color: #64748b;
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
+.goat-summary__chart-shell {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 220px;
+}
+
+.goat-summary__chart-center {
+  position: absolute;
+  inset: 50% auto auto 50%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.12rem;
+  text-align: center;
+  pointer-events: none;
+}
+
+.goat-summary__chart-center strong {
+  color: #0f172a;
+  font-size: 0.95rem;
+  font-weight: 800;
+  line-height: 1.2;
+}
+
+.goat-summary__chart-center span {
+  color: #64748b;
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.goat-summary__legend {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
+.goat-summary__legend-item {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.55rem;
+}
+
+.goat-summary__legend-dot {
+  width: 0.7rem;
+  height: 0.7rem;
+  border-radius: 999px;
+}
+
+.goat-summary__legend-label {
+  color: #334155;
+  font-size: 0.92rem;
+}
+
+.goat-summary__legend-value {
+  color: #0f172a;
+  font-size: 0.95rem;
+}
+
+.goat-summary__error-copy,
+.goat-summary__empty-copy {
+  margin: 0;
+  color: #475569;
+  font-size: 0.92rem;
+  line-height: 1.5;
+}
+
+@media (max-width: 1120px) {
+  .goat-summary__panels {
+    grid-template-columns: 1fr;
+  }
+}
+
 @media (max-width: 768px) {
   .goat-summary {
-    padding: 0.9rem;
+    padding: 1rem;
   }
 
   .goat-summary__grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .goat-summary__chart-shell {
+    min-height: 200px;
   }
 }
 

--- a/src/Components/dash-animal-info/GoatDashboardSummary.test.tsx
+++ b/src/Components/dash-animal-info/GoatDashboardSummary.test.tsx
@@ -1,0 +1,49 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import GoatDashboardSummary from "./GoatDashboardSummary";
+
+describe("GoatDashboardSummary", () => {
+  it("renders the herd totals and breed breakdown from the real summary", () => {
+    const html = renderToStaticMarkup(
+      <GoatDashboardSummary
+        summary={{
+          total: 128,
+          males: 19,
+          females: 109,
+          active: 117,
+          inactive: 4,
+          sold: 5,
+          deceased: 2,
+          breeds: [
+            { breed: "Saanen", count: 48 },
+            { breed: "Boer", count: 32 },
+            { breed: "Parda Alpina", count: 18 },
+          ],
+        }}
+        visibleCount={12}
+      />
+    );
+
+    expect(html).toContain("128 animais no rebanho");
+    expect(html).toContain("12 animais exibidos nesta tela");
+    expect(html).toContain("Distribuição por sexo");
+    expect(html).toContain("Situação do rebanho");
+    expect(html).toContain("Raças cadastradas");
+    expect(html).toContain("Saanen");
+  });
+
+  it("keeps a compact retry state when the summary fails", () => {
+    const html = renderToStaticMarkup(
+      <GoatDashboardSummary
+        summary={null}
+        visibleCount={0}
+        error="Falha ao carregar o resumo."
+        onRetry={() => undefined}
+      />
+    );
+
+    expect(html).toContain("Não foi possível carregar os indicadores da fazenda.");
+    expect(html).toContain("Falha ao carregar o resumo.");
+    expect(html).toContain(">Tentar novamente<");
+  });
+});

--- a/src/Components/dash-animal-info/GoatDashboardSummary.tsx
+++ b/src/Components/dash-animal-info/GoatDashboardSummary.tsx
@@ -1,4 +1,4 @@
-import { Pie, PieChart, Cell } from "recharts";
+import { Cell, Pie, PieChart } from "recharts";
 import type { GoatHerdSummaryDTO } from "../../Models/GoatHerdSummaryDTO";
 import { Button } from "../ui";
 import "./GoatDashboardSummary.css";
@@ -74,7 +74,9 @@ function ChartPanel({
           <h3>{title}</h3>
           <p>{subtitle}</p>
         </header>
-        <p className="goat-summary__empty-copy">Ainda não há dados suficientes para exibir este gráfico.</p>
+        <p className="goat-summary__empty-copy">
+          Ainda não há dados suficientes para exibir este gráfico.
+        </p>
       </article>
     );
   }
@@ -92,15 +94,15 @@ function ChartPanel({
           <span>rebanho</span>
         </div>
 
-        <PieChart width={220} height={220}>
+        <PieChart width={210} height={210}>
           <Pie
             data={data}
             dataKey="value"
             nameKey="label"
             cx="50%"
             cy="50%"
-            innerRadius={58}
-            outerRadius={86}
+            innerRadius={56}
+            outerRadius={82}
             paddingAngle={2}
             stroke="none"
           >
@@ -114,7 +116,11 @@ function ChartPanel({
       <ul className="goat-summary__legend" aria-label={`Legenda de ${title.toLowerCase()}`}>
         {data.map((entry) => (
           <li key={entry.label} className="goat-summary__legend-item">
-            <span className="goat-summary__legend-dot" style={{ backgroundColor: entry.color }} aria-hidden="true" />
+            <span
+              className="goat-summary__legend-dot"
+              style={{ backgroundColor: entry.color }}
+              aria-hidden="true"
+            />
             <span className="goat-summary__legend-label">{entry.label}</span>
             <strong className="goat-summary__legend-value">{entry.value}</strong>
           </li>
@@ -136,7 +142,9 @@ export default function GoatDashboardSummary({
       <section className="goat-summary goat-summary--loading" aria-label="Resumo do rebanho">
         <header className="goat-summary__header">
           <span className="goat-summary__eyebrow">Resumo do rebanho</span>
-          <strong className="goat-summary__headline">Carregando indicadores da fazenda...</strong>
+          <strong className="goat-summary__headline">
+            Carregando indicadores da fazenda...
+          </strong>
         </header>
       </section>
     );
@@ -147,7 +155,9 @@ export default function GoatDashboardSummary({
       <section className="goat-summary goat-summary--error" aria-label="Resumo do rebanho">
         <header className="goat-summary__header">
           <span className="goat-summary__eyebrow">Resumo do rebanho</span>
-          <strong className="goat-summary__headline">Não foi possível carregar os indicadores da fazenda.</strong>
+          <strong className="goat-summary__headline">
+            Não foi possível carregar os indicadores da fazenda.
+          </strong>
         </header>
         {error ? <p className="goat-summary__error-copy">{error}</p> : null}
         {onRetry ? (
@@ -188,15 +198,22 @@ export default function GoatDashboardSummary({
       <header className="goat-summary__header">
         <div>
           <span className="goat-summary__eyebrow">Resumo do rebanho</span>
-          <strong className="goat-summary__headline">{formatAnimalCount(summary.total)} no rebanho</strong>
+          <strong className="goat-summary__headline">
+            {formatAnimalCount(summary.total)} no rebanho
+          </strong>
         </div>
 
-        <p className="goat-summary__subheadline">{formatAnimalCount(visibleCount)} exibid{visibleCount === 1 ? "o" : "os"} nesta tela</p>
+        <p className="goat-summary__subheadline">
+          {formatAnimalCount(visibleCount)} exibid{visibleCount === 1 ? "o" : "os"} nesta tela
+        </p>
       </header>
 
       <div className="goat-summary__grid">
         {items.map((item) => (
-          <div key={item.label} className={`goat-summary__chip goat-summary__chip--${item.tone ?? "default"}`}>
+          <div
+            key={item.label}
+            className={`goat-summary__chip goat-summary__chip--${item.tone ?? "default"}`}
+          >
             <span className="goat-summary__label">{item.label}</span>
             <strong className="goat-summary__value">{item.value}</strong>
           </div>

--- a/src/Components/dash-animal-info/GoatDashboardSummary.tsx
+++ b/src/Components/dash-animal-info/GoatDashboardSummary.tsx
@@ -1,9 +1,14 @@
-﻿import "./GoatDashboardSummary.css";
-import type { GoatResponseDTO } from "../../Models/goatResponseDTO";
-import { GoatGenderEnum, GoatStatusEnum } from "../../types/goatEnums";
+import { Pie, PieChart, Cell } from "recharts";
+import type { GoatHerdSummaryDTO } from "../../Models/GoatHerdSummaryDTO";
+import { Button } from "../ui";
+import "./GoatDashboardSummary.css";
 
 interface Props {
-  goats: GoatResponseDTO[];
+  summary: GoatHerdSummaryDTO | null;
+  visibleCount: number;
+  loading?: boolean;
+  error?: string | null;
+  onRetry?: () => void;
 }
 
 interface SummaryItem {
@@ -12,69 +17,181 @@ interface SummaryItem {
   tone?: "success" | "warning" | "danger" | "neutral";
 }
 
-export default function GoatDashboardSummary({ goats }: Props) {
-  const total = goats.length;
+interface ChartDatum {
+  label: string;
+  value: number;
+  color: string;
+}
 
-  const males = goats.filter(
-    (g) =>
-      g.gender === GoatGenderEnum.MALE ||
-      g.gender === "MALE" ||
-      g.gender === "M" ||
-      g.gender === "Macho"
-  ).length;
+const SEX_COLORS = ["#2563eb", "#ec4899"];
+const STATUS_COLORS = ["#10b981", "#f59e0b", "#f43f5e", "#64748b"];
+const BREED_COLORS = ["#14b8a6", "#8b5cf6", "#f97316", "#22c55e", "#3b82f6", "#94a3b8"];
 
-  const females = goats.filter(
-    (g) =>
-      g.gender === GoatGenderEnum.FEMALE ||
-      g.gender === "FEMALE" ||
-      g.gender === "F" ||
-      g.gender === "Fêmea"
-  ).length;
+function formatAnimalCount(value: number) {
+  return `${value} ${value === 1 ? "animal" : "animais"}`;
+}
 
-  const active = goats.filter(
-    (g) =>
-      g.status === GoatStatusEnum.ATIVO ||
-      g.status === "ATIVO" ||
-      g.status === "Ativo"
-  ).length;
+function buildBreedChartData(summary: GoatHerdSummaryDTO): ChartDatum[] {
+  const ranked = [...summary.breeds]
+    .filter((entry) => entry.count > 0)
+    .sort((left, right) => right.count - left.count || left.breed.localeCompare(right.breed))
+    .slice(0, 5)
+    .map((entry, index) => ({
+      label: entry.breed,
+      value: entry.count,
+      color: BREED_COLORS[index % BREED_COLORS.length],
+    }));
 
-  const sold = goats.filter(
-    (g) =>
-      g.status === GoatStatusEnum.SOLD ||
-      g.status === "SOLD" ||
-      g.status === "Vendido"
-  ).length;
+  const topCount = ranked.reduce((accumulator, entry) => accumulator + entry.value, 0);
+  const otherCount = Math.max(summary.total - topCount, 0);
 
-  const deceased = goats.filter(
-    (g) =>
-      g.status === GoatStatusEnum.DECEASED ||
-      g.status === "DECEASED" ||
-      g.status === "Morto" ||
-      g.status === "Falecido"
-  ).length;
+  if (otherCount > 0) {
+    ranked.push({
+      label: "Outras raças",
+      value: otherCount,
+      color: BREED_COLORS[BREED_COLORS.length - 1],
+    });
+  }
 
-  const inactive = goats.filter(
-    (g) =>
-      g.status === GoatStatusEnum.INACTIVE ||
-      g.status === "INACTIVE" ||
-      g.status === "Inativo"
-  ).length;
+  return ranked;
+}
 
-  const items: SummaryItem[] = [
-    { label: "Total", value: total },
-    { label: "Machos", value: males },
-    { label: "Fêmeas", value: females },
-    { label: "Ativos", value: active, tone: "success" },
-    { label: "Inativos", value: inactive, tone: "warning" },
-    { label: "Vendidos", value: sold, tone: "danger" },
-    { label: "Falecidos", value: deceased, tone: "neutral" },
-  ];
+function ChartPanel({
+  title,
+  subtitle,
+  totalLabel,
+  data,
+}: {
+  title: string;
+  subtitle: string;
+  totalLabel: string;
+  data: ChartDatum[];
+}) {
+  if (data.length === 0) {
+    return (
+      <article className="goat-summary__panel goat-summary__panel--empty">
+        <header className="goat-summary__panel-header">
+          <h3>{title}</h3>
+          <p>{subtitle}</p>
+        </header>
+        <p className="goat-summary__empty-copy">Ainda não há dados suficientes para exibir este gráfico.</p>
+      </article>
+    );
+  }
 
   return (
-    <section className="goat-summary" aria-label="Resumo do rebanho filtrado">
+    <article className="goat-summary__panel">
+      <header className="goat-summary__panel-header">
+        <h3>{title}</h3>
+        <p>{subtitle}</p>
+      </header>
+
+      <div className="goat-summary__chart-shell">
+        <div className="goat-summary__chart-center" aria-hidden="true">
+          <strong>{totalLabel}</strong>
+          <span>rebanho</span>
+        </div>
+
+        <PieChart width={220} height={220}>
+          <Pie
+            data={data}
+            dataKey="value"
+            nameKey="label"
+            cx="50%"
+            cy="50%"
+            innerRadius={58}
+            outerRadius={86}
+            paddingAngle={2}
+            stroke="none"
+          >
+            {data.map((entry) => (
+              <Cell key={entry.label} fill={entry.color} />
+            ))}
+          </Pie>
+        </PieChart>
+      </div>
+
+      <ul className="goat-summary__legend" aria-label={`Legenda de ${title.toLowerCase()}`}>
+        {data.map((entry) => (
+          <li key={entry.label} className="goat-summary__legend-item">
+            <span className="goat-summary__legend-dot" style={{ backgroundColor: entry.color }} aria-hidden="true" />
+            <span className="goat-summary__legend-label">{entry.label}</span>
+            <strong className="goat-summary__legend-value">{entry.value}</strong>
+          </li>
+        ))}
+      </ul>
+    </article>
+  );
+}
+
+export default function GoatDashboardSummary({
+  summary,
+  visibleCount,
+  loading = false,
+  error = null,
+  onRetry,
+}: Props) {
+  if (loading) {
+    return (
+      <section className="goat-summary goat-summary--loading" aria-label="Resumo do rebanho">
+        <header className="goat-summary__header">
+          <span className="goat-summary__eyebrow">Resumo do rebanho</span>
+          <strong className="goat-summary__headline">Carregando indicadores da fazenda...</strong>
+        </header>
+      </section>
+    );
+  }
+
+  if (error || !summary) {
+    return (
+      <section className="goat-summary goat-summary--error" aria-label="Resumo do rebanho">
+        <header className="goat-summary__header">
+          <span className="goat-summary__eyebrow">Resumo do rebanho</span>
+          <strong className="goat-summary__headline">Não foi possível carregar os indicadores da fazenda.</strong>
+        </header>
+        {error ? <p className="goat-summary__error-copy">{error}</p> : null}
+        {onRetry ? (
+          <Button variant="outline" size="sm" onClick={onRetry}>
+            Tentar novamente
+          </Button>
+        ) : null}
+      </section>
+    );
+  }
+
+  const items: SummaryItem[] = [
+    { label: "Total", value: summary.total },
+    { label: "Machos", value: summary.males },
+    { label: "Fêmeas", value: summary.females },
+    { label: "Ativos", value: summary.active, tone: "success" },
+    { label: "Inativos", value: summary.inactive, tone: "warning" },
+    { label: "Vendidos", value: summary.sold, tone: "danger" },
+    { label: "Falecidos", value: summary.deceased, tone: "neutral" },
+  ];
+
+  const sexData: ChartDatum[] = [
+    { label: "Machos", value: summary.males, color: SEX_COLORS[0] },
+    { label: "Fêmeas", value: summary.females, color: SEX_COLORS[1] },
+  ].filter((entry) => entry.value > 0);
+
+  const statusData: ChartDatum[] = [
+    { label: "Ativos", value: summary.active, color: STATUS_COLORS[0] },
+    { label: "Inativos", value: summary.inactive, color: STATUS_COLORS[1] },
+    { label: "Vendidos", value: summary.sold, color: STATUS_COLORS[2] },
+    { label: "Falecidos", value: summary.deceased, color: STATUS_COLORS[3] },
+  ].filter((entry) => entry.value > 0);
+
+  const breedData = buildBreedChartData(summary);
+
+  return (
+    <section className="goat-summary" aria-label="Resumo do rebanho da fazenda">
       <header className="goat-summary__header">
-        <span className="goat-summary__eyebrow">Resumo do rebanho</span>
-        <strong className="goat-summary__headline">{total} animal{total === 1 ? "" : "is"} nesta lista</strong>
+        <div>
+          <span className="goat-summary__eyebrow">Resumo do rebanho</span>
+          <strong className="goat-summary__headline">{formatAnimalCount(summary.total)} no rebanho</strong>
+        </div>
+
+        <p className="goat-summary__subheadline">{formatAnimalCount(visibleCount)} exibid{visibleCount === 1 ? "o" : "os"} nesta tela</p>
       </header>
 
       <div className="goat-summary__grid">
@@ -84,6 +201,29 @@ export default function GoatDashboardSummary({ goats }: Props) {
             <strong className="goat-summary__value">{item.value}</strong>
           </div>
         ))}
+      </div>
+
+      <div className="goat-summary__panels">
+        <ChartPanel
+          title="Distribuição por sexo"
+          subtitle="Visão geral rápida do rebanho por machos e fêmeas."
+          totalLabel={formatAnimalCount(summary.total)}
+          data={sexData}
+        />
+
+        <ChartPanel
+          title="Situação do rebanho"
+          subtitle="Animais ativos, inativos, vendidos e falecidos."
+          totalLabel={formatAnimalCount(summary.total)}
+          data={statusData}
+        />
+
+        <ChartPanel
+          title="Raças cadastradas"
+          subtitle="Principais raças da fazenda, agrupando excedentes em outras."
+          totalLabel={`${summary.breeds.length} raça${summary.breeds.length === 1 ? "" : "s"}`}
+          data={breedData}
+        />
       </div>
     </section>
   );

--- a/src/Components/goat-card-list/goatcard.css
+++ b/src/Components/goat-card-list/goatcard.css
@@ -86,13 +86,23 @@
 }
 
 .goat-status-badge.active {
-  background: rgba(16, 185, 129, 0.1);
-  color: var(--gf-color-primary);
+    background: rgba(16, 185, 129, 0.14);
+    color: #10b981;
 }
 
 .goat-status-badge.inactive {
-  background: rgba(239, 68, 68, 0.1);
-  color: #ef4444;
+    background: rgba(245, 158, 11, 0.14);
+    color: #f59e0b;
+}
+
+.goat-status-badge.sold {
+    background: rgba(244, 63, 94, 0.14);
+    color: #f43f5e;
+}
+
+.goat-status-badge.deceased {
+    background: rgba(100, 116, 139, 0.14);
+    color: #64748b;
 }
 
 /* Card Body - Grid Layout for Compactness */

--- a/src/Components/goat-create-form/GoatCreateForm.tsx
+++ b/src/Components/goat-create-form/GoatCreateForm.tsx
@@ -54,14 +54,79 @@ export default function GoatCreateForm({
 
   const [isSubmitting, setIsSubmitting] = useState(false);
 
+  function deriveIdentificationFields(
+    registrationNumber?: string,
+    tod?: string,
+    toe?: string,
+    fallbackTod?: string
+  ) {
+    const normalizedRegistration = registrationNumber?.trim() ?? "";
+    const normalizedTod = tod?.trim() ?? "";
+    const normalizedToe = toe?.trim() ?? "";
+    const normalizedFallbackTod = fallbackTod?.trim() ?? "";
+
+    if (!normalizedRegistration) {
+      return {
+        tod: normalizedTod,
+        toe: normalizedToe,
+      };
+    }
+
+    if (normalizedTod && normalizedToe) {
+      return {
+        tod: normalizedTod,
+        toe: normalizedToe,
+      };
+    }
+
+    const inferredTodLength =
+      normalizedFallbackTod.length > 0
+        ? normalizedFallbackTod.length
+        : normalizedRegistration.length > 5
+          ? 5
+          : 0;
+
+    const inferredTodFromRegistration =
+      inferredTodLength > 0 ? normalizedRegistration.slice(0, inferredTodLength) : "";
+
+    const inferredToeFromRegistration =
+      inferredTodFromRegistration && normalizedRegistration.startsWith(inferredTodFromRegistration)
+        ? normalizedRegistration.slice(inferredTodFromRegistration.length)
+        : "";
+
+    const derivedTod =
+      normalizedTod ||
+      (normalizedFallbackTod && normalizedRegistration.startsWith(normalizedFallbackTod)
+        ? normalizedFallbackTod
+        : inferredTodFromRegistration);
+
+    const derivedToe =
+      normalizedToe ||
+      (derivedTod && normalizedRegistration.startsWith(derivedTod)
+        ? normalizedRegistration.slice(derivedTod.length)
+        : inferredToeFromRegistration);
+
+    return {
+      tod: derivedTod,
+      toe: derivedToe,
+    };
+  }
+
   useEffect(() => {
     if (mode === "edit" && initialData) {
       const convertedData = convertResponseToRequest(fromDTOToExtended(initialData));
+      const derivedIdentification = deriveIdentificationFields(
+        convertedData.registrationNumber,
+        convertedData.tod,
+        convertedData.toe,
+        defaultTod
+      );
+
       const dataWithFallbacks = {
         ...convertedData,
         userId: convertedData.userId || currentUserId,
-        tod: convertedData.tod || "",
-        toe: convertedData.toe || "",
+        tod: derivedIdentification.tod || "",
+        toe: derivedIdentification.toe || "",
         category: convertedData.category || "",
         fatherRegistrationNumber: convertedData.fatherRegistrationNumber || "",
         motherRegistrationNumber: convertedData.motherRegistrationNumber || "",
@@ -76,6 +141,31 @@ export default function GoatCreateForm({
       }));
     }
   }, [mode, initialData, defaultFarmId, defaultUserId, defaultTod, currentUserId]);
+
+  useEffect(() => {
+    if (mode !== "edit" || !formData.registrationNumber) {
+      return;
+    }
+
+    const derivedIdentification = deriveIdentificationFields(
+      formData.registrationNumber,
+      formData.tod,
+      formData.toe,
+      defaultTod
+    );
+
+    if (
+      derivedIdentification.tod &&
+      derivedIdentification.toe &&
+      (derivedIdentification.tod !== formData.tod || derivedIdentification.toe !== formData.toe)
+    ) {
+      setFormData((prev) => ({
+        ...prev,
+        tod: prev.tod || derivedIdentification.tod,
+        toe: prev.toe || derivedIdentification.toe,
+      }));
+    }
+  }, [mode, formData.registrationNumber, formData.tod, formData.toe, defaultTod]);
 
   useEffect(() => {
     if (formData.tod && formData.toe && mode !== "edit") {
@@ -263,7 +353,14 @@ export default function GoatCreateForm({
 
             <label className="goat-create-form__field">
               <span>TOD <span className="goat-create-form__required">*</span></span>
-              <input type="text" name="tod" value={formData.tod} onChange={handleChange} required readOnly={!!defaultTod} />
+              <input
+                type="text"
+                name="tod"
+                value={formData.tod}
+                onChange={handleChange}
+                required
+                readOnly={mode === "create" && !!defaultTod}
+              />
               <small>Identificação da orelha direita.</small>
             </label>
 

--- a/src/Components/goat-create-form/GoatCreateModal.tsx
+++ b/src/Components/goat-create-form/GoatCreateModal.tsx
@@ -10,6 +10,7 @@ interface Props {
   onGoatCreated: () => void;
   mode?: "create" | "edit";
   initialData?: GoatResponseDTO;
+  loading?: boolean;
   defaultFarmId?: number;
   defaultUserId?: number;
   defaultTod?: string;
@@ -20,6 +21,7 @@ export default function GoatCreateModal({
   onGoatCreated,
   mode = "create",
   initialData,
+  loading = false,
   defaultFarmId,
   defaultUserId,
   defaultTod,
@@ -34,6 +36,8 @@ export default function GoatCreateModal({
       defaultTod === undefined ||
       defaultTod === null ||
       defaultTod === "");
+
+  const isEditLoading = mode === "edit" && (loading || !initialData);
 
   const handleGoatCreatedAndClose = () => {
     onGoatCreated();
@@ -53,8 +57,12 @@ export default function GoatCreateModal({
         </button>
 
         <div className="goat-create-modal__body">
-          {missingProps ? (
-            <p className="goat-create-modal__loading">Carregando dados da fazenda...</p>
+          {missingProps || isEditLoading ? (
+            <p className="goat-create-modal__loading">
+              {mode === "edit"
+                ? "Carregando dados completos da cabra..."
+                : "Carregando dados da fazenda..."}
+            </p>
           ) : (
             <GoatCreateForm
               mode={mode}

--- a/src/Components/goat-info-card/GoatInfoCard.tsx
+++ b/src/Components/goat-info-card/GoatInfoCard.tsx
@@ -12,12 +12,20 @@ export default function GoatInfoCard({ goat }: Props) {
   const displayedStatus = statusDisplayMap[goat.status] || goat.status;
   const displayedGender = genderDisplayMap[goat.gender] || goat.gender;
   const displayedCategory = categoryDisplayMap[goat.category] || goat.category;
+  const getStatusClass = (status?: string) => {
+    const normalized = String(status ?? displayedStatus ?? '').trim().toLowerCase();
+    if (normalized === 'ativo' || normalized === 'active') return 'ativo';
+    if (normalized === 'inativo' || normalized === 'inactive') return 'inativo';
+    if (normalized === 'vendido' || normalized === 'sold') return 'vendido';
+    if (normalized === 'falecido' || normalized === 'morto' || normalized === 'deceased') return 'falecido';
+    return '';
+  };
 
   return (
     <div className="goat-info-container">
       <div className="goat-info-header">
         <h2 className="goat-name">{goat.name}</h2>
-        <span className={`status-badge ${goat.status?.toLowerCase()}`}>
+        <span className={`status-badge ${getStatusClass(String(goat.status ?? displayedStatus))}`}>
           {displayedStatus}
         </span>
       </div>

--- a/src/Components/goat-info-card/goatInfo.css
+++ b/src/Components/goat-info-card/goatInfo.css
@@ -38,18 +38,23 @@
 }
 
 .status-badge.ativo {
-  background-color: #dcfce7;
-  color: #166534;
+  background-color: rgba(16, 185, 129, 0.14);
+  color: #10b981;
+}
+
+.status-badge.inativo {
+  background-color: rgba(245, 158, 11, 0.14);
+  color: #f59e0b;
 }
 
 .status-badge.vendido {
-  background-color: #fee2e2;
-  color: #991b1b;
+  background-color: rgba(244, 63, 94, 0.14);
+  color: #f43f5e;
 }
 
 .status-badge.falecido {
-  background-color: #f1f5f9;
-  color: #475569;
+  background-color: rgba(100, 116, 139, 0.14);
+  color: #64748b;
 }
 
 /* Grid Layout */

--- a/src/Models/GoatHerdSummaryDTO.ts
+++ b/src/Models/GoatHerdSummaryDTO.ts
@@ -1,0 +1,15 @@
+export interface GoatBreedSummaryDTO {
+  breed: string;
+  count: number;
+}
+
+export interface GoatHerdSummaryDTO {
+  total: number;
+  males: number;
+  females: number;
+  active: number;
+  inactive: number;
+  sold: number;
+  deceased: number;
+  breeds: GoatBreedSummaryDTO[];
+}

--- a/src/Pages/dashboard/Dashboard.tsx
+++ b/src/Pages/dashboard/Dashboard.tsx
@@ -15,7 +15,6 @@ import ContextBreadcrumb from "../../Components/pages-headers/ContextBreadcrumb"
 import { getGenealogy } from "../../api/GenealogyAPI/genealogy";
 import {
   fetchGoatById,
-  fetchGoatByRegistrationNumber,
   findGoatsByFarmAndName,
 } from "../../api/GoatAPI/goat";
 import type { GoatFarmDTO } from "../../Models/goatFarm";
@@ -104,18 +103,7 @@ export default function AnimalDashboard() {
 
     const loadGoatFromRoute = async () => {
       try {
-        let goatData: GoatResponseDTO;
-
-        if (/^\d+$/.test(routeGoatId)) {
-          try {
-            goatData = await fetchGoatById(routeFarmId, routeGoatId);
-          } catch (error) {
-            console.warn("Detalhe do animal: fallback para registro apos falha por ID", error);
-            goatData = await fetchGoatByRegistrationNumber(routeGoatId);
-          }
-        } else {
-          goatData = await fetchGoatByRegistrationNumber(routeGoatId);
-        }
+        const goatData = await fetchGoatById(routeFarmId, routeGoatId);
 
         if (cancelled) {
           return;
@@ -158,7 +146,7 @@ export default function AnimalDashboard() {
 
     const fetchDetails = async () => {
       try {
-        const fullData = await fetchGoatByRegistrationNumber(goat.registrationNumber);
+        const fullData = await fetchGoatById(resolvedFarmId, goat.registrationNumber);
         if (!cancelled) {
           setGoat((prev) => (prev ? { ...prev, ...fullData } : fullData));
         }

--- a/src/Pages/goat-list-page/GoatListPage.tsx
+++ b/src/Pages/goat-list-page/GoatListPage.tsx
@@ -12,9 +12,14 @@ import PageHeader from "../../Components/pages-headers/PageHeader";
 import SearchInputBox from "../../Components/searchs/SearchInputBox";
 
 import type { GoatFarmDTO } from "../../Models/goatFarm";
+import type { GoatHerdSummaryDTO } from "../../Models/GoatHerdSummaryDTO";
 import type { GoatResponseDTO } from "../../Models/goatResponseDTO";
 
-import { findGoatsByFarmAndName, findGoatsByFarmIdPaginated } from "../../api/GoatAPI/goat";
+import {
+  fetchGoatHerdSummary,
+  findGoatsByFarmAndName,
+  findGoatsByFarmIdPaginated,
+} from "../../api/GoatAPI/goat";
 import { getGoatFarmById } from "../../api/GoatFarmAPI/goatFarm";
 import { useAuth } from "../../contexts/AuthContext";
 import { usePermissions } from "../../Hooks/usePermissions";
@@ -38,6 +43,9 @@ export default function GoatListPage() {
   const [loadingGoats, setLoadingGoats] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
   const [goatLoadError, setGoatLoadError] = useState<string | null>(null);
+  const [herdSummary, setHerdSummary] = useState<GoatHerdSummaryDTO | null>(null);
+  const [loadingHerdSummary, setLoadingHerdSummary] = useState(true);
+  const [herdSummaryError, setHerdSummaryError] = useState<string | null>(null);
 
   const [page, setPage] = useState(0);
   const [hasMore, setHasMore] = useState(true);
@@ -65,6 +73,7 @@ export default function GoatListPage() {
     setPage(0);
     setHasMore(true);
     void loadGoatsPage(0);
+    void loadHerdSummary(Number(farmId));
     void fetchFarmData(Number(farmId));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [farmId]);
@@ -116,8 +125,30 @@ export default function GoatListPage() {
     }
   }
 
+  async function loadHerdSummary(id: number) {
+    setLoadingHerdSummary(true);
+    setHerdSummaryError(null);
+
+    try {
+      const data = await fetchGoatHerdSummary(id);
+      setHerdSummary(data);
+    } catch (error) {
+      setHerdSummary(null);
+      setHerdSummaryError(getApiErrorMessage(parseApiError(error)));
+    } finally {
+      setLoadingHerdSummary(false);
+    }
+  }
+
   function reloadGoatList() {
     void loadGoatsPage(0);
+  }
+
+  function reloadGoatListAndSummary() {
+    if (!farmId) return;
+
+    void loadGoatsPage(0);
+    void loadHerdSummary(Number(farmId));
   }
 
   async function handleSearch(term: string) {
@@ -145,7 +176,7 @@ export default function GoatListPage() {
   }
 
   function handleGoatCreated() {
-    reloadGoatList();
+    reloadGoatListAndSummary();
   }
 
   function openEditModal(goat: GoatResponseDTO) {
@@ -235,29 +266,39 @@ export default function GoatListPage() {
               description={goatLoadError}
               onRetry={reloadGoatList}
             />
-          ) : filteredGoats.length === 0 ? (
-            <EmptyState
-              title="Nenhuma cabra encontrada"
-              description="Cadastre um animal ou ajuste a busca para encontrar registros desta fazenda."
-              actionLabel={canCreate ? "Cadastrar nova cabra" : undefined}
-              onAction={canCreate ? () => setShowCreateModal(true) : undefined}
-            />
           ) : (
             <>
-              <GoatDashboardSummary goats={filteredGoats} />
-
-              <GoatCardList
-                goats={filteredGoats}
-                onEdit={openEditModal}
-                farmOwnerId={farmData?.ownerId ?? farmData?.userId}
+              <GoatDashboardSummary
+                summary={herdSummary}
+                visibleCount={filteredGoats.length}
+                loading={loadingHerdSummary}
+                error={herdSummaryError}
+                onRetry={farmId ? () => void loadHerdSummary(Number(farmId)) : undefined}
               />
 
-              {hasMore && (
-                <ButtonSeeMore
-                  onClick={handleSeeMore}
-                  loading={loadingMore}
-                  disabled={loadingMore}
+              {filteredGoats.length === 0 ? (
+                <EmptyState
+                  title="Nenhuma cabra encontrada"
+                  description="Cadastre um animal ou ajuste a busca para encontrar registros desta fazenda."
+                  actionLabel={canCreate ? "Cadastrar nova cabra" : undefined}
+                  onAction={canCreate ? () => setShowCreateModal(true) : undefined}
                 />
+              ) : (
+                <>
+                  <GoatCardList
+                    goats={filteredGoats}
+                    onEdit={openEditModal}
+                    farmOwnerId={farmData?.ownerId ?? farmData?.userId}
+                  />
+
+                  {hasMore && (
+                    <ButtonSeeMore
+                      onClick={handleSeeMore}
+                      loading={loadingMore}
+                      disabled={loadingMore}
+                    />
+                  )}
+                </>
               )}
             </>
           )}

--- a/src/Pages/goat-list-page/GoatListPage.tsx
+++ b/src/Pages/goat-list-page/GoatListPage.tsx
@@ -16,6 +16,7 @@ import type { GoatHerdSummaryDTO } from "../../Models/GoatHerdSummaryDTO";
 import type { GoatResponseDTO } from "../../Models/goatResponseDTO";
 
 import {
+  fetchGoatById,
   fetchGoatHerdSummary,
   findGoatsByFarmAndName,
   findGoatsByFarmIdPaginated,
@@ -39,6 +40,7 @@ export default function GoatListPage() {
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [editModalOpen, setEditModalOpen] = useState(false);
   const [selectedGoat, setSelectedGoat] = useState<GoatResponseDTO | null>(null);
+  const [loadingEditGoat, setLoadingEditGoat] = useState(false);
   const [farmData, setFarmData] = useState<GoatFarmDTO | null>(null);
   const [loadingGoats, setLoadingGoats] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
@@ -179,14 +181,36 @@ export default function GoatListPage() {
     reloadGoatListAndSummary();
   }
 
-  function openEditModal(goat: GoatResponseDTO) {
-    setSelectedGoat(goat);
+  async function openEditModal(goat: GoatResponseDTO) {
+    if (!farmId) return;
+
     setEditModalOpen(true);
+    setLoadingEditGoat(true);
+    setSelectedGoat(null);
+
+    try {
+      const goatIdentifier = goat.registrationNumber?.trim() || goat.id;
+
+      if (!goatIdentifier) {
+        throw new Error("Cabra selecionada sem identificador válido para edição.");
+      }
+
+      const detailedGoat = await fetchGoatById(Number(farmId), goatIdentifier);
+
+      setSelectedGoat(detailedGoat);
+    } catch (error) {
+      setEditModalOpen(false);
+      setSelectedGoat(null);
+      toast.error(getApiErrorMessage(parseApiError(error)));
+    } finally {
+      setLoadingEditGoat(false);
+    }
   }
 
   function closeEditModal() {
     setSelectedGoat(null);
     setEditModalOpen(false);
+    setLoadingEditGoat(false);
   }
 
   function handleSeeMore() {
@@ -315,10 +339,12 @@ export default function GoatListPage() {
         />
       )}
 
-      {editModalOpen && selectedGoat && (
+      {editModalOpen && (
         <GoatCreateModal
           mode="edit"
           initialData={selectedGoat}
+          loading={loadingEditGoat}
+          defaultTod={farmData?.tod}
           onClose={closeEditModal}
           onGoatCreated={handleGoatCreated}
         />

--- a/src/Pages/goat-list-page/goatList.css
+++ b/src/Pages/goat-list-page/goatList.css
@@ -3,25 +3,39 @@
 .goat-section {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  padding: 1rem 0 1.4rem;
+  gap: 0.8rem;
+  padding: 0.75rem 0 1rem;
 }
 
 .goat-toolbar {
-  margin: -0.15rem 0 0.2rem;
+  margin: -0.05rem 0 0.05rem;
 }
 
 .goat-toolbar .search-container-box {
   margin-bottom: 0;
 }
 
+.goat-toolbar .search-box {
+  max-width: 100%;
+  padding: 4px 6px;
+}
+
+.goat-toolbar .search-box input {
+  padding: 0.55rem 1rem;
+}
+
+.goat-toolbar .search-button {
+  width: 46px;
+  height: 46px;
+}
+
 .farm-context-entry {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
-  gap: 0.9rem;
+  gap: 0.75rem;
   align-items: center;
   margin-bottom: 0;
-  padding: 0.95rem 1.1rem;
+  padding: 0.8rem 1rem;
   border-radius: 1rem;
   background:
     radial-gradient(circle at top right, rgba(16, 185, 129, 0.12), transparent 36%),
@@ -33,7 +47,7 @@
 .farm-context-entry__eyebrow {
   display: inline-flex;
   margin-bottom: 0.2rem;
-  font-size: 0.76rem;
+  font-size: 0.72rem;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.08em;
@@ -43,14 +57,14 @@
 .farm-context-entry__title {
   display: block;
   color: #0f172a;
-  font-size: 0.98rem;
+  font-size: 0.95rem;
 }
 
 .farm-context-entry__description {
-  margin: 0.25rem 0 0;
+  margin: 0.2rem 0 0;
   color: #475569;
-  font-size: 0.92rem;
-  line-height: 1.5;
+  font-size: 0.9rem;
+  line-height: 1.45;
 }
 
 .farm-context-entry__cta {
@@ -58,7 +72,7 @@
   align-items: center;
   justify-content: center;
   min-width: 12.75rem;
-  padding: 0.75rem 1.05rem;
+  padding: 0.68rem 1rem;
   border-radius: 999px;
   text-decoration: none;
   font-weight: 700;
@@ -76,7 +90,7 @@
 .goat-state-wrapper {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.8rem;
 }
 
 @media (max-width: 768px) {

--- a/src/api/GoatAPI/goat.test.ts
+++ b/src/api/GoatAPI/goat.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { requestBackEnd } from "../../utils/request";
+import { fetchGoatHerdSummary } from "./goat";
+
+vi.mock("../../utils/request", () => ({
+  requestBackEnd: {
+    get: vi.fn(),
+  },
+}));
+
+describe("Goat API", () => {
+  const mockedGet = vi.mocked(requestBackEnd.get);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches the herd summary using the canonical route", async () => {
+    mockedGet.mockResolvedValueOnce({
+      data: {
+        total: 128,
+        males: 19,
+        females: 109,
+        active: 117,
+        inactive: 4,
+        sold: 5,
+        deceased: 2,
+        breeds: [
+          { breed: "Saanen", count: 48 },
+          { breed: "Boer", count: 32 },
+          { breed: null, count: 3 },
+        ],
+      },
+    });
+
+    const result = await fetchGoatHerdSummary(42);
+
+    expect(mockedGet).toHaveBeenCalledWith("/goatfarms/42/goats/summary");
+    expect(result.total).toBe(128);
+    expect(result.females).toBe(109);
+    expect(result.breeds).toEqual([
+      { breed: "Saanen", count: 48 },
+      { breed: "Boer", count: 32 },
+      { breed: "Não informada", count: 3 },
+    ]);
+  });
+});

--- a/src/api/GoatAPI/goat.ts
+++ b/src/api/GoatAPI/goat.ts
@@ -1,5 +1,6 @@
 // src/api/GoatAPI/goat.ts
 import type { GoatResponseDTO } from "../../Models/goatResponseDTO";
+import type { GoatHerdSummaryDTO } from "../../Models/GoatHerdSummaryDTO";
 import { requestBackEnd } from "../../utils/request";
 import type { BackendGoatPayload } from "../../Convertes/goats/goatConverter";
 import { toGoatResponseDTO } from "../../Convertes/goats/goatConverter";
@@ -74,6 +75,29 @@ export async function findGoatsByFarmIdPaginated(
   return {
     ...raw,
     content: (raw?.content ?? []).map(toGoatResponseDTO),
+  };
+}
+
+export async function fetchGoatHerdSummary(
+  farmId: number
+): Promise<GoatHerdSummaryDTO> {
+  const { data } = await requestBackEnd.get(`/goatfarms/${farmId}/goats/summary`);
+  const raw = data?.data ?? data;
+
+  return {
+    total: Number(raw?.total ?? 0),
+    males: Number(raw?.males ?? 0),
+    females: Number(raw?.females ?? 0),
+    active: Number(raw?.active ?? 0),
+    inactive: Number(raw?.inactive ?? 0),
+    sold: Number(raw?.sold ?? 0),
+    deceased: Number(raw?.deceased ?? 0),
+    breeds: Array.isArray(raw?.breeds)
+      ? raw.breeds.map((entry: { breed?: string; count?: number }) => ({
+          breed: entry?.breed?.trim() || "Não informada",
+          count: Number(entry?.count ?? 0),
+        }))
+      : [],
   };
 }
 

--- a/src/utils/Translate-Map/statusDisplayMap.ts
+++ b/src/utils/Translate-Map/statusDisplayMap.ts
@@ -1,6 +1,9 @@
 // src/utils/statusDisplayMap.ts
 export const statusDisplayMap: Record<string, string> = {
   ATIVO: "Ativo",
+  INATIVO: "Inativo",
+  FALECIDO: "Falecido",
+  VENDIDO: "Vendido",
   INACTIVE: "Inativo",
   DECEASED: "Falecido",
   SOLD: "Vendido",


### PR DESCRIPTION
## Summary\n- consume the real herd summary endpoint instead of counting only the current page\n- preload full goat data before opening edit and backfill TOD/TOE from the registration when needed\n- align status badges with the herd summary colors and normalize PT-BR status mapping\n\n## Validation\n- npm test\n- npm run lint\n- npm run build\n- npm run test:e2e