### PR TITLE
feat: unify farm operational agenda

### DIFF
--- a/docs/FARM_OPERATIONAL_AGENDA.md
+++ b/docs/FARM_OPERATIONAL_AGENDA.md
@@ -1,0 +1,24 @@
+﻿# Agenda operacional da fazenda
+
+## Estratégia incremental adotada
+
+A agenda da fazenda passou a combinar sinais já existentes de três fontes:
+
+- sanidade: `GET /api/v1/goatfarms/{farmId}/health-events/alerts`
+- reprodução: `GET /api/v1/goatfarms/{farmId}/reproduction/alerts/pregnancy-diagnosis`
+- lactação: `GET /api/v1/goatfarms/{farmId}/milk/alerts/dry-off`
+
+A implementação permanece `frontend-only` neste estágio porque o backend já expõe os dados necessários para um resumo operacional útil.
+
+## O que a tela entrega agora
+
+- contadores por origem: sanidade, reprodução e lactação
+- total consolidado de itens em atenção
+- lista resumida com os próximos itens relevantes
+- filtro rápido por origem
+- CTA para alertas consolidados
+- aviso explícito de que a tabela detalhada abaixo continua sanitária
+
+## Limite funcional atual
+
+A agenda ainda não é um calendário unificado completo entre módulos. O detalhamento acionável continua sanitário, enquanto reprodução e lactação entram como resumo operacional com links para suas telas próprias.

--- a/src/Pages/health/FarmHealthAgendaPage.tsx
+++ b/src/Pages/health/FarmHealthAgendaPage.tsx
@@ -1,11 +1,12 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+﻿import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { toast } from "react-toastify";
-import { useAuth } from "../../contexts/AuthContext";
-import { RoleEnum } from "../../Models/auth";
-import { PermissionService } from "../../services/PermissionService";
-import { healthAPI } from "../../api/GoatFarmAPI/health";
+import { getFarmDryOffAlerts } from "../../api/GoatFarmAPI/lactation";
 import { getGoatFarmById } from "../../api/GoatFarmAPI/goatFarm";
+import { healthAPI } from "../../api/GoatFarmAPI/health";
+import { getFarmPregnancyDiagnosisAlerts } from "../../api/GoatFarmAPI/reproduction";
+import GoatFarmHeader from "../../Components/pages-headers/GoatFarmHeader";
+import { useAuth } from "../../contexts/AuthContext";
 import {
   HealthEventCancelRequestDTO,
   HealthEventDoneRequestDTO,
@@ -14,19 +15,28 @@ import {
   HealthEventType
 } from "../../Models/HealthDTOs";
 import { HealthAlertsDTO } from "../../Models/HealthAlertsDTO";
+import { LactationDryOffAlertResponseDTO } from "../../Models/LactationDTOs";
+import { RoleEnum } from "../../Models/auth";
+import { PregnancyDiagnosisAlertResponseDTO } from "../../Models/ReproductionDTOs";
 import { GoatFarmDTO } from "../../Models/goatFarm";
-import HealthFilters, { HealthFiltersValues } from "./components/HealthFilters";
-import FarmHealthAlertsPanel from "./components/FarmHealthAlertsPanel";
-import FarmHealthCalendarTable from "./components/FarmHealthCalendarTable";
+import { PermissionService } from "../../services/PermissionService";
 import CancelHealthEventModal from "./components/CancelHealthEventModal";
 import DoneHealthEventModal from "./components/DoneHealthEventModal";
+import FarmHealthAlertsPanel from "./components/FarmHealthAlertsPanel";
+import FarmHealthCalendarTable from "./components/FarmHealthCalendarTable";
+import FarmOperationalAgendaPanel from "./components/FarmOperationalAgendaPanel";
+import HealthFilters, { HealthFiltersValues } from "./components/HealthFilters";
 import ReopenHealthEventModal from "./components/ReopenHealthEventModal";
+import {
+  buildFarmOperationalAgenda,
+  type FarmOperationalAgendaFilter,
+  type FarmOperationalAgendaItem
+} from "./farmOperationalAgenda";
 import {
   getFriendlyErrorMessage,
   isForbiddenError,
   isUnauthorizedError
 } from "./healthHelpers";
-import GoatFarmHeader from "../../Components/pages-headers/GoatFarmHeader";
 import "./healthPages.css";
 
 const DEFAULT_FILTERS: HealthFiltersValues = {
@@ -44,7 +54,6 @@ export default function FarmHealthAgendaPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const { tokenPayload } = useAuth();
 
-  // --- Pagination State ---
   const rawPage = Number(searchParams.get("page") ?? "0");
   const currentPage = Number.isNaN(rawPage) || rawPage < 0 ? 0 : rawPage;
 
@@ -53,7 +62,6 @@ export default function FarmHealthAgendaPage() {
     ? rawSize
     : PAGE_SIZE_OPTIONS[0];
 
-  // --- Filter State ---
   const lowType = searchParams.get("type");
   const lowStatus = searchParams.get("status");
   const lowFrom = searchParams.get("from");
@@ -64,39 +72,50 @@ export default function FarmHealthAgendaPage() {
     status: (lowStatus as HealthEventStatus) ?? "",
     from: lowFrom ?? "",
     to: lowTo ?? ""
-  }), [lowType, lowStatus, lowFrom, lowTo]);
+  }), [lowFrom, lowStatus, lowTo, lowType]);
 
   const [filterDraft, setFilterDraft] = useState<HealthFiltersValues>(DEFAULT_FILTERS);
-
-  // --- Data State ---
   const [farmData, setFarmData] = useState<GoatFarmDTO | null>(null);
   const [alerts, setAlerts] = useState<HealthAlertsDTO | null>(null);
+  const [pregnancyAlerts, setPregnancyAlerts] = useState<PregnancyDiagnosisAlertResponseDTO | null>(null);
+  const [dryOffAlerts, setDryOffAlerts] = useState<LactationDryOffAlertResponseDTO | null>(null);
   const [events, setEvents] = useState<HealthEventResponseDTO[]>([]);
   const [totalElements, setTotalElements] = useState(0);
   const [totalPages, setTotalPages] = useState(0);
-  
-  // --- Loading/Error State ---
   const [loadingAlerts, setLoadingAlerts] = useState(false);
   const [loadingCalendar, setLoadingCalendar] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
-
-  // --- Modal State ---
+  const [operationalWarning, setOperationalWarning] = useState("");
   const [selectedForDone, setSelectedForDone] = useState<HealthEventResponseDTO | null>(null);
   const [selectedForCancel, setSelectedForCancel] = useState<HealthEventResponseDTO | null>(null);
   const [selectedForReopen, setSelectedForReopen] = useState<HealthEventResponseDTO | null>(null);
   const [showCanceled, setShowCanceled] = useState(false);
+  const [operationalFilter, setOperationalFilter] = useState<FarmOperationalAgendaFilter>("all");
 
   const farmIdNumber = useMemo(() => (farmId ? Number(farmId) : NaN), [farmId]);
-
   const userRole = tokenPayload?.authorities[0] || RoleEnum.ROLE_PUBLIC;
   const showReopenAction = PermissionService.canReopenEvent(userRole, tokenPayload?.userId, farmData?.ownerId);
 
   const filteredEvents = useMemo(() => {
     if (showCanceled) return events;
-    return events.filter((e) => e.status !== HealthEventStatus.CANCELADO);
+    return events.filter((event) => event.status !== HealthEventStatus.CANCELADO);
   }, [events, showCanceled]);
 
-  // Sync draft with URL params
+  const operationalAgenda = useMemo(
+    () => buildFarmOperationalAgenda(farmIdNumber, {
+      healthAlerts: alerts,
+      pregnancyAlerts,
+      dryOffAlerts,
+      maxItems: 8
+    }),
+    [alerts, dryOffAlerts, farmIdNumber, pregnancyAlerts]
+  );
+
+  const operationalItems = useMemo(() => {
+    if (operationalFilter === "all") return operationalAgenda.items;
+    return operationalAgenda.items.filter((item) => item.source === operationalFilter);
+  }, [operationalAgenda.items, operationalFilter]);
+
   useEffect(() => {
     setFilterDraft({
       type: appliedFilters.type,
@@ -104,57 +123,88 @@ export default function FarmHealthAgendaPage() {
       from: appliedFilters.from,
       to: appliedFilters.to
     });
-  }, [appliedFilters.type, appliedFilters.status, appliedFilters.from, appliedFilters.to]);
+  }, [appliedFilters.from, appliedFilters.status, appliedFilters.to, appliedFilters.type]);
 
-  // Fetch Farm Data
   useEffect(() => {
     if (Number.isNaN(farmIdNumber)) return;
-    
+
     getGoatFarmById(farmIdNumber)
       .then(setFarmData)
-      .catch((err) => console.error("Erro ao carregar fazenda", err));
+      .catch((error) => console.error("Erro ao carregar fazenda", error));
   }, [farmIdNumber]);
 
-  // Fetch Alerts
-  useEffect(() => {
+  const loadOperationalAlerts = useCallback(async () => {
     if (Number.isNaN(farmIdNumber)) return;
 
     setLoadingAlerts(true);
-    healthAPI.getAlerts(farmIdNumber)
-      .then(setAlerts)
-      .catch((err) => {
-        console.error("Erro ao carregar alertas", err);
-        // We set alerts to null so the panel can show error state
-        setAlerts(null);
-      })
-      .finally(() => setLoadingAlerts(false));
+    setOperationalWarning("");
+
+    const [healthResult, pregnancyResult, dryOffResult] = await Promise.allSettled([
+      healthAPI.getAlerts(farmIdNumber),
+      getFarmPregnancyDiagnosisAlerts(farmIdNumber, { page: 0, size: 5 }),
+      getFarmDryOffAlerts(farmIdNumber, { page: 0, size: 5 })
+    ]);
+
+    const failedSources: string[] = [];
+
+    if (healthResult.status === "fulfilled") {
+      setAlerts(healthResult.value);
+    } else {
+      console.error("Erro ao carregar alertas de sanidade", healthResult.reason);
+      setAlerts(null);
+      failedSources.push("sanidade");
+    }
+
+    if (pregnancyResult.status === "fulfilled") {
+      setPregnancyAlerts(pregnancyResult.value);
+    } else {
+      console.error("Erro ao carregar alertas de reprodução", pregnancyResult.reason);
+      setPregnancyAlerts(null);
+      failedSources.push("reprodução");
+    }
+
+    if (dryOffResult.status === "fulfilled") {
+      setDryOffAlerts(dryOffResult.value);
+    } else {
+      console.error("Erro ao carregar alertas de lactação", dryOffResult.reason);
+      setDryOffAlerts(null);
+      failedSources.push("lactação");
+    }
+
+    if (failedSources.length > 0) {
+      setOperationalWarning(
+        `Parte da agenda operacional não pôde ser carregada agora (${failedSources.join(", ")}).`
+      );
+    }
+
+    setLoadingAlerts(false);
   }, [farmIdNumber]);
 
-  // Fetch Calendar (Events)
+  useEffect(() => {
+    loadOperationalAlerts();
+  }, [loadOperationalAlerts]);
+
   const loadEvents = useCallback(async () => {
     if (Number.isNaN(farmIdNumber)) return;
+
     setLoadingCalendar(true);
     setErrorMessage("");
 
     try {
       const query: Record<string, string | number> = {
         page: currentPage,
-        size: currentPageSize
+        size: currentPageSize,
+        from: appliedFilters.from || "2000-01-01",
+        to: appliedFilters.to || "2099-12-31"
       };
 
       if (appliedFilters.type) query.type = appliedFilters.type;
-      
+
       if (appliedFilters.status) {
         query.status = appliedFilters.status;
       } else if (showCanceled) {
-        // If no status filter is applied but "Show Canceled" is on, fetch canceled events
         query.status = HealthEventStatus.CANCELADO;
       }
-      
-      // Workaround for backend error "could not determine data type of parameter"
-      // We explicitly send a wide date range instead of null
-      query.from = appliedFilters.from || "2000-01-01";
-      query.to = appliedFilters.to || "2099-12-31";
 
       const response = await healthAPI.getCalendar(farmIdNumber, query);
       setEvents(response.content || []);
@@ -166,6 +216,7 @@ export default function FarmHealthAgendaPage() {
         navigate("/login");
         return;
       }
+
       setErrorMessage(
         isForbiddenError(error)
           ? "Sem permissão para visualizar eventos desta fazenda."
@@ -174,31 +225,25 @@ export default function FarmHealthAgendaPage() {
     } finally {
       setLoadingCalendar(false);
     }
-  }, [
-    appliedFilters,
-    currentPage,
-    currentPageSize,
-    farmIdNumber,
-    navigate
-  ]);
+  }, [appliedFilters.from, appliedFilters.status, appliedFilters.to, appliedFilters.type, currentPage, currentPageSize, farmIdNumber, navigate, showCanceled]);
 
   useEffect(() => {
     loadEvents();
   }, [loadEvents]);
 
-  // --- Handlers ---
-
   const updateSearchParams = (changes: Record<string, string | null>) => {
     const nextParams = new URLSearchParams(searchParams.toString());
+
     Object.entries(changes).forEach(([key, value]) => {
       if (value === null || value === "") nextParams.delete(key);
       else nextParams.set(key, value);
     });
+
     setSearchParams(nextParams);
   };
 
   const handleFilterChange = (field: keyof HealthFiltersValues, value: string) => {
-    setFilterDraft((prev) => ({ ...prev, [field]: value }));
+    setFilterDraft((previous) => ({ ...previous, [field]: value }));
   };
 
   const handleApplyFilters = () => {
@@ -240,73 +285,57 @@ export default function FarmHealthAgendaPage() {
       newParams.from = today;
       newParams.to = today;
     } else if (filterType === "upcoming") {
-        // Assuming upcoming is next 7 days as per alert window
-        const nextWeek = new Date();
-        nextWeek.setDate(nextWeek.getDate() + 7);
-        newParams.status = HealthEventStatus.AGENDADO;
-        newParams.from = today;
-        newParams.to = nextWeek.toISOString().split("T")[0];
-    } else if (filterType === "overdue") {
-       // Backend handles overdue logic, but for filter we might just filter by status AGENDADO and rely on visual cues, 
-       // OR we set a 'to' date in the past. 
-       // Since the API filter might not have "overdue=true", we typically filter AGENDADO + To < Today.
-       // However, let's just clear dates and set Status=AGENDADO for now, or maybe the user wants to see *all* overdue.
-       // Better UX: Filter Status=AGENDADO. The user can sort/see badges.
-       // Ideally we'd have a specific "overdue" query param, but let's stick to standard filters.
-       // Let's set Status=AGENDADO and clear dates to show all pending.
-       newParams.status = HealthEventStatus.AGENDADO;
-       newParams.from = null;
-       newParams.to = null; 
-       // Or set 'to' = yesterday
-       const yesterday = new Date();
-       yesterday.setDate(yesterday.getDate() - 1);
-       newParams.to = yesterday.toISOString().split("T")[0];
+      const nextWeek = new Date();
+      nextWeek.setDate(nextWeek.getDate() + 7);
+      newParams.status = HealthEventStatus.AGENDADO;
+      newParams.from = today;
+      newParams.to = nextWeek.toISOString().split("T")[0];
+    } else {
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+      newParams.status = HealthEventStatus.AGENDADO;
+      newParams.from = null;
+      newParams.to = yesterday.toISOString().split("T")[0];
     }
 
-    // Update draft to match
-    setFilterDraft(prev => ({
-        ...prev,
-        status: newParams.status as HealthEventStatus || "",
-        from: newParams.from || "",
-        to: newParams.to || ""
+    setFilterDraft((previous) => ({
+      ...previous,
+      status: (newParams.status as HealthEventStatus) || "",
+      from: newParams.from || "",
+      to: newParams.to || ""
     }));
 
     updateSearchParams(newParams);
-    
-    // Scroll to table
     document.querySelector(".health-filters-shell")?.scrollIntoView({ behavior: "smooth" });
   };
 
   const handleNavigateToDetail = (goatId: string, eventId: number) => {
-    // Navigate to existing goat-specific detail page
-    // Route: /app/goatfarms/:farmId/goats/:goatId/health/:eventId
     navigate(`/app/goatfarms/${farmIdNumber}/goats/${goatId}/health/${eventId}`);
   };
 
-  const handleMarkAsDone = async (event: HealthEventResponseDTO, payload: HealthEventDoneRequestDTO) => {
+  const handleMarkAsDone = useCallback(async (event: HealthEventResponseDTO, payload: HealthEventDoneRequestDTO) => {
     try {
       await healthAPI.markAsDone(farmIdNumber, event.goatId, event.id, payload);
       toast.success("Evento realizado com sucesso!");
       setSelectedForDone(null);
-      loadEvents(); // Reload calendar
-      // Also reload alerts? Ideally yes.
-      healthAPI.getAlerts(farmIdNumber).then(setAlerts);
+      await loadEvents();
+      await loadOperationalAlerts();
     } catch (error) {
       toast.error(getFriendlyErrorMessage(error, "Erro ao marcar como realizado."));
     }
-  };
+  }, [farmIdNumber, loadEvents, loadOperationalAlerts]);
 
-  const handleCancel = async (event: HealthEventResponseDTO, payload: HealthEventCancelRequestDTO) => {
+  const handleCancel = useCallback(async (event: HealthEventResponseDTO, payload: HealthEventCancelRequestDTO) => {
     try {
       await healthAPI.cancel(farmIdNumber, event.goatId, event.id, payload);
       toast.success("Evento cancelado.");
       setSelectedForCancel(null);
-      loadEvents();
-      healthAPI.getAlerts(farmIdNumber).then(setAlerts);
+      await loadEvents();
+      await loadOperationalAlerts();
     } catch (error) {
       toast.error(getFriendlyErrorMessage(error, "Erro ao cancelar evento."));
     }
-  };
+  }, [farmIdNumber, loadEvents, loadOperationalAlerts]);
 
   const handleReopenEvent = useCallback(async () => {
     if (!selectedForReopen || Number.isNaN(farmIdNumber)) return;
@@ -316,16 +345,19 @@ export default function FarmHealthAgendaPage() {
       toast.success("Evento reaberto com sucesso.");
       setSelectedForReopen(null);
       await loadEvents();
-      healthAPI.getAlerts(farmIdNumber).then(setAlerts);
+      await loadOperationalAlerts();
     } catch (error) {
       if (isForbiddenError(error)) {
         toast.error("Você não tem permissão para reabrir este evento.");
       } else {
-        const message = getFriendlyErrorMessage(error, "Erro ao reabrir evento.");
-        toast.error(message);
+        toast.error(getFriendlyErrorMessage(error, "Erro ao reabrir evento."));
       }
     }
-  }, [farmIdNumber, selectedForReopen, loadEvents]);
+  }, [farmIdNumber, loadEvents, loadOperationalAlerts, selectedForReopen]);
+
+  const handleOperationalItemOpen = useCallback((item: FarmOperationalAgendaItem) => {
+    navigate(item.href);
+  }, [navigate]);
 
   if (Number.isNaN(farmIdNumber)) {
     return (
@@ -344,33 +376,46 @@ export default function FarmHealthAgendaPage() {
 
   return (
     <div className="health-page">
-      <GoatFarmHeader 
-        name={farmData?.name || "Capril"} 
-        logoUrl={farmData?.logoUrl} 
+      <GoatFarmHeader
+        name={farmData?.name || "Capril"}
+        logoUrl={farmData?.logoUrl}
         farmId={farmIdNumber}
       />
 
       <section className="health-hero mb-4">
         <div className="health-hero__meta">
-            <button className="health-btn health-btn-text health-hero__back" type="button" onClick={() => navigate("/goatfarms")}>
-                <i className="fa-solid fa-arrow-left" aria-hidden="true"></i> Voltar ao Painel
-            </button>
-            <div>
-                <h1>Agenda Sanitária da Fazenda</h1>
-                <p className="text-muted">Visão geral de eventos sanitários de todo o rebanho</p>
-            </div>
+          <button className="health-btn health-btn-text health-hero__back" type="button" onClick={() => navigate("/goatfarms")}>
+            <i className="fa-solid fa-arrow-left" aria-hidden="true"></i> Voltar ao Painel
+          </button>
+          <div>
+            <h1>Agenda Operacional da Fazenda</h1>
+            <p className="text-muted">
+              Resumo da rotina por sanidade, reprodução e lactação. O detalhamento abaixo continua sanitário.
+            </p>
+          </div>
         </div>
       </section>
 
-      <FarmHealthAlertsPanel 
-        alerts={alerts} 
-        loading={loadingAlerts} 
+      <FarmOperationalAgendaPanel
+        loading={loadingAlerts}
+        warningMessage={operationalWarning}
+        summary={operationalAgenda}
+        activeFilter={operationalFilter}
+        items={operationalItems}
+        onFilterChange={setOperationalFilter}
+        onOpenItem={handleOperationalItemOpen}
+        onOpenAlerts={() => navigate(`/app/goatfarms/${farmIdNumber}/alerts`)}
+      />
+
+      <FarmHealthAlertsPanel
+        alerts={alerts}
+        loading={loadingAlerts}
         onFilterChange={handleAlertFilterClick}
         onNavigateToDetail={handleNavigateToDetail}
       />
 
       <div className="health-filters-shell">
-        <h3 className="mb-3 ps-2 border-start border-4 border-success">Todos os Eventos</h3>
+        <h3 className="mb-3 ps-2 border-start border-4 border-success">Detalhamento sanitário</h3>
         <HealthFilters
           values={filterDraft}
           onChange={handleFilterChange}
@@ -378,7 +423,7 @@ export default function FarmHealthAgendaPage() {
           onClear={handleClearFilters}
           isBusy={loadingCalendar}
           showCanceled={showCanceled}
-          onToggleCanceled={() => setShowCanceled((prev) => !prev)}
+          onToggleCanceled={() => setShowCanceled((previous) => !previous)}
         />
       </div>
 
@@ -401,7 +446,6 @@ export default function FarmHealthAgendaPage() {
         onShowCanceled={() => setShowCanceled(true)}
       />
 
-      {/* Modals */}
       <DoneHealthEventModal
         isOpen={Boolean(selectedForDone)}
         eventTitle={selectedForDone?.title}

--- a/src/Pages/health/FarmOperationalAgendaPanel.test.tsx
+++ b/src/Pages/health/FarmOperationalAgendaPanel.test.tsx
@@ -1,0 +1,64 @@
+﻿import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import FarmOperationalAgendaPanel from "./components/FarmOperationalAgendaPanel";
+import { FarmOperationalAgendaItem, FarmOperationalAgendaSummary } from "./farmOperationalAgenda";
+
+const summary: FarmOperationalAgendaSummary = {
+  totalAttention: 5,
+  counts: {
+    health: 2,
+    reproduction: 2,
+    lactation: 1
+  },
+  items: []
+};
+
+const items: FarmOperationalAgendaItem[] = [
+  {
+    id: "health-1",
+    source: "health",
+    sourceLabel: "Sanidade",
+    title: "Vacinação",
+    description: "Evento sanitário previsto para hoje · Cabra MATRIZ-01",
+    goatId: "MATRIZ-01",
+    date: "2026-03-11",
+    href: "/health/1",
+    overdue: false
+  },
+  {
+    id: "reproduction-1",
+    source: "reproduction",
+    sourceLabel: "Reprodução",
+    title: "Diagnóstico de prenhez pendente",
+    description: "Cabra MATRIZ-02 · última cobertura em 01/03/2026",
+    goatId: "MATRIZ-02",
+    date: "2026-03-12",
+    href: "/reproduction/2",
+    overdue: true,
+    overdueDays: 1
+  }
+];
+
+describe("FarmOperationalAgendaPanel", () => {
+  it("renderiza a visão resumida da agenda operacional", () => {
+    const markup = renderToStaticMarkup(
+      <FarmOperationalAgendaPanel
+        loading={false}
+        warningMessage="Parte da agenda operacional não pôde ser carregada agora."
+        summary={summary}
+        activeFilter="all"
+        items={items}
+        onFilterChange={vi.fn()}
+        onOpenItem={vi.fn()}
+        onOpenAlerts={vi.fn()}
+      />
+    );
+
+    expect(markup).toContain("O que precisa da sua atenção");
+    expect(markup).toContain("Total em atenção");
+    expect(markup).toContain("Parte da agenda operacional não pôde ser carregada agora.");
+    expect(markup).toContain("Vacinação");
+    expect(markup).toContain("Diagnóstico de prenhez pendente");
+    expect(markup).toContain("Cabra MATRIZ-02");
+  });
+});

--- a/src/Pages/health/components/FarmOperationalAgendaPanel.tsx
+++ b/src/Pages/health/components/FarmOperationalAgendaPanel.tsx
@@ -1,0 +1,142 @@
+﻿import {
+  FarmOperationalAgendaFilter,
+  FarmOperationalAgendaItem,
+  FarmOperationalAgendaSummary,
+  formatOperationalAgendaDate
+} from "../farmOperationalAgenda";
+
+interface FarmOperationalAgendaPanelProps {
+  loading: boolean;
+  warningMessage?: string;
+  summary: FarmOperationalAgendaSummary;
+  activeFilter: FarmOperationalAgendaFilter;
+  items: FarmOperationalAgendaItem[];
+  onFilterChange: (filter: FarmOperationalAgendaFilter) => void;
+  onOpenItem: (item: FarmOperationalAgendaItem) => void;
+  onOpenAlerts: () => void;
+}
+
+const FILTERS: Array<{ value: FarmOperationalAgendaFilter; label: string }> = [
+  { value: "all", label: "Tudo" },
+  { value: "health", label: "Sanidade" },
+  { value: "reproduction", label: "Reprodução" },
+  { value: "lactation", label: "Lactação" }
+];
+
+export default function FarmOperationalAgendaPanel({
+  loading,
+  warningMessage,
+  summary,
+  activeFilter,
+  items,
+  onFilterChange,
+  onOpenItem,
+  onOpenAlerts
+}: FarmOperationalAgendaPanelProps) {
+  return (
+    <section className="operational-agenda-panel">
+      <div className="operational-agenda-panel__header">
+        <div>
+          <p className="operational-agenda-panel__eyebrow">Gestão da rotina</p>
+          <h2>O que precisa da sua atenção</h2>
+          <p className="operational-agenda-panel__copy">
+            Resumo operacional da fazenda com sinais de sanidade, reprodução e lactação.
+          </p>
+        </div>
+        <button className="health-btn health-btn-outline-secondary" type="button" onClick={onOpenAlerts}>
+          Ver alertas consolidados
+        </button>
+      </div>
+
+      <div className="operational-agenda-panel__metrics">
+        <article className="operational-agenda-metric operational-agenda-metric--accent">
+          <span>Total em atenção</span>
+          <strong>{summary.totalAttention}</strong>
+        </article>
+        <article className="operational-agenda-metric">
+          <span>Sanidade</span>
+          <strong>{summary.counts.health}</strong>
+        </article>
+        <article className="operational-agenda-metric">
+          <span>Reprodução</span>
+          <strong>{summary.counts.reproduction}</strong>
+        </article>
+        <article className="operational-agenda-metric">
+          <span>Lactação</span>
+          <strong>{summary.counts.lactation}</strong>
+        </article>
+      </div>
+
+      {warningMessage ? (
+        <div className="operational-agenda-panel__warning" role="status">
+          <i className="fa-solid fa-triangle-exclamation" aria-hidden="true"></i>
+          <span>{warningMessage}</span>
+        </div>
+      ) : null}
+
+      <div className="operational-agenda-panel__toolbar">
+        <div className="operational-agenda-panel__chips" role="tablist" aria-label="Filtrar origem da agenda operacional">
+          {FILTERS.map((filter) => (
+            <button
+              key={filter.value}
+              type="button"
+              className={`operational-agenda-chip${activeFilter === filter.value ? " operational-agenda-chip--active" : ""}`}
+              onClick={() => onFilterChange(filter.value)}
+            >
+              {filter.label}
+            </button>
+          ))}
+        </div>
+        <p className="operational-agenda-panel__hint">
+          A tabela detalhada logo abaixo continua mostrando apenas o calendário sanitário.
+        </p>
+      </div>
+
+      {loading ? (
+        <div className="operational-agenda-list operational-agenda-list--loading" aria-label="Carregando agenda operacional">
+          <div className="operational-agenda-skeleton"></div>
+          <div className="operational-agenda-skeleton"></div>
+          <div className="operational-agenda-skeleton"></div>
+        </div>
+      ) : items.length > 0 ? (
+        <div className="operational-agenda-list">
+          {items.map((item) => (
+            <article key={item.id} className="operational-agenda-item">
+              <div className="operational-agenda-item__meta">
+                <span className={`operational-agenda-item__badge operational-agenda-item__badge--${item.source}`}>
+                  {item.sourceLabel}
+                </span>
+                <span className="operational-agenda-item__date">{formatOperationalAgendaDate(item.date)}</span>
+              </div>
+              <div className="operational-agenda-item__body">
+                <div>
+                  <h3>{item.title}</h3>
+                  <p>{item.description}</p>
+                </div>
+                <div className="operational-agenda-item__aux">
+                  <span>Cabra {item.goatId}</span>
+                  {item.overdue ? (
+                    <span className="operational-agenda-item__risk">
+                      {typeof item.overdueDays === "number" && item.overdueDays > 0
+                        ? `${item.overdueDays} dia(s) de atraso`
+                        : "Em atraso"}
+                    </span>
+                  ) : null}
+                </div>
+              </div>
+              <div className="operational-agenda-item__actions">
+                <button className="health-btn health-btn-outline-secondary" type="button" onClick={() => onOpenItem(item)}>
+                  Abrir
+                </button>
+              </div>
+            </article>
+          ))}
+        </div>
+      ) : (
+        <div className="operational-agenda-panel__empty">
+          Nenhuma ação operacional pendente foi encontrada para o filtro selecionado.
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/Pages/health/farmOperationalAgenda.test.ts
+++ b/src/Pages/health/farmOperationalAgenda.test.ts
@@ -1,0 +1,89 @@
+﻿import { describe, expect, it } from "vitest";
+import { buildFarmOperationalAgenda } from "./farmOperationalAgenda";
+
+describe("buildFarmOperationalAgenda", () => {
+  it("combina sinais de sanidade, reprodução e lactação em ordem operacional", () => {
+    const summary = buildFarmOperationalAgenda(12, {
+      healthAlerts: {
+        dueTodayCount: 1,
+        upcomingCount: 1,
+        overdueCount: 1,
+        dueTodayTop: [
+          {
+            id: 11,
+            farmId: 12,
+            goatId: "MATRIZ-01",
+            type: "VACINACAO",
+            status: "AGENDADO",
+            title: "Vacinação obrigatória",
+            scheduledDate: "2026-03-11",
+            overdue: false
+          }
+        ],
+        upcomingTop: [
+          {
+            id: 12,
+            farmId: 12,
+            goatId: "MATRIZ-04",
+            type: "VERMIFUGACAO",
+            status: "AGENDADO",
+            title: "Vermifugação",
+            scheduledDate: "2026-03-14",
+            overdue: false
+          }
+        ],
+        overdueTop: [
+          {
+            id: 13,
+            farmId: 12,
+            goatId: "MATRIZ-02",
+            type: "EXAME_CLINICO",
+            status: "AGENDADO",
+            title: "Exame clínico",
+            scheduledDate: "2026-03-09",
+            overdue: true
+          }
+        ]
+      },
+      pregnancyAlerts: {
+        totalPending: 1,
+        alerts: [
+          {
+            goatId: "MATRIZ-03",
+            eligibleDate: "2026-03-10",
+            daysOverdue: 1,
+            lastCoverageDate: "2026-02-08",
+            lastCheckDate: null
+          }
+        ]
+      },
+      dryOffAlerts: {
+        totalPending: 1,
+        alerts: [
+          {
+            goatId: "MATRIZ-05",
+            dryOffDate: "2026-03-12",
+            startDatePregnancy: "2025-10-13",
+            breedingDate: "2025-10-10",
+            confirmDate: "2025-11-10",
+            dryAtPregnancyDays: 140,
+            gestationDays: 145,
+            daysOverdue: 0,
+            dryOffRecommendation: true
+          }
+        ]
+      },
+      maxItems: 4
+    });
+
+    expect(summary.totalAttention).toBe(5);
+    expect(summary.counts.health).toBe(3);
+    expect(summary.counts.reproduction).toBe(1);
+    expect(summary.counts.lactation).toBe(1);
+    expect(summary.items).toHaveLength(4);
+    expect(summary.items[0]).toMatchObject({ source: "health", goatId: "MATRIZ-02", overdue: true });
+    expect(summary.items[1]).toMatchObject({ source: "reproduction", goatId: "MATRIZ-03", overdue: true });
+    expect(summary.items[2]).toMatchObject({ source: "health", goatId: "MATRIZ-01" });
+    expect(summary.items[3]).toMatchObject({ source: "lactation", goatId: "MATRIZ-05" });
+  });
+});

--- a/src/Pages/health/farmOperationalAgenda.ts
+++ b/src/Pages/health/farmOperationalAgenda.ts
@@ -1,0 +1,179 @@
+﻿import { HealthAlertsDTO } from "../../Models/HealthAlertsDTO";
+import { HealthEventResponseDTO } from "../../Models/HealthDTOs";
+import { LactationDryOffAlertResponseDTO } from "../../Models/LactationDTOs";
+import { PregnancyDiagnosisAlertResponseDTO } from "../../Models/ReproductionDTOs";
+
+export type FarmOperationalAgendaSource = "health" | "reproduction" | "lactation";
+export type FarmOperationalAgendaFilter = "all" | FarmOperationalAgendaSource;
+
+export interface FarmOperationalAgendaItem {
+  id: string;
+  source: FarmOperationalAgendaSource;
+  sourceLabel: string;
+  title: string;
+  description: string;
+  goatId: string;
+  date: string;
+  href: string;
+  overdue: boolean;
+  overdueDays?: number;
+}
+
+export interface FarmOperationalAgendaSummary {
+  totalAttention: number;
+  counts: Record<FarmOperationalAgendaSource, number>;
+  items: FarmOperationalAgendaItem[];
+}
+
+interface BuildFarmOperationalAgendaInput {
+  healthAlerts: HealthAlertsDTO | null;
+  pregnancyAlerts: PregnancyDiagnosisAlertResponseDTO | null;
+  dryOffAlerts: LactationDryOffAlertResponseDTO | null;
+  maxItems?: number;
+}
+
+const SOURCE_LABELS: Record<FarmOperationalAgendaSource, string> = {
+  health: "Sanidade",
+  reproduction: "Reprodução",
+  lactation: "Lactação"
+};
+
+function isValidDate(value: string | undefined | null): value is string {
+  return Boolean(value) && !Number.isNaN(Date.parse(value as string));
+}
+
+function formatDate(value: string): string {
+  return new Intl.DateTimeFormat("pt-BR", {
+    timeZone: "UTC",
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric"
+  }).format(new Date(`${value}T00:00:00Z`));
+}
+
+function compareDates(left: string, right: string): number {
+  return new Date(`${left}T00:00:00Z`).getTime() - new Date(`${right}T00:00:00Z`).getTime();
+}
+
+function getPriority(item: FarmOperationalAgendaItem): number {
+  return item.overdue ? 0 : 1;
+}
+
+function toHealthItems(farmId: number, alerts: HealthAlertsDTO | null): FarmOperationalAgendaItem[] {
+  if (!alerts || Number.isNaN(farmId)) return [];
+
+  const seen = new Set<number>();
+  const items: FarmOperationalAgendaItem[] = [];
+
+  const pushEvent = (event: HealthEventResponseDTO, source: "due" | "upcoming" | "overdue") => {
+    if (seen.has(event.id) || !isValidDate(event.scheduledDate)) return;
+    seen.add(event.id);
+
+    const sourceDescription = source === "overdue"
+      ? "Evento sanitário em atraso"
+      : source === "due"
+        ? "Evento sanitário previsto para hoje"
+        : "Evento sanitário programado para os próximos dias";
+
+    items.push({
+      id: `health-${event.id}`,
+      source: "health",
+      sourceLabel: SOURCE_LABELS.health,
+      title: event.title,
+      description: `${sourceDescription} · Cabra ${event.goatId}`,
+      goatId: event.goatId,
+      date: event.scheduledDate,
+      href: `/app/goatfarms/${farmId}/goats/${encodeURIComponent(event.goatId)}/health/${event.id}`,
+      overdue: event.overdue || source === "overdue"
+    });
+  };
+
+  alerts.overdueTop.forEach((event) => pushEvent(event, "overdue"));
+  alerts.dueTodayTop.forEach((event) => pushEvent(event, "due"));
+  alerts.upcomingTop.forEach((event) => pushEvent(event, "upcoming"));
+
+  return items;
+}
+
+function toPregnancyItems(farmId: number, response: PregnancyDiagnosisAlertResponseDTO | null): FarmOperationalAgendaItem[] {
+  if (!response || Number.isNaN(farmId)) return [];
+
+  return response.alerts
+    .filter((alert) => isValidDate(alert.eligibleDate))
+    .map((alert) => ({
+      id: `reproduction-${alert.goatId}-${alert.eligibleDate}`,
+      source: "reproduction" as const,
+      sourceLabel: SOURCE_LABELS.reproduction,
+      title: "Diagnóstico de prenhez pendente",
+      description: `Cabra ${alert.goatId} · última cobertura em ${formatDate(alert.lastCoverageDate)}`,
+      goatId: alert.goatId,
+      date: alert.eligibleDate,
+      href: `/app/goatfarms/${farmId}/goats/${encodeURIComponent(alert.goatId)}/reproduction`,
+      overdue: alert.daysOverdue > 0,
+      overdueDays: alert.daysOverdue
+    }));
+}
+
+function toDryOffItems(farmId: number, response: LactationDryOffAlertResponseDTO | null): FarmOperationalAgendaItem[] {
+  if (!response || Number.isNaN(farmId)) return [];
+
+  return response.alerts
+    .filter((alert) => isValidDate(alert.dryOffDate))
+    .map((alert) => ({
+      id: `lactation-${alert.goatId}-${alert.dryOffDate}`,
+      source: "lactation" as const,
+      sourceLabel: SOURCE_LABELS.lactation,
+      title: "Secagem recomendada",
+      description: `Cabra ${alert.goatId} · gestação com ${alert.gestationDays} dias`,
+      goatId: alert.goatId,
+      date: alert.dryOffDate,
+      href: `/app/goatfarms/${farmId}/goats/${encodeURIComponent(alert.goatId)}/lactations/active`,
+      overdue: alert.daysOverdue > 0,
+      overdueDays: alert.daysOverdue
+    }));
+}
+
+export function buildFarmOperationalAgenda(
+  farmId: number,
+  {
+    healthAlerts,
+    pregnancyAlerts,
+    dryOffAlerts,
+    maxItems = 6
+  }: BuildFarmOperationalAgendaInput
+): FarmOperationalAgendaSummary {
+  const healthItems = toHealthItems(farmId, healthAlerts);
+  const pregnancyItems = toPregnancyItems(farmId, pregnancyAlerts);
+  const dryOffItems = toDryOffItems(farmId, dryOffAlerts);
+
+  const items = [...healthItems, ...pregnancyItems, ...dryOffItems]
+    .sort((left, right) => {
+      const priorityDelta = getPriority(left) - getPriority(right);
+      if (priorityDelta !== 0) return priorityDelta;
+
+      const dateDelta = compareDates(left.date, right.date);
+      if (dateDelta !== 0) return dateDelta;
+
+      return left.title.localeCompare(right.title, "pt-BR");
+    })
+    .slice(0, maxItems);
+
+  return {
+    totalAttention:
+      (healthAlerts?.dueTodayCount ?? 0) +
+      (healthAlerts?.upcomingCount ?? 0) +
+      (healthAlerts?.overdueCount ?? 0) +
+      (pregnancyAlerts?.totalPending ?? 0) +
+      (dryOffAlerts?.totalPending ?? 0),
+    counts: {
+      health: (healthAlerts?.dueTodayCount ?? 0) + (healthAlerts?.upcomingCount ?? 0) + (healthAlerts?.overdueCount ?? 0),
+      reproduction: pregnancyAlerts?.totalPending ?? 0,
+      lactation: dryOffAlerts?.totalPending ?? 0
+    },
+    items
+  };
+}
+
+export function formatOperationalAgendaDate(value: string): string {
+  return formatDate(value);
+}

--- a/src/Pages/health/healthPages.css
+++ b/src/Pages/health/healthPages.css
@@ -656,3 +656,259 @@
     gap: 0.25rem;
   }
 }
+
+.operational-agenda-panel {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.96), rgba(240, 253, 250, 0.92));
+  border-radius: var(--gf-radius-lg);
+  box-shadow: var(--gf-shadow-premium);
+  padding: 1.5rem;
+  border: 1px solid rgba(15, 23, 42, 0.06);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.operational-agenda-panel__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.operational-agenda-panel__eyebrow {
+  margin: 0 0 0.35rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.74rem;
+  font-weight: 700;
+  color: var(--gf-color-primary);
+}
+
+.operational-agenda-panel__header h2 {
+  margin: 0;
+  color: var(--gf-color-secondary);
+}
+
+.operational-agenda-panel__copy,
+.operational-agenda-panel__hint {
+  margin: 0;
+  color: var(--gf-color-text-secondary);
+}
+
+.operational-agenda-panel__metrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.85rem;
+}
+
+.operational-agenda-metric {
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 18px;
+  padding: 1rem 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.operational-agenda-metric span {
+  color: var(--gf-color-text-secondary);
+  font-size: 0.85rem;
+}
+
+.operational-agenda-metric strong {
+  color: var(--gf-color-secondary);
+  font-size: 1.75rem;
+  line-height: 1;
+}
+
+.operational-agenda-metric--accent {
+  background: linear-gradient(135deg, rgba(16, 185, 129, 0.14), rgba(20, 184, 166, 0.08));
+  border-color: rgba(16, 185, 129, 0.3);
+}
+
+.operational-agenda-panel__warning {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.85rem 1rem;
+  border-radius: 16px;
+  background: rgba(245, 158, 11, 0.12);
+  border: 1px solid rgba(245, 158, 11, 0.28);
+  color: #92400e;
+}
+
+.operational-agenda-panel__toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.operational-agenda-panel__chips {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.operational-agenda-chip {
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--gf-color-secondary);
+  font-weight: 600;
+  padding: 0.55rem 0.95rem;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.operational-agenda-chip--active {
+  background: rgba(16, 185, 129, 0.12);
+  border-color: rgba(16, 185, 129, 0.35);
+  color: #047857;
+}
+
+.operational-agenda-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.operational-agenda-item {
+  display: grid;
+  grid-template-columns: 150px minmax(0, 1fr) auto;
+  gap: 1rem;
+  align-items: center;
+  padding: 1rem 1.1rem;
+  background: rgba(255, 255, 255, 0.94);
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.operational-agenda-item__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.operational-agenda-item__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: fit-content;
+  border-radius: 999px;
+  padding: 0.3rem 0.75rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.operational-agenda-item__badge--health {
+  background: rgba(59, 130, 246, 0.12);
+  color: #1d4ed8;
+}
+
+.operational-agenda-item__badge--reproduction {
+  background: rgba(249, 115, 22, 0.12);
+  color: #c2410c;
+}
+
+.operational-agenda-item__badge--lactation {
+  background: rgba(16, 185, 129, 0.12);
+  color: #047857;
+}
+
+.operational-agenda-item__date {
+  color: var(--gf-color-text-secondary);
+  font-size: 0.88rem;
+  font-weight: 600;
+}
+
+.operational-agenda-item__body {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+}
+
+.operational-agenda-item__body h3 {
+  margin: 0;
+  color: var(--gf-color-secondary);
+  font-size: 1rem;
+}
+
+.operational-agenda-item__body p {
+  margin: 0.25rem 0 0;
+  color: var(--gf-color-text-secondary);
+}
+
+.operational-agenda-item__aux {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  align-items: flex-end;
+  color: var(--gf-color-text-secondary);
+  font-size: 0.85rem;
+  min-width: 160px;
+}
+
+.operational-agenda-item__risk {
+  color: #b45309;
+  font-weight: 700;
+}
+
+.operational-agenda-item__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.operational-agenda-panel__empty {
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px dashed rgba(148, 163, 184, 0.4);
+  border-radius: 18px;
+  padding: 1rem 1.1rem;
+  color: var(--gf-color-text-secondary);
+}
+
+.operational-agenda-list--loading {
+  gap: 0.6rem;
+}
+
+.operational-agenda-skeleton {
+  height: 86px;
+  border-radius: 18px;
+  background: linear-gradient(90deg, rgba(226, 232, 240, 0.55), rgba(241, 245, 249, 0.92), rgba(226, 232, 240, 0.55));
+  background-size: 240px 100%;
+  animation: health-shimmer 1.4s infinite linear;
+}
+
+@media (max-width: 992px) {
+  .operational-agenda-panel__metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .operational-agenda-item {
+    grid-template-columns: 1fr;
+  }
+
+  .operational-agenda-item__body {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .operational-agenda-item__aux,
+  .operational-agenda-item__actions {
+    align-items: flex-start;
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 640px) {
+  .operational-agenda-panel {
+    padding: 1.1rem;
+  }
+
+  .operational-agenda-panel__metrics {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary\n- enrich the existing farm agenda page with an operational summary across health, reproduction and lactation\n- keep the detailed calendar below as a sanitary view and document the current scope\n- add tests for the operational agenda aggregator and summary panel\n\n## Validation\n- npm test -- --run\n- npm run build\n- npm run lint\n- npm run test:e2e