### PR TITLE
feat: add reproduction breeding warning flow

### DIFF
--- a/src/Pages/reproduction/ReproductionPage.tsx
+++ b/src/Pages/reproduction/ReproductionPage.tsx
@@ -32,6 +32,10 @@ import {
   formatLocalDatePtBR,
   getTodayLocalDate,
 } from "../../utils/localDate";
+import {
+  buildCoverageConflictState,
+  type CoverageConflictState,
+} from "./reproductionCoverageConflict";
 import { Button } from "../../Components/ui/Button";
 import "./reproductionPages.css";
 
@@ -74,9 +78,6 @@ const closeReasonLabels: Record<PregnancyCloseReason, string> = {
   DATA_FIX_DUPLICATED_ACTIVE: "Correção de dados",
 };
 
-const activePregnancyBlockMessage =
-  "Existe uma gestação ativa. Para registrar nova cobertura, encerre ou corrija a gestação atual (falso positivo/aborto).";
-
 const recommendationWarningLabels: Record<string, string> = {
   GESTACAO_ATIVA_SEM_CHECK_VALIDO:
     "Existe gestação ativa sem diagnóstico positivo válido no período recomendado.",
@@ -110,6 +111,8 @@ export default function ReproductionPage() {
 
   const [showBreedingModal, setShowBreedingModal] = useState(false);
   const [breedingModalMode, setBreedingModalMode] = useState<BreedingModalMode>("standard");
+  const [breedingConflict, setBreedingConflict] = useState<CoverageConflictState | null>(null);
+  const [showBreedingConflictModal, setShowBreedingConflictModal] = useState(false);
   const [showDiagnosisModal, setShowDiagnosisModal] = useState(false);
   const [showCloseModal, setShowCloseModal] = useState(false);
   const [breedingError, setBreedingError] = useState<string | null>(null);
@@ -145,6 +148,14 @@ export default function ReproductionPage() {
     return coverageEvent?.eventDate || null;
   }, [latestEvents]);
 
+  const latestCoverageReferenceDate = useMemo(
+    () =>
+      recommendation?.lastCoverage?.effectiveDate ||
+      recommendation?.lastCoverage?.eventDate ||
+      latestCoverageEventDate,
+    [recommendation?.lastCoverage?.effectiveDate, recommendation?.lastCoverage?.eventDate, latestCoverageEventDate]
+  );
+
   const activePregnancyReferenceDate = useMemo(
     () =>
       recommendation?.lastCoverage?.effectiveDate ||
@@ -170,6 +181,11 @@ export default function ReproductionPage() {
     !!minCheckDate &&
     !!diagnosisForm.checkDate &&
     diffDaysLocalDate(diagnosisForm.checkDate, minCheckDate) > 0;
+
+  const coverageConflictState = useMemo(
+    () => buildCoverageConflictState(breedingForm.eventDate, latestCoverageReferenceDate),
+    [breedingForm.eventDate, latestCoverageReferenceDate]
+  );
 
   // Timeline Logic
   const timelineTotalDays = 60;
@@ -406,9 +422,8 @@ export default function ReproductionPage() {
       toast.error("Sem permissão para esta ação.");
       return;
     }
-    if (mode === "standard" && hasActivePregnancy) {
-      toast.info(activePregnancyBlockMessage);
-    }
+    setBreedingConflict(coverageConflictState);
+    setShowBreedingConflictModal(false);
     setBreedingError(null);
     setBreedingModalMode(mode);
     setShowBreedingModal(true);
@@ -427,9 +442,14 @@ export default function ReproductionPage() {
     setShowBreedingModal(false);
     setBreedingModalMode("standard");
     setBreedingError(null);
+    setBreedingConflict(null);
+    setShowBreedingConflictModal(false);
   };
 
-  const handleBreedingSubmit = async () => {
+  const getCoverageConflictForDate = (selectedDate?: string): CoverageConflictState =>
+    buildCoverageConflictState(selectedDate, latestCoverageReferenceDate);
+
+  const handleBreedingSubmit = async (skipCoverageConfirmation = false) => {
     if (!canManage) {
       toast.error("Sem permissão para esta ação.");
       return;
@@ -439,9 +459,23 @@ export default function ReproductionPage() {
       return;
     }
 
+    const coverageConflict = getCoverageConflictForDate(breedingForm.eventDate);
+    if (!coverageConflict.canProceed) {
+      setBreedingError(coverageConflict.message);
+      return;
+    }
+
+    if (
+      coverageConflict.kind === "later" &&
+      !skipCoverageConfirmation &&
+      coverageConflict.message !== null
+    ) {
+      setBreedingConflict(coverageConflict);
+      setShowBreedingConflictModal(true);
+      return;
+    }
+
     const submittedDate = breedingForm.eventDate;
-    const referenceDateAtSubmit = activePregnancyReferenceDate;
-    const hadActivePregnancyAtSubmit = hasActivePregnancy;
 
     try {
       setBreedingError(null);
@@ -451,21 +485,19 @@ export default function ReproductionPage() {
         notes: breedingForm.notes || undefined,
       });
 
-      const isLateRegistration =
-        hadActivePregnancyAtSubmit &&
-        !!referenceDateAtSubmit &&
-        submittedDate < referenceDateAtSubmit;
-
-        if (isLateRegistration) {
-          toast.info(
-            "Cobertura registrada como histórico (registro tardio). Não altera a gestação ativa."
-          );
-        } else {
+      if (submittedDate < (activePregnancyReferenceDate || submittedDate)) {
+        toast.info("Cobertura registrada como histórica. O ciclo anterior permanece no histórico.");
+      } else if (coverageConflict.kind === "later") {
+        toast.success(
+          "Cobertura registrada. A contagem para diagnóstico será reiniciada a partir desta data."
+        );
+      } else {
         toast.success("Cobertura registrada");
       }
 
       closeBreedingModal();
       resetBreedingForm();
+      setShowBreedingConflictModal(false);
       await refreshReproductionState();
     } catch (error) {
       console.error("Erro ao registrar cobertura", error);
@@ -627,16 +659,10 @@ export default function ReproductionPage() {
           <div className="repro-action-shell">
             <div className="repro-actions">
               <Button
-                variant={hasActivePregnancy ? "secondary" : "primary"}
+                variant="primary"
                 className="repro-action-button repro-action-button--coverage"
-                disabled={!canManage || hasActivePregnancy}
-                title={
-                  !canManage
-                    ? "Sem permissão para registrar cobertura."
-                    : hasActivePregnancy
-                      ? activePregnancyBlockMessage
-                      : ""
-                }
+                disabled={!canManage}
+                title={!canManage ? "Sem permissão para registrar cobertura." : ""}
                 onClick={() => openBreedingModal("standard")}
               >
                 <i className="fa-solid fa-plus" aria-hidden="true"></i>
@@ -713,10 +739,10 @@ export default function ReproductionPage() {
           </div>
         </div>
 
-        {hasActivePregnancy && (
+        {latestCoverageReferenceDate && (
           <p className="repro-action-helper repro-action-helper--warning">
-            Gestação ativa em acompanhamento. Novas coberturas ficam bloqueadas até o encerramento
-            ou correção desta gestação.
+            Já existe cobertura para esta cabra. Coberturas com data posterior mantêm o histórico e
+            reiniciam a contagem para diagnóstico.
           </p>
         )}
 
@@ -1062,7 +1088,19 @@ export default function ReproductionPage() {
                 Registre uma cobertura com data anterior para manter o histórico reprodutivo.
               </p>
             )}
-            {breedingError && <p className="text-danger">{breedingError}</p>}
+            {breedingConflict?.kind === "sameDay" && breedingError && (
+              <p className="repro-breeding-conflict-message repro-breeding-conflict-message--error">
+                {breedingError}
+              </p>
+            )}
+            {breedingConflict?.kind === "later" && (
+              <p className="repro-breeding-conflict-message repro-breeding-conflict-message--warning">
+                {breedingConflict.message}
+              </p>
+            )}
+            {breedingError &&
+              breedingConflict?.kind !== "sameDay" &&
+              breedingConflict?.kind !== "later" && <p className="text-danger">{breedingError}</p>}
             <div className="repro-form-grid">
               <div>
                 <label>Data da cobertura</label>
@@ -1075,6 +1113,10 @@ export default function ReproductionPage() {
                       eventDate: e.target.value,
                     }));
                     setBreedingError(null);
+                    setShowBreedingConflictModal(false);
+                    setBreedingConflict(
+                      buildCoverageConflictState(e.target.value, latestCoverageReferenceDate)
+                    );
                   }}
                   disabled={!canManage}
                 />
@@ -1127,6 +1169,39 @@ export default function ReproductionPage() {
               </Button>
               <Button variant="primary" onClick={handleBreedingSubmit} disabled={!canManage}>
                 Salvar
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {showBreedingConflictModal && breedingConflict && (
+        <div className="repro-modal">
+          <div className="repro-modal-content repro-confirmation-modal">
+            <h3>Confirmar nova cobertura recente</h3>
+            <p className="repro-breeding-conflict-message repro-breeding-conflict-message--warning">
+              {breedingConflict.message}
+            </p>
+            <p className="repro-modal-text">
+              Esta ação mantém a cobertura anterior no histórico e reinicia a contagem para diagnóstico
+              a partir desta data. Confirme para continuar.
+            </p>
+            <div className="repro-modal-actions">
+              <Button
+                variant="secondary"
+                onClick={() => {
+                  setShowBreedingConflictModal(false);
+                  setBreedingConflict(null);
+                }}
+              >
+                Cancelar
+              </Button>
+              <Button
+                variant="warning"
+                onClick={() => handleBreedingSubmit(true)}
+                disabled={!canManage}
+              >
+                Confirmar e salvar
               </Button>
             </div>
           </div>

--- a/src/Pages/reproduction/reproductionCoverageConflict.test.ts
+++ b/src/Pages/reproduction/reproductionCoverageConflict.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { buildCoverageConflictState } from "./reproductionCoverageConflict";
+
+describe("reproductionCoverageConflict", () => {
+  it("returns no conflict when there is no previous coverage", () => {
+    const result = buildCoverageConflictState("2026-03-01", null);
+
+    expect(result.kind).toBe("none");
+    expect(result.canProceed).toBe(true);
+    expect(result.requiresConfirmation).toBe(false);
+  });
+
+  it("blocks submission when the selected date is the same as last coverage", () => {
+    const result = buildCoverageConflictState("2026-03-10", "2026-03-10");
+
+    expect(result.kind).toBe("sameDay");
+    expect(result.canProceed).toBe(false);
+    expect(result.message).toContain("cobertura registrada para esta cabra hoje");
+    expect(result.message).toContain("Use a correção de cobertura");
+  });
+
+  it("requires explicit confirmation when selected date is after last coverage", () => {
+    const result = buildCoverageConflictState("2026-03-12", "2026-03-10");
+
+    expect(result.kind).toBe("later");
+    expect(result.requiresConfirmation).toBe(true);
+    expect(result.canProceed).toBe(true);
+    expect(result.daysSinceLastCoverage).toBe(2);
+    expect(result.message).toContain("há 2 dias");
+    expect(result.message).toContain("reiniciará a contagem para diagnóstico");
+  });
+});

--- a/src/Pages/reproduction/reproductionCoverageConflict.ts
+++ b/src/Pages/reproduction/reproductionCoverageConflict.ts
@@ -1,0 +1,85 @@
+import { diffDaysLocalDate, formatLocalDatePtBR } from "../../utils/localDate";
+
+export type CoverageConflictState =
+  | {
+      kind: "none";
+      requiresConfirmation: false;
+      canProceed: true;
+      message: null;
+      lastCoverageDate: null;
+      daysSinceLastCoverage: null;
+    }
+  | {
+      kind: "sameDay";
+      requiresConfirmation: false;
+      canProceed: false;
+      message: string;
+      lastCoverageDate: string;
+      daysSinceLastCoverage: number;
+    }
+  | {
+      kind: "later";
+      requiresConfirmation: true;
+      canProceed: true;
+      message: string;
+      lastCoverageDate: string;
+      daysSinceLastCoverage: number;
+    };
+
+const coverageAlreadySavedMessage = (
+  daysSinceLastCoverage: number,
+  lastCoverageDate: string
+) =>
+  `Já existe uma cobertura registrada para esta cabra há ${daysSinceLastCoverage} dia${daysSinceLastCoverage > 1 ? "s" : ""} (${formatLocalDatePtBR(
+    lastCoverageDate
+  )}). Registrar uma nova cobertura reiniciará a contagem para diagnóstico e manterá a anterior no histórico.`;
+
+export const buildCoverageConflictState = (
+  selectedDate?: string,
+  lastCoverageDate?: string | null
+): CoverageConflictState => {
+  if (!selectedDate || !lastCoverageDate) {
+    return {
+      kind: "none",
+      requiresConfirmation: false,
+      canProceed: true,
+      message: null,
+      lastCoverageDate: null,
+      daysSinceLastCoverage: null,
+    };
+  }
+
+  const daysSinceLastCoverage = diffDaysLocalDate(lastCoverageDate, selectedDate);
+
+  if (daysSinceLastCoverage === 0) {
+    return {
+      kind: "sameDay",
+      requiresConfirmation: false,
+      canProceed: false,
+      message:
+        "Já existe uma cobertura registrada para esta cabra hoje. Use a correção de cobertura se precisar ajustar o lançamento.",
+      lastCoverageDate,
+      daysSinceLastCoverage: 0,
+    };
+  }
+
+  if (daysSinceLastCoverage > 0) {
+    return {
+      kind: "later",
+      requiresConfirmation: true,
+      canProceed: true,
+      message: coverageAlreadySavedMessage(daysSinceLastCoverage, lastCoverageDate),
+      lastCoverageDate,
+      daysSinceLastCoverage,
+    };
+  }
+
+  return {
+    kind: "none",
+    requiresConfirmation: false,
+    canProceed: true,
+    message: null,
+    lastCoverageDate: null,
+    daysSinceLastCoverage: null,
+  };
+};

--- a/src/Pages/reproduction/reproductionPages.css
+++ b/src/Pages/reproduction/reproductionPages.css
@@ -612,6 +612,34 @@
   flex-wrap: wrap;
 }
 
+.repro-breeding-conflict-message {
+  margin: 0;
+  padding: 0.68rem 0.82rem;
+  border-radius: 12px;
+  border: 1px solid transparent;
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+.repro-breeding-conflict-message--warning {
+  border-color: rgba(245, 158, 11, 0.2);
+  background: rgba(254, 243, 199, 0.82);
+  color: #7c2d12;
+}
+
+.repro-breeding-conflict-message--error {
+  border-color: rgba(239, 68, 68, 0.26);
+  background: rgba(254, 226, 226, 0.88);
+  color: #b91c1c;
+}
+
+.repro-confirmation-modal .repro-modal-text {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--gf-color-text-secondary, #64748b);
+  line-height: 1.4;
+}
+
 .page-loading {
   min-height: 40vh;
   display: flex;


### PR DESCRIPTION
## Summary
- warn when a goat already has a recent breeding and require explicit confirmation before saving a later one
- surface the same-day rejection guidance in the breeding modal using the approved correction message
- add conflict-state tests for none, same-day block and later confirmation scenarios

## Validation
- npm test
- npm run build
- npm run lint