### PR TITLE
feat(dashboard-ui): enrich farm dashboard with management summary

### DIFF
--- a/docs/FARM_DASHBOARD.md
+++ b/docs/FARM_DASHBOARD.md
@@ -1,0 +1,30 @@
+﻿# Dashboard da Fazenda
+
+## Escopo atual
+
+A dashboard da fazenda continua usando a rota existente `/app/goatfarms/:farmId/dashboard` e o componente existente `FarmDashboardPage`.
+
+Ela foi evoluída para entregar uma visão mais gerencial sem criar uma segunda dashboard paralela.
+
+## Fontes de dados reaproveitadas
+
+- `GET /goatfarms/{farmId}` para contexto da fazenda.
+- `GET /goatfarms/{farmId}/goats/summary` para KPIs básicos do rebanho.
+- `GET /goatfarms/{farmId}/reproduction/alerts/pregnancy-diagnosis` para alertas de reprodução.
+- `GET /goatfarms/{farmId}/milk/alerts/dry-off` para alertas de lactação.
+- `GET /goatfarms/{farmId}/health-events/alerts` para resumo sanitário e agenda resumida.
+- `GET /goatfarms/{farmId}/inventory/items` para volume de itens cadastrados.
+- `GET /goatfarms/{farmId}/inventory/balances` para saldos ativos.
+- `GET /goatfarms/{farmId}/inventory/movements` para último movimento e volume do histórico.
+
+## Decisão arquitetural
+
+Nenhum endpoint novo de backend foi criado.
+
+A auditoria mostrou que os dados necessários já existiam em APIs canônicas e estáveis. A evolução foi mantida no frontend para evitar superfície nova desnecessária e preservar a arquitetura do backend.
+
+## Limites conhecidos
+
+- A agenda resumida mostra explicitamente o recorte sanitário disponível hoje. Ela não finge ser uma agenda unificada entre módulos.
+- O bloco de estoque usa apenas resumos confiáveis já disponíveis. Não inventa conceito de estoque crítico.
+- A navegação continua separando contexto de fazenda e contexto de animal.

--- a/src/Pages/dashboard/FarmDashboardPage.css
+++ b/src/Pages/dashboard/FarmDashboardPage.css
@@ -1,7 +1,7 @@
-.farm-dashboard-page__content {
+﻿.farm-dashboard-page__content {
   width: min(100%, var(--gf-max-width));
   margin: 0 auto;
-  padding: 0 1.5rem 2rem;
+  padding: 0 1.5rem 2.5rem;
 }
 
 .farm-dashboard-hero {
@@ -9,6 +9,7 @@
   grid-template-columns: minmax(0, 1fr) auto;
   gap: 1.5rem;
   align-items: center;
+  margin-top: 1rem;
   padding: 1.5rem;
   border-radius: 1.25rem;
   background:
@@ -18,10 +19,11 @@
   box-shadow: 0 16px 36px rgba(15, 23, 42, 0.08);
 }
 
-.farm-dashboard-hero__eyebrow {
+.farm-dashboard-hero__eyebrow,
+.farm-dashboard-panel__eyebrow {
   display: inline-flex;
   margin-bottom: 0.65rem;
-  font-size: 0.8rem;
+  font-size: 0.78rem;
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -37,17 +39,42 @@
 
 .farm-dashboard-hero__description {
   margin: 0.75rem 0 0;
-  max-width: 44rem;
+  max-width: 48rem;
   font-size: 1rem;
   line-height: 1.7;
   color: #475569;
+}
+
+.farm-dashboard-hero__highlights {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.farm-dashboard-hero__highlight {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  min-width: 11rem;
+  padding: 0.8rem 0.9rem;
+  border-radius: 1rem;
+  background-color: rgba(255, 255, 255, 0.75);
+  border: 1px solid #d7e5dd;
+  color: #334155;
+  font-size: 0.92rem;
+}
+
+.farm-dashboard-hero__highlight strong {
+  font-size: 1.1rem;
+  color: #0f172a;
 }
 
 .farm-dashboard-hero__cta {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 12rem;
+  min-width: 13rem;
   padding: 0.95rem 1.35rem;
   border-radius: 999px;
   background: linear-gradient(135deg, #10b981 0%, #059669 100%);
@@ -66,7 +93,7 @@
 
 .farm-dashboard-metrics {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 1rem;
   margin-top: 1.25rem;
 }
@@ -102,8 +129,253 @@
 }
 
 .farm-dashboard-metric-card__value {
-  font-size: 1rem;
+  display: block;
+  margin-bottom: 0.35rem;
+  font-size: 1.6rem;
+  line-height: 1.1;
   color: #0f172a;
+}
+
+.farm-dashboard-metric-card__helper {
+  margin: 0;
+  color: #475569;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.farm-dashboard-section-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+  margin-top: 1.25rem;
+}
+
+.farm-dashboard-panel,
+.farm-dashboard-attention {
+  padding: 1.25rem;
+  border-radius: 1rem;
+  background-color: #ffffff;
+  border: 1px solid #dbe4ee;
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.06);
+}
+
+.farm-dashboard-panel__header,
+.farm-dashboard-attention__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.farm-dashboard-panel__title {
+  margin: 0;
+  font-size: 1.2rem;
+  color: #0f172a;
+}
+
+.farm-dashboard-panel__mini-label {
+  display: inline-flex;
+  margin-bottom: 0.6rem;
+  color: #64748b;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.farm-dashboard-panel__hint,
+.farm-dashboard-panel__description {
+  margin: 0;
+  color: #475569;
+  font-size: 0.95rem;
+  line-height: 1.55;
+}
+
+.farm-dashboard-panel__body-copy {
+  margin-top: 1rem;
+}
+
+.farm-dashboard-panel__link {
+  display: inline-flex;
+  align-items: center;
+  margin-top: 1rem;
+  font-weight: 700;
+  color: #0f766e;
+  text-decoration: none;
+}
+
+.farm-dashboard-panel__link:hover,
+.farm-dashboard-panel__link:focus-visible {
+  color: #0b5f59;
+}
+
+.farm-dashboard-stat-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.75rem;
+}
+
+.farm-dashboard-stat {
+  padding: 0.95rem;
+  border-radius: 0.9rem;
+  background-color: #f8fafc;
+  border: 1px solid #e2e8f0;
+}
+
+.farm-dashboard-stat__label {
+  display: block;
+  margin-bottom: 0.25rem;
+  color: #64748b;
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.farm-dashboard-stat__value {
+  color: #0f172a;
+  font-size: 1.2rem;
+}
+
+.farm-dashboard-tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.farm-dashboard-tag {
+  display: inline-flex;
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: #eefbf4;
+  color: #0f766e;
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.farm-dashboard-alert-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.farm-dashboard-alert-card {
+  padding: 1rem;
+  border-radius: 0.9rem;
+  border: 1px solid transparent;
+}
+
+.farm-dashboard-alert-card--warning {
+  background-color: #fff7ed;
+  border-color: #fdba74;
+}
+
+.farm-dashboard-alert-card--info {
+  background-color: #eff6ff;
+  border-color: #93c5fd;
+}
+
+.farm-dashboard-alert-card--neutral {
+  background-color: #f8fafc;
+  border-color: #cbd5e1;
+}
+
+.farm-dashboard-alert-card__label {
+  display: block;
+  margin-bottom: 0.35rem;
+  font-size: 0.85rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #475569;
+}
+
+.farm-dashboard-alert-card__value {
+  display: block;
+  margin-bottom: 0.35rem;
+  font-size: 1.4rem;
+  color: #0f172a;
+}
+
+.farm-dashboard-alert-card__description {
+  margin: 0;
+  color: #475569;
+  font-size: 0.93rem;
+  line-height: 1.45;
+}
+
+.farm-dashboard-agenda-list,
+.farm-dashboard-attention__list {
+  display: grid;
+  gap: 0.75rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.farm-dashboard-agenda-item,
+.farm-dashboard-attention__item {
+  padding: 0.95rem 1rem;
+  border-radius: 0.9rem;
+  border: 1px solid #dbe4ee;
+  background-color: #f8fafc;
+}
+
+.farm-dashboard-agenda-item--today {
+  border-color: #f59e0b;
+  background-color: #fff7ed;
+}
+
+.farm-dashboard-agenda-item--overdue {
+  border-color: #ef4444;
+  background-color: #fef2f2;
+}
+
+.farm-dashboard-agenda-item--upcoming {
+  border-color: #93c5fd;
+  background-color: #eff6ff;
+}
+
+.farm-dashboard-agenda-item__badge {
+  display: inline-flex;
+  margin-bottom: 0.45rem;
+  color: #0f766e;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.farm-dashboard-agenda-item__title {
+  margin: 0 0 0.25rem;
+  color: #0f172a;
+  font-size: 1rem;
+}
+
+.farm-dashboard-agenda-item__meta {
+  margin: 0;
+  color: #475569;
+  font-size: 0.92rem;
+}
+
+.farm-dashboard-attention {
+  margin-top: 1.25rem;
+}
+
+.farm-dashboard-attention__item {
+  position: relative;
+  padding-left: 1.25rem;
+}
+
+.farm-dashboard-attention__item::before {
+  content: "";
+  position: absolute;
+  top: 1.2rem;
+  left: 0.65rem;
+  width: 0.38rem;
+  height: 0.38rem;
+  border-radius: 999px;
+  background-color: #10b981;
 }
 
 .farm-dashboard-actions {
@@ -178,7 +450,7 @@
 
 .farm-dashboard-action-card__content h2 {
   margin: 0 0 0.35rem;
-  font-size: 1.15rem;
+  font-size: 1.1rem;
 }
 
 .farm-dashboard-action-card__content p {
@@ -191,21 +463,15 @@
   font-size: 1rem;
 }
 
-.farm-dashboard-loading {
-  margin-top: 1rem;
-  padding: 0.95rem 1rem;
-  border-radius: 0.85rem;
-  background-color: #eff6ff;
-  color: #1d4ed8;
-  font-weight: 600;
+@media (max-width: 1080px) {
+  .farm-dashboard-section-grid,
+  .farm-dashboard-actions,
+  .farm-dashboard-alert-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (max-width: 960px) {
-  .farm-dashboard-metrics,
-  .farm-dashboard-actions {
-    grid-template-columns: 1fr;
-  }
-
   .farm-dashboard-hero {
     grid-template-columns: 1fr;
   }
@@ -217,10 +483,12 @@
 
 @media (max-width: 640px) {
   .farm-dashboard-page__content {
-    padding: 0 1rem 1.5rem;
+    padding: 0 1rem 1.75rem;
   }
 
   .farm-dashboard-hero,
+  .farm-dashboard-panel,
+  .farm-dashboard-attention,
   .farm-dashboard-action-card {
     padding: 1rem;
   }
@@ -231,5 +499,9 @@
 
   .farm-dashboard-action-card__arrow {
     display: none;
+  }
+
+  .farm-dashboard-hero__highlights {
+    flex-direction: column;
   }
 }

--- a/src/Pages/dashboard/FarmDashboardPage.test.tsx
+++ b/src/Pages/dashboard/FarmDashboardPage.test.tsx
@@ -1,0 +1,203 @@
+﻿import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import type { FarmDashboardData } from "./FarmDashboardPage";
+import { FarmDashboardPageView } from "./FarmDashboardPage";
+
+vi.mock("../../Components/pages-headers/GoatFarmHeader", () => ({
+  default: ({ name }: { name: string }) => <div>{name}</div>,
+}));
+
+vi.mock("../../Components/pages-headers/ContextBreadcrumb", () => ({
+  default: ({ items }: { items: Array<{ label: string }> }) => (
+    <nav>{items.map((item) => item.label).join(" > ")}</nav>
+  ),
+}));
+
+describe("FarmDashboardPageView", () => {
+  const baseData: FarmDashboardData = {
+    farmData: {
+      id: 7,
+      name: "Capril Vilar",
+      tod: "12345",
+      createdAt: "2026-01-01",
+      updatedAt: "2026-03-11",
+      userId: 1,
+      userName: "Alberto",
+      userEmail: "alberto@example.com",
+      userCpf: "00000000000",
+      addressId: 11,
+      street: "Rua A",
+      district: "Centro",
+      city: "Belo Horizonte",
+      state: "MG",
+      cep: "30100-000",
+      phones: [],
+      logoUrl: "",
+    },
+    herdSummary: {
+      total: 128,
+      males: 19,
+      females: 109,
+      active: 117,
+      inactive: 4,
+      sold: 5,
+      deceased: 2,
+      breeds: [
+        { breed: "Saanen", count: 48 },
+        { breed: "Boer", count: 32 },
+      ],
+    },
+    reproductionAlerts: {
+      totalPending: 3,
+      alerts: [],
+    },
+    lactationAlerts: {
+      totalPending: 2,
+      alerts: [],
+    },
+    healthAlerts: {
+      dueTodayCount: 1,
+      upcomingCount: 4,
+      overdueCount: 1,
+      dueTodayTop: [
+        {
+          id: 501,
+          farmId: 7,
+          goatId: "GOAT-001",
+          type: "VACINA",
+          status: "AGENDADO",
+          title: "Vacina clostridial",
+          scheduledDate: "2026-03-11",
+          overdue: false,
+        },
+      ],
+      upcomingTop: [
+        {
+          id: 502,
+          farmId: 7,
+          goatId: "GOAT-003",
+          type: "VERMIFUGACAO",
+          status: "AGENDADO",
+          title: "Vermifugação",
+          scheduledDate: "2026-03-13",
+          overdue: false,
+        },
+      ],
+      overdueTop: [
+        {
+          id: 503,
+          farmId: 7,
+          goatId: "GOAT-002",
+          type: "MEDICACAO",
+          status: "AGENDADO",
+          title: "Medicamento pós-parto",
+          scheduledDate: "2026-03-09",
+          overdue: true,
+        },
+      ],
+    },
+    inventoryItems: {
+      content: [{ id: 11, name: "Ração", trackLot: true, active: true }],
+      page: {
+        number: 0,
+        size: 1,
+        totalElements: 14,
+        totalPages: 14,
+      },
+    },
+    inventoryBalances: {
+      content: [
+        { itemId: 11, itemName: "Ração", trackLot: true, lotId: 99, quantity: 120 },
+      ],
+      page: {
+        number: 0,
+        size: 5,
+        totalElements: 6,
+        totalPages: 2,
+      },
+    },
+    inventoryMovements: {
+      content: [
+        {
+          movementId: 800,
+          type: "OUT",
+          quantity: 5,
+          itemId: 11,
+          itemName: "Ração",
+          movementDate: "2026-03-10",
+          resultingBalance: 120,
+          createdAt: "2026-03-10T10:00:00Z",
+        },
+      ],
+      page: {
+        number: 0,
+        size: 1,
+        totalElements: 38,
+        totalPages: 38,
+      },
+    },
+  };
+
+  it("renders the loading state", () => {
+    const html = renderToStaticMarkup(
+      <MemoryRouter>
+        <FarmDashboardPageView
+          farmIdNumber={7}
+          data={null}
+          loading={true}
+          error={null}
+          sectionErrors={{}}
+          onRetry={() => {}}
+        />
+      </MemoryRouter>
+    );
+
+    expect(html).toContain("Carregando dashboard da fazenda");
+  });
+
+  it("renders the error state with retry copy", () => {
+    const html = renderToStaticMarkup(
+      <MemoryRouter>
+        <FarmDashboardPageView
+          farmIdNumber={7}
+          data={null}
+          loading={false}
+          error="Falha ao carregar a fazenda"
+          sectionErrors={{}}
+          onRetry={() => {}}
+        />
+      </MemoryRouter>
+    );
+
+    expect(html).toContain("Não foi possível carregar a dashboard da fazenda");
+    expect(html).toContain("Falha ao carregar a fazenda");
+    expect(html).toContain("Tentar novamente");
+  });
+
+  it("renders the management blocks and navigation links", () => {
+    const html = renderToStaticMarkup(
+      <MemoryRouter>
+        <FarmDashboardPageView
+          farmIdNumber={7}
+          data={baseData}
+          loading={false}
+          error={null}
+          sectionErrors={{}}
+          onRetry={() => {}}
+        />
+      </MemoryRouter>
+    );
+
+    expect(html).toContain("Indicadores do rebanho");
+    expect(html).toContain("Alertas resumidos");
+    expect(html).toContain("Agenda sanitária da fazenda");
+    expect(html).toContain("Estoque em resumo");
+    expect(html).toContain("O que precisa da sua atenção hoje");
+    expect(html).toContain('href="/app/goatfarms/7/alerts"');
+    expect(html).toContain('href="/app/goatfarms/7/health-agenda"');
+    expect(html).toContain('href="/app/goatfarms/7/inventory"');
+    expect(html).toContain('href="/cabras?farmId=7"');
+  });
+});
+

--- a/src/Pages/dashboard/FarmDashboardPage.tsx
+++ b/src/Pages/dashboard/FarmDashboardPage.tsx
@@ -1,21 +1,37 @@
-import { useEffect, useMemo, useState } from "react";
+﻿import { useCallback, useEffect, useMemo, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { getGoatFarmById } from "../../api/GoatFarmAPI/goatFarm";
-import { findGoatsByFarmIdPaginated } from "../../api/GoatAPI/goat";
-import GoatFarmHeader from "../../Components/pages-headers/GoatFarmHeader";
+import { healthAPI } from "../../api/GoatFarmAPI/health";
+import { listInventoryBalances, listInventoryItems, listInventoryMovements } from "../../api/GoatFarmAPI/inventory";
+import { getFarmDryOffAlerts } from "../../api/GoatFarmAPI/lactation";
+import { getFarmPregnancyDiagnosisAlerts } from "../../api/GoatFarmAPI/reproduction";
+import { fetchGoatHerdSummary } from "../../api/GoatAPI/goat";
 import ContextBreadcrumb from "../../Components/pages-headers/ContextBreadcrumb";
+import GoatFarmHeader from "../../Components/pages-headers/GoatFarmHeader";
+import { Alert, EmptyState, ErrorState, LoadingState } from "../../Components/ui";
+import type { HealthAlertsDTO } from "../../Models/HealthAlertsDTO";
+import type { HealthEventResponseDTO } from "../../Models/HealthDTOs";
+import type { InventoryBalancesPage, InventoryItemsPage, InventoryMovementHistoryPage } from "../../Models/InventoryDTOs";
+import type { LactationDryOffAlertResponseDTO } from "../../Models/LactationDTOs";
 import type { GoatFarmDTO } from "../../Models/goatFarm";
+import type { GoatHerdSummaryDTO } from "../../Models/GoatHerdSummaryDTO";
+import type { PregnancyDiagnosisAlertResponseDTO } from "../../Models/ReproductionDTOs";
 import {
   buildFarmAlertsPath,
   buildFarmGoatsPath,
   buildFarmHealthAgendaPath,
   buildFarmInventoryPath,
 } from "../../utils/appRoutes";
+import { getApiErrorMessage, parseApiError } from "../../utils/apiError";
 import "./FarmDashboardPage.css";
 
-type FarmMetric = {
+type FarmDashboardSectionKey = "herd" | "alerts" | "agenda" | "inventory";
+type FarmDashboardSectionErrors = Partial<Record<FarmDashboardSectionKey, string>>;
+
+type FarmDashboardMetric = {
   label: string;
   value: string;
+  helper: string;
   icon: string;
 };
 
@@ -27,182 +43,649 @@ type FarmActionCard = {
   tone: "primary" | "secondary";
 };
 
-export default function FarmDashboardPage() {
-  const { farmId } = useParams<{ farmId: string }>();
-  const farmIdNumber = useMemo(() => Number(farmId), [farmId]);
-  const [farmData, setFarmData] = useState<GoatFarmDTO | null>(null);
-  const [totalGoats, setTotalGoats] = useState<number | null>(null);
-  const [loading, setLoading] = useState(true);
+type FarmAgendaEntry = {
+  title: string;
+  goatId: string;
+  scheduledDate: string;
+  badge: string;
+  tone: "today" | "overdue" | "upcoming";
+};
 
-  useEffect(() => {
-    if (Number.isNaN(farmIdNumber)) {
-      setLoading(false);
-      return;
-    }
+export interface FarmDashboardData {
+  farmData: GoatFarmDTO;
+  herdSummary: GoatHerdSummaryDTO | null;
+  reproductionAlerts: PregnancyDiagnosisAlertResponseDTO | null;
+  lactationAlerts: LactationDryOffAlertResponseDTO | null;
+  healthAlerts: HealthAlertsDTO | null;
+  inventoryItems: InventoryItemsPage | null;
+  inventoryBalances: InventoryBalancesPage | null;
+  inventoryMovements: InventoryMovementHistoryPage | null;
+}
 
-    let cancelled = false;
+export interface FarmDashboardPageViewProps {
+  farmIdNumber: number;
+  data: FarmDashboardData | null;
+  loading: boolean;
+  error: string | null;
+  sectionErrors: FarmDashboardSectionErrors;
+  onRetry: () => void;
+}
 
-    const loadContext = async () => {
-      try {
-        const [farm, goatPage] = await Promise.all([
-          getGoatFarmById(farmIdNumber),
-          findGoatsByFarmIdPaginated(farmIdNumber, 0, 1),
-        ]);
+const INVENTORY_MOVEMENT_LABELS: Record<string, string> = {
+  IN: "Entrada",
+  OUT: "Saída",
+  ADJUST: "Ajuste",
+};
 
-        if (cancelled) {
-          return;
-        }
+const resolveErrorMessage = (error: unknown): string =>
+  getApiErrorMessage(parseApiError(error));
 
-        setFarmData(farm);
-        setTotalGoats(goatPage.totalElements ?? goatPage.content.length);
-      } catch (error) {
-        console.error("Erro ao carregar o dashboard da fazenda", error);
-      } finally {
-        if (!cancelled) {
-          setLoading(false);
-        }
-      }
-    };
+const formatCount = (value?: number | null): string =>
+  typeof value === "number" ? new Intl.NumberFormat("pt-BR").format(value) : "--";
 
-    void loadContext();
+const formatLocalDate = (value?: string | null): string => {
+  if (!value) {
+    return "Data não informada";
+  }
 
-    return () => {
-      cancelled = true;
-    };
-  }, [farmIdNumber]);
+  const datePart = value.includes("T") ? value.slice(0, 10) : value;
+  const parts = datePart.split("-");
 
-  if (Number.isNaN(farmIdNumber)) {
-    return (
-      <div className="farm-dashboard-page">
-        <div className="alert alert-danger">Identificador da fazenda inválido.</div>
-      </div>
+  if (parts.length === 3) {
+    return `${parts[2]}/${parts[1]}/${parts[0]}`;
+  }
+
+  return value;
+};
+
+const buildAgendaEntries = (healthAlerts: HealthAlertsDTO | null): FarmAgendaEntry[] => {
+  if (!healthAlerts) {
+    return [];
+  }
+
+  const mapEvent = (
+    event: HealthEventResponseDTO,
+    badge: string,
+    tone: FarmAgendaEntry["tone"]
+  ): FarmAgendaEntry => ({
+    title: event.title || "Evento sanitário",
+    goatId: event.goatId,
+    scheduledDate: event.scheduledDate,
+    badge,
+    tone,
+  });
+
+  return [
+    ...healthAlerts.dueTodayTop.map((event) => mapEvent(event, "Hoje", "today")),
+    ...healthAlerts.overdueTop.map((event) => mapEvent(event, "Atrasado", "overdue")),
+    ...healthAlerts.upcomingTop.map((event) => mapEvent(event, "Próximo", "upcoming")),
+  ].slice(0, 4);
+};
+
+const buildAttentionItems = (data: FarmDashboardData | null): string[] => {
+  if (!data) {
+    return [];
+  }
+
+  const items: string[] = [];
+  const reproductionPending = data.reproductionAlerts?.totalPending ?? 0;
+  const lactationPending = data.lactationAlerts?.totalPending ?? 0;
+  const dueToday = data.healthAlerts?.dueTodayCount ?? 0;
+  const overdue = data.healthAlerts?.overdueCount ?? 0;
+  const upcoming = data.healthAlerts?.upcomingCount ?? 0;
+
+  if (reproductionPending > 0) {
+    items.push(
+      `${formatCount(reproductionPending)} diagnóstico${reproductionPending === 1 ? "" : "s"} de prenhez pendente${reproductionPending === 1 ? "" : "s"}.`
     );
   }
 
-  const farmName = farmData?.name || "Fazenda";
-  const metrics: FarmMetric[] = [
+  if (lactationPending > 0) {
+    items.push(
+      `${formatCount(lactationPending)} secagem${lactationPending === 1 ? "" : "s"} recomendada${lactationPending === 1 ? "" : "s"}.`
+    );
+  }
+
+  if (dueToday > 0) {
+    items.push(
+      `${formatCount(dueToday)} evento${dueToday === 1 ? "" : "s"} sanitário${dueToday === 1 ? "" : "s"} para hoje.`
+    );
+  }
+
+  if (overdue > 0) {
+    items.push(
+      `${formatCount(overdue)} evento${overdue === 1 ? "" : "s"} sanitário${overdue === 1 ? "" : "s"} atrasado${overdue === 1 ? "" : "s"}.`
+    );
+  }
+
+  if (items.length === 0 && upcoming > 0) {
+    items.push(
+      `${formatCount(upcoming)} evento${upcoming === 1 ? "" : "s"} sanitário${upcoming === 1 ? "" : "s"} chegando nos próximos 7 dias.`
+    );
+  }
+
+  return items;
+};
+
+export function FarmDashboardPageView({
+  farmIdNumber,
+  data,
+  loading,
+  error,
+  sectionErrors,
+  onRetry,
+}: FarmDashboardPageViewProps) {
+  const safeFarmId = Number.isFinite(farmIdNumber) && farmIdNumber > 0 ? farmIdNumber : 0;
+  const farmName = data?.farmData.name || "Fazenda";
+  const farmLocation = [data?.farmData.city, data?.farmData.state].filter(Boolean).join(" • ");
+  const herdSummary = data?.herdSummary ?? null;
+  const reproductionPending = data?.reproductionAlerts?.totalPending ?? 0;
+  const lactationPending = data?.lactationAlerts?.totalPending ?? 0;
+  const healthDueToday = data?.healthAlerts?.dueTodayCount ?? 0;
+  const healthOverdue = data?.healthAlerts?.overdueCount ?? 0;
+  const healthUpcoming = data?.healthAlerts?.upcomingCount ?? 0;
+  const totalAttention = reproductionPending + lactationPending + healthDueToday + healthOverdue;
+  const agendaEntries = useMemo(() => buildAgendaEntries(data?.healthAlerts ?? null), [data?.healthAlerts]);
+  const attentionItems = useMemo(() => buildAttentionItems(data), [data]);
+  const breeds = herdSummary?.breeds?.slice(0, 3) ?? [];
+  const inventoryItemsCount = data?.inventoryItems?.page.totalElements;
+  const inventoryBalancesCount = data?.inventoryBalances?.page.totalElements;
+  const inventoryMovementsCount = data?.inventoryMovements?.page.totalElements;
+  const latestMovement = data?.inventoryMovements?.content?.[0] ?? null;
+
+  const metrics: FarmDashboardMetric[] = [
     {
-      label: "Rebanho",
-      value: totalGoats == null ? "..." : `${totalGoats}`,
-      icon: "fa-solid fa-cow",
+      label: "Animais",
+      value: formatCount(herdSummary?.total),
+      helper: "Total cadastrado no rebanho",
+      icon: "fa-solid fa-goat",
     },
     {
-      label: "Contexto",
-      value: "Gestão da propriedade",
-      icon: "fa-solid fa-tractor",
+      label: "Ativos",
+      value: formatCount(herdSummary?.active),
+      helper: "Animais ativos na fazenda",
+      icon: "fa-solid fa-shield-heart",
     },
     {
-      label: "Acesso rápido",
-      value: "Estoque, alertas e agenda",
-      icon: "fa-solid fa-bolt",
+      label: "Fêmeas / Machos",
+      value:
+        herdSummary != null
+          ? `${formatCount(herdSummary.females)} / ${formatCount(herdSummary.males)}`
+          : "--",
+      helper: "Distribuição básica do plantel",
+      icon: "fa-solid fa-venus-mars",
+    },
+    {
+      label: "Atenção hoje",
+      value: formatCount(totalAttention),
+      helper:
+        totalAttention > 0
+          ? "Pendências que merecem ação agora"
+          : "Sem pendências críticas no momento",
+      icon: "fa-solid fa-bell",
     },
   ];
 
   const actionCards: FarmActionCard[] = [
     {
-      title: "Estoque",
-      description: "Cadastre produtos, acompanhe saldos e registre movimentações da fazenda.",
-      icon: "fa-solid fa-boxes-stacked",
-      to: buildFarmInventoryPath(farmIdNumber),
+      title: "Alertas",
+      description: "Veja reprodução, lactação e sanidade com foco no que está pendente agora.",
+      icon: "fa-solid fa-bell",
+      to: buildFarmAlertsPath(safeFarmId),
       tone: "primary",
     },
     {
-      title: "Rebanho",
-      description: "Acesse a lista de animais da fazenda e entre no detalhe de cada cabra.",
-      icon: "fa-solid fa-goat",
-      to: buildFarmGoatsPath(farmIdNumber),
-      tone: "secondary",
-    },
-    {
-      title: "Alertas",
-      description: "Concentre pendências de reprodução, leite e sanidade em um só lugar.",
-      icon: "fa-solid fa-bell",
-      to: buildFarmAlertsPath(farmIdNumber),
-      tone: "secondary",
-    },
-    {
-      title: "Agenda da Fazenda",
-      description: "Acompanhe compromissos sanitários e próximos eventos do rebanho.",
+      title: "Agenda sanitária",
+      description: "Abra a agenda da fazenda e acompanhe o recorte operacional já disponível hoje.",
       icon: "fa-solid fa-calendar-days",
-      to: buildFarmHealthAgendaPath(farmIdNumber),
+      to: buildFarmHealthAgendaPath(safeFarmId),
+      tone: "secondary",
+    },
+    {
+      title: "Estoque",
+      description: "Consulte itens, saldos e movimentações recentes sem sair do contexto da fazenda.",
+      icon: "fa-solid fa-boxes-stacked",
+      to: buildFarmInventoryPath(safeFarmId),
+      tone: "secondary",
+    },
+    {
+      title: "Rebanho",
+      description: "Acesse a lista de animais da fazenda e siga para os módulos por cabra quando precisar.",
+      icon: "fa-solid fa-tractor",
+      to: buildFarmGoatsPath(safeFarmId),
       tone: "secondary",
     },
   ];
 
-  return (
-    <div className="farm-dashboard-page">
-      <GoatFarmHeader
-        name={farmName}
-        logoUrl={farmData?.logoUrl}
-        farmId={farmIdNumber}
+  const content = loading ? (
+    <LoadingState label="Carregando dashboard da fazenda..." />
+  ) : error ? (
+    <ErrorState
+      title="Não foi possível carregar a dashboard da fazenda"
+      description={error}
+      onRetry={onRetry}
+    />
+  ) : (
+    <>
+      <ContextBreadcrumb
+        items={[
+          { label: "Fazendas", to: "/goatfarms" },
+          { label: farmName, to: buildFarmGoatsPath(safeFarmId) },
+          { label: "Dashboard da Fazenda" },
+        ]}
       />
 
-      <div className="farm-dashboard-page__content">
-        <ContextBreadcrumb
-          items={[
-            { label: "Fazendas", to: "/goatfarms" },
-            { label: farmName, to: buildFarmGoatsPath(farmIdNumber) },
-            { label: "Dashboard da Fazenda" },
-          ]}
-        />
+      <section className="farm-dashboard-hero" aria-label="Resumo da fazenda">
+        <div>
+          <span className="farm-dashboard-hero__eyebrow">Gestão da propriedade</span>
+          <h1 className="farm-dashboard-hero__title">{farmName}</h1>
+          <p className="farm-dashboard-hero__description">
+            {farmLocation ? `${farmLocation} • ` : ""}
+            Use esta visão para acompanhar rebanho, alertas, agenda sanitária e estoque
+            sem misturar o contexto da fazenda com o manejo individual de cada animal.
+          </p>
 
-        <section className="farm-dashboard-hero" aria-label="Resumo da fazenda">
-          <div>
-            <span className="farm-dashboard-hero__eyebrow">Gerir a Fazenda</span>
-            <h1 className="farm-dashboard-hero__title">{farmName}</h1>
-            <p className="farm-dashboard-hero__description">
-              Use este hub para ações da propriedade. Estoque, agenda, alertas e
-              gestão do rebanho ficam aqui, separados do manejo de cada animal.
-            </p>
+          <div className="farm-dashboard-hero__highlights">
+            <span className="farm-dashboard-hero__highlight">
+              <strong>{formatCount(reproductionPending + lactationPending)}</strong>
+              alertas reprodutivos e de lactação
+            </span>
+            <span className="farm-dashboard-hero__highlight">
+              <strong>{formatCount(healthDueToday + healthOverdue)}</strong>
+              pontos sanitários em atenção
+            </span>
+            <span className="farm-dashboard-hero__highlight">
+              <strong>{formatCount(inventoryItemsCount)}</strong>
+              itens cadastrados no estoque
+            </span>
+          </div>
+        </div>
+
+        <Link to={buildFarmAlertsPath(safeFarmId)} className="farm-dashboard-hero__cta">
+          Ver alertas da fazenda
+        </Link>
+      </section>
+
+      <section className="farm-dashboard-metrics" aria-label="KPIs da fazenda">
+        {metrics.map((metric) => (
+          <article key={metric.label} className="farm-dashboard-metric-card">
+            <span className="farm-dashboard-metric-card__icon" aria-hidden="true">
+              <i className={metric.icon}></i>
+            </span>
+            <span className="farm-dashboard-metric-card__label">{metric.label}</span>
+            <strong className="farm-dashboard-metric-card__value">{metric.value}</strong>
+            <p className="farm-dashboard-metric-card__helper">{metric.helper}</p>
+          </article>
+        ))}
+      </section>
+
+      <section className="farm-dashboard-section-grid" aria-label="Resumo gerencial da fazenda">
+        <article className="farm-dashboard-panel">
+          <div className="farm-dashboard-panel__header">
+            <div>
+              <span className="farm-dashboard-panel__eyebrow">Rebanho</span>
+              <h2 className="farm-dashboard-panel__title">Indicadores do rebanho</h2>
+            </div>
           </div>
 
-          <Link
-            to={buildFarmInventoryPath(farmIdNumber)}
-            className="farm-dashboard-hero__cta"
-          >
-            Abrir Estoque
-          </Link>
-        </section>
+          {sectionErrors.herd ? (
+            <Alert variant="warning" title="Resumo parcial do rebanho">
+              {sectionErrors.herd}
+            </Alert>
+          ) : null}
 
-        <section className="farm-dashboard-metrics" aria-label="Indicadores da fazenda">
-          {metrics.map((metric) => (
-            <article key={metric.label} className="farm-dashboard-metric-card">
-              <span className="farm-dashboard-metric-card__icon" aria-hidden="true">
-                <i className={metric.icon}></i>
-              </span>
-              <span className="farm-dashboard-metric-card__label">{metric.label}</span>
-              <strong className="farm-dashboard-metric-card__value">{metric.value}</strong>
-            </article>
-          ))}
-        </section>
-
-        <section className="farm-dashboard-actions" aria-label="Ações da fazenda">
-          {actionCards.map((card) => (
-            <Link
-              key={card.title}
-              to={card.to}
-              className={`farm-dashboard-action-card farm-dashboard-action-card--${card.tone}`}
-            >
-              <span className="farm-dashboard-action-card__icon" aria-hidden="true">
-                <i className={card.icon}></i>
-              </span>
-              <div className="farm-dashboard-action-card__content">
-                <h2>{card.title}</h2>
-                <p>{card.description}</p>
+          {herdSummary ? (
+            <>
+              <div className="farm-dashboard-stat-list">
+                <div className="farm-dashboard-stat">
+                  <span className="farm-dashboard-stat__label">Ativos</span>
+                  <strong className="farm-dashboard-stat__value">{formatCount(herdSummary.active)}</strong>
+                </div>
+                <div className="farm-dashboard-stat">
+                  <span className="farm-dashboard-stat__label">Inativos</span>
+                  <strong className="farm-dashboard-stat__value">{formatCount(herdSummary.inactive)}</strong>
+                </div>
+                <div className="farm-dashboard-stat">
+                  <span className="farm-dashboard-stat__label">Vendidos</span>
+                  <strong className="farm-dashboard-stat__value">{formatCount(herdSummary.sold)}</strong>
+                </div>
+                <div className="farm-dashboard-stat">
+                  <span className="farm-dashboard-stat__label">Falecidos</span>
+                  <strong className="farm-dashboard-stat__value">{formatCount(herdSummary.deceased)}</strong>
+                </div>
               </div>
-              <span className="farm-dashboard-action-card__arrow" aria-hidden="true">
-                <i className="fa-solid fa-arrow-right"></i>
-              </span>
-            </Link>
-          ))}
-        </section>
 
-        {loading && (
-          <div className="farm-dashboard-loading" role="status">
-            Carregando dados da fazenda...
+              <div className="farm-dashboard-panel__body-copy">
+                <span className="farm-dashboard-panel__mini-label">Raças mais frequentes</span>
+                {breeds.length > 0 ? (
+                  <div className="farm-dashboard-tag-list">
+                    {breeds.map((breed) => (
+                      <span key={`${breed.breed}-${breed.count}`} className="farm-dashboard-tag">
+                        {breed.breed}: {formatCount(breed.count)}
+                      </span>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="farm-dashboard-panel__hint">Sem distribuição por raça disponível.</p>
+                )}
+              </div>
+
+              <Link to={buildFarmGoatsPath(safeFarmId)} className="farm-dashboard-panel__link">
+                Abrir rebanho
+              </Link>
+            </>
+          ) : (
+            <EmptyState
+              title="Resumo do rebanho indisponível"
+              description="Não foi possível montar os indicadores agregados do rebanho agora."
+              actionLabel="Tentar novamente"
+              onAction={onRetry}
+            />
+          )}
+        </article>
+
+        <article className="farm-dashboard-panel">
+          <div className="farm-dashboard-panel__header">
+            <div>
+              <span className="farm-dashboard-panel__eyebrow">Alertas</span>
+              <h2 className="farm-dashboard-panel__title">Alertas resumidos</h2>
+            </div>
           </div>
+
+          {sectionErrors.alerts ? (
+            <Alert variant="warning" title="Resumo parcial de alertas">
+              {sectionErrors.alerts}
+            </Alert>
+          ) : null}
+
+          <div className="farm-dashboard-alert-grid">
+            <article className="farm-dashboard-alert-card farm-dashboard-alert-card--warning">
+              <span className="farm-dashboard-alert-card__label">Reprodução</span>
+              <strong className="farm-dashboard-alert-card__value">{formatCount(reproductionPending)}</strong>
+              <p className="farm-dashboard-alert-card__description">Diagnósticos de prenhez pendentes.</p>
+            </article>
+            <article className="farm-dashboard-alert-card farm-dashboard-alert-card--info">
+              <span className="farm-dashboard-alert-card__label">Lactação</span>
+              <strong className="farm-dashboard-alert-card__value">{formatCount(lactationPending)}</strong>
+              <p className="farm-dashboard-alert-card__description">Secagens recomendadas pendentes.</p>
+            </article>
+            <article className="farm-dashboard-alert-card farm-dashboard-alert-card--neutral">
+              <span className="farm-dashboard-alert-card__label">Sanidade</span>
+              <strong className="farm-dashboard-alert-card__value">{formatCount(healthDueToday + healthOverdue)}</strong>
+              <p className="farm-dashboard-alert-card__description">
+                {formatCount(healthUpcoming)} próximos nos próximos 7 dias.
+              </p>
+            </article>
+          </div>
+
+          <p className="farm-dashboard-panel__hint">
+            O detalhamento completo continua centralizado na página consolidada de alertas.
+          </p>
+
+          <Link to={buildFarmAlertsPath(safeFarmId)} className="farm-dashboard-panel__link">
+            Ver alertas
+          </Link>
+        </article>
+
+        <article className="farm-dashboard-panel">
+          <div className="farm-dashboard-panel__header">
+            <div>
+              <span className="farm-dashboard-panel__eyebrow">Agenda</span>
+              <h2 className="farm-dashboard-panel__title">Agenda sanitária da fazenda</h2>
+            </div>
+          </div>
+
+          <p className="farm-dashboard-panel__hint">
+            Recorte disponível hoje: sanidade. A agenda ainda não é unificada entre módulos.
+          </p>
+
+          {sectionErrors.agenda ? (
+            <Alert variant="warning" title="Agenda parcial indisponível">
+              {sectionErrors.agenda}
+            </Alert>
+          ) : null}
+
+          {agendaEntries.length > 0 ? (
+            <ul className="farm-dashboard-agenda-list">
+              {agendaEntries.map((entry) => (
+                <li key={`${entry.goatId}-${entry.title}-${entry.scheduledDate}`} className={`farm-dashboard-agenda-item farm-dashboard-agenda-item--${entry.tone}`}>
+                  <div>
+                    <span className="farm-dashboard-agenda-item__badge">{entry.badge}</span>
+                    <h3 className="farm-dashboard-agenda-item__title">{entry.title}</h3>
+                    <p className="farm-dashboard-agenda-item__meta">
+                      Cabra {entry.goatId} • {formatLocalDate(entry.scheduledDate)}
+                    </p>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <EmptyState
+              title="Sem agenda sanitária imediata"
+              description="Não há itens sanitários em destaque para hoje e próximos dias."
+            />
+          )}
+
+          <Link to={buildFarmHealthAgendaPath(safeFarmId)} className="farm-dashboard-panel__link">
+            Abrir agenda
+          </Link>
+        </article>
+
+        <article className="farm-dashboard-panel">
+          <div className="farm-dashboard-panel__header">
+            <div>
+              <span className="farm-dashboard-panel__eyebrow">Estoque</span>
+              <h2 className="farm-dashboard-panel__title">Estoque em resumo</h2>
+            </div>
+          </div>
+
+          {sectionErrors.inventory ? (
+            <Alert variant="warning" title="Resumo parcial de estoque">
+              {sectionErrors.inventory}
+            </Alert>
+          ) : null}
+
+          <div className="farm-dashboard-stat-list">
+            <div className="farm-dashboard-stat">
+              <span className="farm-dashboard-stat__label">Itens</span>
+              <strong className="farm-dashboard-stat__value">{formatCount(inventoryItemsCount)}</strong>
+            </div>
+            <div className="farm-dashboard-stat">
+              <span className="farm-dashboard-stat__label">Saldos ativos</span>
+              <strong className="farm-dashboard-stat__value">{formatCount(inventoryBalancesCount)}</strong>
+            </div>
+            <div className="farm-dashboard-stat">
+              <span className="farm-dashboard-stat__label">Movimentos</span>
+              <strong className="farm-dashboard-stat__value">{formatCount(inventoryMovementsCount)}</strong>
+            </div>
+          </div>
+
+          <div className="farm-dashboard-panel__body-copy">
+            <span className="farm-dashboard-panel__mini-label">Último movimento</span>
+            {latestMovement ? (
+              <p className="farm-dashboard-panel__description">
+                {INVENTORY_MOVEMENT_LABELS[latestMovement.type] || latestMovement.type} • {latestMovement.itemName} • {formatLocalDate(latestMovement.movementDate)}
+              </p>
+            ) : (
+              <p className="farm-dashboard-panel__description">
+                Nenhuma movimentação recente disponível para resumo.
+              </p>
+            )}
+          </div>
+
+          <Link to={buildFarmInventoryPath(safeFarmId)} className="farm-dashboard-panel__link">
+            Abrir estoque
+          </Link>
+        </article>
+      </section>
+
+      <section className="farm-dashboard-attention" aria-label="Atenção hoje">
+        <div className="farm-dashboard-attention__header">
+          <div>
+            <span className="farm-dashboard-panel__eyebrow">Foco do dia</span>
+            <h2 className="farm-dashboard-panel__title">O que precisa da sua atenção hoje</h2>
+          </div>
+        </div>
+
+        {attentionItems.length > 0 ? (
+          <ul className="farm-dashboard-attention__list">
+            {attentionItems.map((item) => (
+              <li key={item} className="farm-dashboard-attention__item">
+                {item}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <EmptyState
+            title="Sem alertas críticos agora"
+            description="A fazenda está sem pendências críticas nesta visão resumida."
+          />
         )}
-      </div>
+      </section>
+
+      <section className="farm-dashboard-actions" aria-label="Ações da fazenda">
+        {actionCards.map((card) => (
+          <Link
+            key={card.title}
+            to={card.to}
+            className={`farm-dashboard-action-card farm-dashboard-action-card--${card.tone}`}
+          >
+            <span className="farm-dashboard-action-card__icon" aria-hidden="true">
+              <i className={card.icon}></i>
+            </span>
+            <div className="farm-dashboard-action-card__content">
+              <h2>{card.title}</h2>
+              <p>{card.description}</p>
+            </div>
+            <span className="farm-dashboard-action-card__arrow" aria-hidden="true">
+              <i className="fa-solid fa-arrow-right"></i>
+            </span>
+          </Link>
+        ))}
+      </section>
+    </>
+  );
+
+  return (
+    <div className="farm-dashboard-page">
+      <GoatFarmHeader name={farmName} logoUrl={data?.farmData.logoUrl} farmId={safeFarmId} />
+
+      <div className="farm-dashboard-page__content">{content}</div>
     </div>
   );
 }
+
+export default function FarmDashboardPage() {
+  const { farmId } = useParams();
+  const farmIdNumber = Number(farmId);
+  const [data, setData] = useState<FarmDashboardData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [sectionErrors, setSectionErrors] = useState<FarmDashboardSectionErrors>({});
+
+  const loadDashboard = useCallback(async () => {
+    if (!Number.isFinite(farmIdNumber) || farmIdNumber <= 0) {
+      setLoading(false);
+      setError("Identificador da fazenda inválido.");
+      setData(null);
+      setSectionErrors({});
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    const results = await Promise.allSettled([
+      getGoatFarmById(farmIdNumber),
+      fetchGoatHerdSummary(farmIdNumber),
+      getFarmPregnancyDiagnosisAlerts(farmIdNumber, { page: 0, size: 5 }),
+      getFarmDryOffAlerts(farmIdNumber, { page: 0, size: 5 }),
+      healthAPI.getAlerts(farmIdNumber, 7),
+      listInventoryItems(farmIdNumber, 0, 1, true),
+      listInventoryBalances(farmIdNumber, { page: 0, size: 5, activeOnly: true }),
+      listInventoryMovements(farmIdNumber, { page: 0, size: 1, sort: "movementDate,desc" }),
+    ]);
+
+    const [
+      farmResult,
+      herdResult,
+      reproductionResult,
+      lactationResult,
+      healthResult,
+      inventoryItemsResult,
+      inventoryBalancesResult,
+      inventoryMovementsResult,
+    ] = results;
+
+    if (farmResult.status !== "fulfilled") {
+      setData(null);
+      setSectionErrors({});
+      setError(resolveErrorMessage(farmResult.reason));
+      setLoading(false);
+      return;
+    }
+
+    const nextSectionErrors: FarmDashboardSectionErrors = {};
+
+    if (herdResult.status !== "fulfilled") {
+      nextSectionErrors.herd = resolveErrorMessage(herdResult.reason);
+    }
+
+    if (
+      reproductionResult.status !== "fulfilled" ||
+      lactationResult.status !== "fulfilled" ||
+      healthResult.status !== "fulfilled"
+    ) {
+      nextSectionErrors.alerts = "Parte do resumo de alertas não pôde ser carregada agora.";
+    }
+
+    if (healthResult.status !== "fulfilled") {
+      nextSectionErrors.agenda = resolveErrorMessage(healthResult.reason);
+    }
+
+    if (
+      inventoryItemsResult.status !== "fulfilled" ||
+      inventoryBalancesResult.status !== "fulfilled" ||
+      inventoryMovementsResult.status !== "fulfilled"
+    ) {
+      nextSectionErrors.inventory = "Parte do resumo de estoque não pôde ser carregada agora.";
+    }
+
+    setData({
+      farmData: farmResult.value,
+      herdSummary: herdResult.status === "fulfilled" ? herdResult.value : null,
+      reproductionAlerts:
+        reproductionResult.status === "fulfilled" ? reproductionResult.value : null,
+      lactationAlerts: lactationResult.status === "fulfilled" ? lactationResult.value : null,
+      healthAlerts: healthResult.status === "fulfilled" ? healthResult.value : null,
+      inventoryItems:
+        inventoryItemsResult.status === "fulfilled" ? inventoryItemsResult.value : null,
+      inventoryBalances:
+        inventoryBalancesResult.status === "fulfilled"
+          ? inventoryBalancesResult.value
+          : null,
+      inventoryMovements:
+        inventoryMovementsResult.status === "fulfilled"
+          ? inventoryMovementsResult.value
+          : null,
+    });
+    setSectionErrors(nextSectionErrors);
+    setLoading(false);
+  }, [farmIdNumber]);
+
+  useEffect(() => {
+    void loadDashboard();
+  }, [loadDashboard]);
+
+  return (
+    <FarmDashboardPageView
+      farmIdNumber={farmIdNumber}
+      data={data}
+      loading={loading}
+      error={error}
+      sectionErrors={sectionErrors}
+      onRetry={loadDashboard}
+    />
+  );
+}
+


### PR DESCRIPTION
## Summary
- evolve the existing farm dashboard into a management-oriented overview
- reuse herd, alerts, health agenda and inventory APIs without adding backend endpoints
- add dashboard view tests and frontend documentation

## Testing
- npm test -- --run
- npm run build
- npm run lint
- npm run test:e2e