### PR TITLE
fix(reproduction): align dry-off timeline and lactation recommendation UI

### DIFF
--- a/src/Pages/lactation/LactationActivePage.tsx
+++ b/src/Pages/lactation/LactationActivePage.tsx
@@ -4,10 +4,10 @@ import { toast } from "react-toastify";
 import PageHeader from "../../Components/pages-headers/PageHeader";
 import { Button, EmptyState, LoadingState, Modal } from "../../Components/ui";
 import { fetchGoatById } from "../../api/GoatAPI/goat";
-import { dryLactation, getActiveLactation } from "../../api/GoatFarmAPI/lactation";
+import { dryLactation, getActiveLactation, getLactationSummary } from "../../api/GoatFarmAPI/lactation";
 import { useFarmPermissions } from "../../Hooks/useFarmPermissions";
 import { usePermissions } from "../../Hooks/usePermissions";
-import type { LactationResponseDTO } from "../../Models/LactationDTOs";
+import type { LactationResponseDTO, LactationSummaryDTO } from "../../Models/LactationDTOs";
 import type { GoatResponseDTO } from "../../Models/goatResponseDTO";
 import { getApiErrorMessage, parseApiError } from "../../utils/apiError";
 import "./lactationPages.css";
@@ -24,6 +24,7 @@ export default function LactationActivePage() {
 
   const [goat, setGoat] = useState<GoatResponseDTO | null>(null);
   const [lactation, setLactation] = useState<LactationResponseDTO | null>(null);
+  const [lactationSummary, setLactationSummary] = useState<LactationSummaryDTO | null>(null);
   const [loading, setLoading] = useState(true);
   const [showDryModal, setShowDryModal] = useState(false);
   const [dryDate, setDryDate] = useState("");
@@ -44,6 +45,12 @@ export default function LactationActivePage() {
         ]);
         setGoat(goatData);
         setLactation(active);
+        if (active) {
+          const summary = await getLactationSummary(farmIdNumber, goatId, active.id);
+          setLactationSummary(summary);
+        } else {
+          setLactationSummary(null);
+        }
       } catch (error) {
         console.error("Erro ao carregar lactação ativa", error);
         toast.error("Erro ao carregar lactação ativa");
@@ -72,6 +79,12 @@ export default function LactationActivePage() {
       setDryDate("");
       const updated = await getActiveLactation(farmIdNumber, goatId!);
       setLactation(updated);
+      if (updated) {
+        const summary = await getLactationSummary(farmIdNumber, goatId!, updated.id);
+        setLactationSummary(summary);
+      } else {
+        setLactationSummary(null);
+      }
     } catch (error) {
       console.error("Erro ao secar lactação", error);
       const parsed = parseApiError(error);
@@ -84,6 +97,27 @@ export default function LactationActivePage() {
   if (loading) {
     return <LoadingState label="Carregando lactação ativa..." />;
   }
+
+  const recommendedDryOffDate = lactationSummary?.pregnancy?.recommendedDryOffDate ?? null;
+  const dryOffRecommendation = Boolean(lactationSummary?.pregnancy?.dryOffRecommendation);
+  const dryOffMessage = lactationSummary?.pregnancy?.message ?? null;
+
+  const dryOffDaysDelta = recommendedDryOffDate
+    ? Math.floor(
+        (new Date(`${recommendedDryOffDate}T00:00:00`).getTime() -
+          new Date().setHours(0, 0, 0, 0)) /
+          (1000 * 60 * 60 * 24)
+      )
+    : null;
+
+  const dryOffTimingText =
+    dryOffDaysDelta == null
+      ? null
+      : dryOffDaysDelta > 0
+      ? `Faltam ${dryOffDaysDelta} dia(s) para a secagem recomendada.`
+      : dryOffDaysDelta < 0
+      ? `Secagem atrasada em ${Math.abs(dryOffDaysDelta)} dia(s).`
+      : "Secagem recomendada para hoje.";
 
   return (
     <div className="module-page lactation-page">
@@ -173,6 +207,19 @@ export default function LactationActivePage() {
                     de leite deste animal.
                   </p>
                 </div>
+                {recommendedDryOffDate && (
+                  <div
+                    className={`lactation-note-card ${
+                      dryOffRecommendation ? "lactation-note-card--warning" : ""
+                    }`}
+                  >
+                    <p>
+                      <strong>Secagem recomendada:</strong> {formatDate(recommendedDryOffDate)}
+                    </p>
+                    {dryOffTimingText && <p>{dryOffTimingText}</p>}
+                    {dryOffMessage && <p>{dryOffMessage}</p>}
+                  </div>
+                )}
               </div>
             </div>
           </section>

--- a/src/Pages/reproduction/reproductionTimeline.test.ts
+++ b/src/Pages/reproduction/reproductionTimeline.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { buildReproductionTimelineView } from "./reproductionTimeline";
+
+describe("reproductionTimeline", () => {
+  it("builds diagnosis timeline while waiting for eligible window", () => {
+    const view = buildReproductionTimelineView({
+      today: "2026-03-12",
+      recommendationCoverageDate: "2026-03-11",
+      minCheckDate: "2026-05-10",
+      recommendationStatus: "NOT_ELIGIBLE",
+      hasActivePregnancy: false,
+      breedingDate: null,
+      expectedDueDate: null,
+      hasActiveLactation: false,
+    });
+
+    expect(view.mode).toBe("DIAGNOSIS");
+    expect(view.overdue).toBe(false);
+    expect(view.endLabel).toContain("Diagnóstico");
+    expect(view.currentStepLabel).toContain("Dia");
+  });
+
+  it("builds gestation timeline when pregnancy is active and no active lactation", () => {
+    const view = buildReproductionTimelineView({
+      today: "2026-03-12",
+      recommendationCoverageDate: "2026-03-11",
+      minCheckDate: "2026-05-10",
+      recommendationStatus: "RESOLVED",
+      hasActivePregnancy: true,
+      breedingDate: "2026-03-11",
+      expectedDueDate: "2026-08-08",
+      hasActiveLactation: false,
+    });
+
+    expect(view.mode).toBe("GESTATION");
+    expect(view.endLabel).toContain("Parto previsto");
+    expect(view.currentStepLabel).toContain("Gestação ativa");
+  });
+
+  it("builds dry-off timeline when pregnancy and lactation are active", () => {
+    const view = buildReproductionTimelineView({
+      today: "2026-06-01",
+      recommendationCoverageDate: "2026-03-11",
+      minCheckDate: "2026-05-10",
+      recommendationStatus: "RESOLVED",
+      hasActivePregnancy: true,
+      breedingDate: "2026-03-11",
+      expectedDueDate: "2026-08-08",
+      hasActiveLactation: true,
+    });
+
+    expect(view.mode).toBe("DRY_OFF");
+    expect(view.endLabel).toContain("Secagem");
+    expect(view.endDate).toBe("2026-06-09");
+  });
+
+  it("builds empty timeline when there is no coverage reference", () => {
+    const view = buildReproductionTimelineView({
+      today: "2026-03-12",
+      recommendationCoverageDate: null,
+      minCheckDate: null,
+      recommendationStatus: null,
+      hasActivePregnancy: false,
+      breedingDate: null,
+      expectedDueDate: null,
+      hasActiveLactation: false,
+    });
+
+    expect(view.mode).toBe("NONE");
+    expect(view.show).toBe(false);
+  });
+});

--- a/src/Pages/reproduction/reproductionTimeline.ts
+++ b/src/Pages/reproduction/reproductionTimeline.ts
@@ -1,0 +1,152 @@
+import { addDaysLocalDate, diffDaysLocalDate, formatLocalDatePtBR } from "../../utils/localDate";
+
+export type ReproductionTimelineMode = "NONE" | "DIAGNOSIS" | "GESTATION" | "DRY_OFF";
+
+type BuildReproductionTimelineViewInput = {
+  today: string;
+  recommendationCoverageDate?: string | null;
+  minCheckDate?: string | null;
+  recommendationStatus?: "NOT_ELIGIBLE" | "ELIGIBLE_PENDING" | "RESOLVED" | null;
+  hasActivePregnancy: boolean;
+  breedingDate?: string | null;
+  expectedDueDate?: string | null;
+  hasActiveLactation: boolean;
+};
+
+export type ReproductionTimelineView = {
+  mode: ReproductionTimelineMode;
+  show: boolean;
+  startLabel: string;
+  endLabel: string;
+  startDate: string | null;
+  endDate: string | null;
+  progressPercent: number;
+  overdue: boolean;
+  overdueDays: number;
+  currentStepLabel: string;
+  nextMilestoneLabel: string;
+  hint: string;
+};
+
+const clampPercent = (value: number) => Math.min(100, Math.max(0, value));
+
+const buildEmptyTimeline = (): ReproductionTimelineView => ({
+  mode: "NONE",
+  show: false,
+  startLabel: "Início",
+  endLabel: "Próximo marco",
+  startDate: null,
+  endDate: null,
+  progressPercent: 0,
+  overdue: false,
+  overdueDays: 0,
+  currentStepLabel: "Sem ciclo ativo",
+  nextMilestoneLabel: "Registrar cobertura",
+  hint: "Sem cobertura registrada para recomendação de diagnóstico.",
+});
+
+const buildProgress = (startDate: string, endDate: string, today: string) => {
+  const totalDays = Math.max(1, diffDaysLocalDate(startDate, endDate));
+  const elapsedDays = Math.max(0, diffDaysLocalDate(startDate, today));
+  return {
+    totalDays,
+    elapsedDays,
+    progressPercent: clampPercent((elapsedDays / totalDays) * 100),
+    overdueDays: Math.max(0, diffDaysLocalDate(endDate, today)),
+  };
+};
+
+export const buildReproductionTimelineView = (
+  input: BuildReproductionTimelineViewInput
+): ReproductionTimelineView => {
+  const {
+    today,
+    recommendationCoverageDate,
+    minCheckDate,
+    recommendationStatus,
+    hasActivePregnancy,
+    breedingDate,
+    expectedDueDate,
+    hasActiveLactation,
+  } = input;
+
+  const cycleStart = breedingDate || recommendationCoverageDate || null;
+  if (!cycleStart) {
+    return buildEmptyTimeline();
+  }
+
+  if (hasActivePregnancy) {
+    if (hasActiveLactation) {
+      const dryOffDate = expectedDueDate
+        ? addDaysLocalDate(expectedDueDate, -60)
+        : addDaysLocalDate(cycleStart, 90);
+      const progress = buildProgress(cycleStart, dryOffDate, today);
+      const isOverdue = progress.overdueDays > 0;
+
+      return {
+        mode: "DRY_OFF",
+        show: true,
+        startLabel: "Cobertura",
+        endLabel: "Secagem (60 dias antes do parto)",
+        startDate: cycleStart,
+        endDate: dryOffDate,
+        progressPercent: progress.progressPercent,
+        overdue: isOverdue,
+        overdueDays: progress.overdueDays,
+        currentStepLabel: isOverdue
+          ? `Secagem atrasada (${progress.overdueDays} dias)`
+          : "Gestação ativa em lactação",
+        nextMilestoneLabel: isOverdue ? "Secar lactação" : formatLocalDatePtBR(dryOffDate),
+        hint: "Com gestação e lactação ativas, prepare a secagem 60 dias antes do parto.",
+      };
+    }
+
+    const dueDate = expectedDueDate || addDaysLocalDate(cycleStart, 150);
+    const progress = buildProgress(cycleStart, dueDate, today);
+    const isOverdue = progress.overdueDays > 0;
+
+    return {
+      mode: "GESTATION",
+      show: true,
+      startLabel: "Cobertura",
+      endLabel: "Parto previsto",
+      startDate: cycleStart,
+      endDate: dueDate,
+      progressPercent: progress.progressPercent,
+      overdue: isOverdue,
+      overdueDays: progress.overdueDays,
+      currentStepLabel: isOverdue
+        ? `Parto previsto atrasado (${progress.overdueDays} dias)`
+        : "Gestação ativa",
+      nextMilestoneLabel: formatLocalDatePtBR(dueDate),
+      hint: "Acompanhando a gestação ativa até o parto previsto.",
+    };
+  }
+
+  const diagnosisDate = minCheckDate || addDaysLocalDate(cycleStart, 60);
+  const progress = buildProgress(cycleStart, diagnosisDate, today);
+  const isPending = recommendationStatus === "ELIGIBLE_PENDING";
+  const isOverdue = isPending || progress.overdueDays > 0;
+
+  return {
+    mode: "DIAGNOSIS",
+    show: true,
+    startLabel: "Cobertura",
+    endLabel: "Diagnóstico",
+    startDate: cycleStart,
+    endDate: diagnosisDate,
+    progressPercent: progress.progressPercent,
+    overdue: isOverdue,
+    overdueDays: progress.overdueDays,
+    currentStepLabel: isOverdue
+      ? `Diagnóstico atrasado (${progress.overdueDays} dias)`
+      : `Dia ${Math.min(progress.elapsedDays, progress.totalDays)} de ${progress.totalDays}`,
+    nextMilestoneLabel: isOverdue ? "Registrar diagnóstico" : formatLocalDatePtBR(diagnosisDate),
+    hint:
+      progress.overdueDays > 0 || isPending
+        ? "Prazo mínimo atingido. Registre o diagnóstico."
+        : `Faltam ${Math.max(0, diffDaysLocalDate(today, diagnosisDate))} dia${
+            diffDaysLocalDate(today, diagnosisDate) === 1 ? "" : "s"
+          } para o diagnóstico.`,
+  };
+};


### PR DESCRIPTION
## Summary\n- aligns reproduction dry-off timeline to 60 days before parto (coverage + 90 days)\n- shows dry-off recommendation in active lactation UI\n- includes only correction scope files\n\n## Notes\n- out-of-scope local changes were stashed and not included