### PR TITLE
Farm cards: open dashboard as primary action

### DIFF
--- a/src/Components/goatfarms-cards/GoatfarmCard.test.tsx
+++ b/src/Components/goatfarms-cards/GoatfarmCard.test.tsx
@@ -18,24 +18,37 @@ vi.mock("../../Hooks/usePermissions", () => ({
 }));
 
 describe("GoatfarmCard", () => {
+  const farm = {
+    id: 1,
+    name: "Capril Vilar",
+    tod: "123",
+    userName: "Alberto",
+    city: "Belo Horizonte",
+    state: "MG",
+    phones: [],
+    logoUrl: "",
+  } as unknown as GoatFarmDTO;
+
   it("closes the primary link before rendering secondary actions", () => {
     const html = renderToStaticMarkup(
       <MemoryRouter>
-        <GoatfarmCard
-          farm={{
-            id: 1,
-            name: "Capril Vilar",
-            tod: "123",
-            userName: "Alberto",
-            city: "Belo Horizonte",
-            state: "MG",
-            phones: [],
-            logoUrl: "",
-          } as unknown as GoatFarmDTO}
-        />
+        <GoatfarmCard farm={farm} />
       </MemoryRouter>
     );
 
     expect(html).toContain("</a><div class=\"farm-card-actions\">");
+  });
+
+  it("uses the farm dashboard as the primary destination and exposes herd as a secondary action", () => {
+    const html = renderToStaticMarkup(
+      <MemoryRouter>
+        <GoatfarmCard farm={farm} />
+      </MemoryRouter>
+    );
+
+    expect(html).toContain('aria-label="Abrir dashboard da fazenda Capril Vilar"');
+    expect(html).toContain('href="/app/goatfarms/1/dashboard"');
+    expect(html).toContain('aria-label="Abrir rebanho da fazenda Capril Vilar"');
+    expect(html).toContain('href="/cabras?farmId=1"');
   });
 });

--- a/src/Components/goatfarms-cards/GoatfarmCard.tsx
+++ b/src/Components/goatfarms-cards/GoatfarmCard.tsx
@@ -5,6 +5,7 @@ import { toast } from "react-toastify";
 import { deleteGoatFarm } from "../../api/GoatFarmAPI/goatFarm";
 import { useAuth } from "../../contexts/AuthContext";
 import { usePermissions } from "../../Hooks/usePermissions";
+import { buildFarmDashboardPath, buildFarmGoatsPath } from "../../utils/appRoutes";
 import "./goatfarmsCards.css";
 
 type Props = {
@@ -17,7 +18,8 @@ export default function GoatFarmCard({ farm, onDeleted }: Props) {
   const permissions = usePermissions();
   const [isDeleting, setIsDeleting] = useState(false);
   const [imageError, setImageError] = useState(false);
-  const farmDetailsPath = `/cabras?farmId=${farm.id}`;
+  const farmDashboardPath = buildFarmDashboardPath(farm.id);
+  const farmGoatsPath = buildFarmGoatsPath(farm.id);
   const farmAddress = [farm.city, farm.state].filter(Boolean).join(" - ");
   const ownerName = farm.userName || farm.ownerName || "Não informado";
 
@@ -81,9 +83,9 @@ export default function GoatFarmCard({ farm, onDeleted }: Props) {
   return (
     <article className="goatfarm-card">
       <Link
-        to={farmDetailsPath}
+        to={farmDashboardPath}
         className="goatfarm-card-link"
-        aria-label={`Abrir detalhes da fazenda ${farm.name}`}
+        aria-label={`Abrir dashboard da fazenda ${farm.name}`}
       >
         <div className="farm-card-header">
           <div className="farm-logo-container">
@@ -162,12 +164,21 @@ export default function GoatFarmCard({ farm, onDeleted }: Props) {
 
       <div className="farm-card-actions">
         <Link
-          to={farmDetailsPath}
+          to={farmDashboardPath}
           className="action-btn details"
-          title="Ver detalhes da fazenda"
-          aria-label={`Ver detalhes da fazenda ${farm.name}`}
+          title="Abrir dashboard da fazenda"
+          aria-label={`Abrir dashboard da fazenda ${farm.name}`}
         >
           <i className="fa-solid fa-magnifying-glass" aria-hidden="true"></i>
+        </Link>
+
+        <Link
+          to={farmGoatsPath}
+          className="action-btn herd"
+          title="Abrir rebanho da fazenda"
+          aria-label={`Abrir rebanho da fazenda ${farm.name}`}
+        >
+          <i className="fa-solid fa-cow" aria-hidden="true"></i>
         </Link>
 
         {canEdit && (

--- a/src/Components/goatfarms-cards/goatfarmsCards.css
+++ b/src/Components/goatfarms-cards/goatfarmsCards.css
@@ -239,6 +239,15 @@
   background-color: #dcfce7;
 }
 
+.action-btn.herd {
+  background-color: #eff6ff;
+  color: #1d4ed8;
+}
+
+.action-btn.herd:hover {
+  background-color: #dbeafe;
+}
+
 .action-btn.edit {
   background-color: #fffbeb;
   color: #b45309;


### PR DESCRIPTION
## Summary\n- route the primary farm card click to the farm dashboard\n- keep herd access as an explicit secondary action\n- add regression coverage for the new destinations\n\n## Validation\n- npm test\n- npm run lint\n- npm run build\n- npm run test:e2e