### PR TITLE
fix: clear stale reproduction recommendation state

### DIFF
--- a/src/Pages/reproduction/ReproductionPage.tsx
+++ b/src/Pages/reproduction/ReproductionPage.tsx
@@ -354,6 +354,8 @@ export default function ReproductionPage() {
 
       if (recommendationResult.status === "fulfilled") {
         setRecommendation(recommendationResult.value);
+      } else {
+        setRecommendation(null);
       }
 
       if (eventsResult.status === "fulfilled") {
@@ -392,6 +394,8 @@ export default function ReproductionPage() {
 
     if (recommendationResult.status === "fulfilled") {
       setRecommendation(recommendationResult.value);
+    } else {
+      setRecommendation(null);
     }
 
     if (eventsResult.status === "fulfilled") {


### PR DESCRIPTION
## Summary\n- clear stale diagnosis recommendation state when the recommendation request fails\n- avoid showing outdated breeding reference after partial refreshes\n\n## Validation\n- npm test -- --run\n- npm run build\n- npm run lint