### PR TITLE
feat(goat): use ABCC race catalog in import modal

### DIFF
--- a/docs/GOAT_ABCC_IMPORT_FRONTEND.md
+++ b/docs/GOAT_ABCC_IMPORT_FRONTEND.md
@@ -1,0 +1,59 @@
+﻿# Importação opcional de cabra via ABCC (Frontend)
+
+## Objetivo
+Adicionar no frontend do módulo Goat um fluxo opcional de importação via ABCC pública, mantendo o cadastro manual existente sem dependência da ABCC.
+
+## Onde o fluxo entra
+- Página: `Lista de Cabras`.
+- Arquivo principal: `src/Pages/goat-list-page/GoatListPage.tsx`.
+- Entrada visual no header:
+  - `Cadastrar nova cabra` (fluxo manual atual)
+  - `Importar da ABCC` (novo fluxo opcional)
+
+## Contratos consumidos no backend
+Todos os requests seguem apenas o backend do CapriGestor (sem chamada direta ao site da ABCC pelo navegador):
+
+- `POST /goatfarms/{farmId}/goats/imports/abcc/search`
+- `POST /goatfarms/{farmId}/goats/imports/abcc/preview`
+- `POST /goatfarms/{farmId}/goats/imports/abcc/confirm`
+
+Implementação frontend:
+- `src/api/GoatAPI/goatAbccImport.ts`
+
+## UX implementada
+Fluxo no modal `Importar animal da ABCC`:
+
+1. Busca ABCC
+- formulário com filtros mínimos (`raceId`, `affix`) e opcionais
+- estados tratados:
+  - loading
+  - vazio
+  - erro com retry
+
+2. Pré-visualização
+- seleção de item da busca
+- carregamento de preview consolidado
+- exibição de warnings de normalização quando vierem do backend
+
+3. Confirmação
+- revisão dos campos principais antes de confirmar
+- envio para endpoint de confirmação
+- feedback de sucesso/erro
+- recarga da listagem do rebanho após confirmação
+
+## Reaproveitamento aplicado
+- Fluxo manual mantido no mesmo ponto de entrada da lista.
+- Conversão de payload reutilizada via `mapGoatToBackend`.
+- Componentes UI já existentes reutilizados (`Modal`, `Button`, `Alert`, `LoadingState`, `EmptyState`, `ErrorState`).
+
+## O que foi criado
+- `src/Components/goat-abcc-import/GoatAbccImportModal.tsx`
+- `src/Components/goat-abcc-import/goatAbccImportModal.css`
+- `src/api/GoatAPI/goatAbccImport.ts`
+- `src/Pages/goat-list-page/GoatListActions.tsx`
+
+## Garantias
+- Frontend não integra direto com ABCC.
+- Cadastro manual permanece disponível e funcional.
+- Fluxo ABCC é opcional e independente.
+- Sem alteração de contrato do backend.

--- a/docs/GOAT_ABCC_IMPORT_FRONTEND.md
+++ b/docs/GOAT_ABCC_IMPORT_FRONTEND.md
@@ -16,6 +16,7 @@ Todos os requests seguem apenas o backend do CapriGestor (sem chamada direta ao 
 - `POST /goatfarms/{farmId}/goats/imports/abcc/search`
 - `POST /goatfarms/{farmId}/goats/imports/abcc/preview`
 - `POST /goatfarms/{farmId}/goats/imports/abcc/confirm`
+- `POST /goatfarms/{farmId}/goats/imports/abcc/confirm-batch`
 
 Implementação frontend:
 - `src/api/GoatAPI/goatAbccImport.ts`
@@ -24,7 +25,16 @@ Implementação frontend:
 Fluxo no modal `Importar animal da ABCC`:
 
 1. Busca ABCC
-- formulário com filtros mínimos (`raceId`, `affix`) e opcionais
+- formulário com filtros mínimos (`raceName`, `affix`) e opcionais
+- para usuário comum, o filtro de `TOD` fica restrito ao TOD da fazenda e o backend aplica a validação em profundidade
+- para `ROLE_ADMIN`, a UI sinaliza modo administrativo com override de TOD
+- paginação com navegação por `Página anterior` e `Próxima página`, usando `currentPage` e `totalPages` retornados pelo backend
+- seleção múltipla restrita à página atual:
+  - checkbox por item
+  - `Selecionar todos desta página`
+  - `Limpar seleção`
+  - `Importar selecionados`
+- resultado em lote com resumo e status por item (`IMPORTED`, `SKIPPED_DUPLICATE`, `ERROR`)
 - estados tratados:
   - loading
   - vazio
@@ -40,6 +50,19 @@ Fluxo no modal `Importar animal da ABCC`:
 - envio para endpoint de confirmação
 - feedback de sucesso/erro
 - recarga da listagem do rebanho após confirmação
+
+4. Confirmação em lote (página atual)
+- envia apenas os `externalId` selecionados da página corrente
+- o backend processa item a item e não derruba o lote inteiro por duplicidade ou TOD incompatível
+- duplicidade por `farmId + registrationNumber` retorna `SKIPPED_DUPLICATE`
+- TOD incompatível para usuário comum retorna `SKIPPED_TOD_MISMATCH`
+- a UI mostra:
+  - total selecionado
+  - total importado
+  - total ignorado por duplicidade
+  - total ignorado por TOD incompatível
+  - total com erro
+  - detalhe por item
 
 ## Reaproveitamento aplicado
 - Fluxo manual mantido no mesmo ponto de entrada da lista.
@@ -57,3 +80,6 @@ Fluxo no modal `Importar animal da ABCC`:
 - Cadastro manual permanece disponível e funcional.
 - Fluxo ABCC é opcional e independente.
 - Sem alteração de contrato do backend.
+- Usuário comum só opera importação ABCC dentro do TOD da fazenda.
+- `ROLE_ADMIN` visualiza e opera em modo de override administrativo de TOD.
+- Seleção em lote vale somente para a página atual da busca.

--- a/src/Components/goat-abcc-import/GoatAbccImportModal.test.tsx
+++ b/src/Components/goat-abcc-import/GoatAbccImportModal.test.tsx
@@ -7,6 +7,8 @@ import {
 
 function createBaseProps(): GoatAbccImportModalViewProps {
   return {
+    isAdminUser: false,
+    farmTod: "12345",
     raceOptions: [
       { id: 9, name: "SAANEN", normalizedBreed: "SAANEN" },
       { id: 2, name: "BOER", normalizedBreed: "BOER" },
@@ -31,6 +33,18 @@ function createBaseProps(): GoatAbccImportModalViewProps {
     searched: false,
     searchError: null,
     searchItems: [],
+    selectedBatchExternalIds: [],
+    onToggleBatchItemSelection: vi.fn(),
+    onSelectAllCurrentPage: vi.fn(),
+    onClearBatchSelection: vi.fn(),
+    onImportBatch: vi.fn(),
+    batchImporting: false,
+    batchResult: null,
+    batchImportError: null,
+    searchCurrentPage: 1,
+    searchTotalPages: 1,
+    onSearchPreviousPage: vi.fn(),
+    onSearchNextPage: vi.fn(),
     selectedExternalId: null,
     onSelectSearchItem: vi.fn(),
     previewLoading: false,
@@ -76,6 +90,7 @@ describe("GoatAbccImportModalView", () => {
     );
 
     expect(html).toContain("Importação ABCC opcional");
+    expect(html).toContain("restrita ao TOD da fazenda atual (12345)");
     expect(html).toContain("TOPAZIO");
     expect(html).toContain("Pré-visualizar");
   });
@@ -107,6 +122,94 @@ describe("GoatAbccImportModalView", () => {
 
     expect(html).toContain("Não foi possível consultar a ABCC");
     expect(html).toContain("Falha de rede na ABCC");
+  });
+
+  it("renders search pagination controls", () => {
+    const html = renderToStaticMarkup(
+      <GoatAbccImportModalView
+        {...createBaseProps()}
+        searched={true}
+        searchCurrentPage={2}
+        searchTotalPages={8}
+      />
+    );
+
+    expect(html).toContain("Página 2 de 8");
+    expect(html).toContain("Página anterior");
+    expect(html).toContain("Próxima página");
+  });
+
+  it("renders batch controls and summary feedback", () => {
+    const html = renderToStaticMarkup(
+      <GoatAbccImportModalView
+        {...createBaseProps()}
+        searched={true}
+        searchItems={[
+          {
+            externalSource: "ABCC_PUBLIC",
+            externalId: "ABCC-001",
+            nome: "TOPAZIO",
+            situacao: "RGD",
+            dna: "SIM",
+            tod: "12345",
+            toe: "67890",
+            criador: "ALBERTO",
+            afixo: "CAPRIL VILAR",
+            dataNascimento: "01/01/2020",
+            sexo: "MACHO",
+            raca: "SAANEN",
+            pelagem: "CHAMOISEE",
+            normalizedGender: "MACHO",
+            normalizedBreed: "SAANEN",
+            normalizedStatus: "ATIVO",
+            normalizationWarnings: [],
+          },
+        ]}
+        selectedBatchExternalIds={["ABCC-001"]}
+        batchResult={{
+          totalSelected: 2,
+          totalImported: 1,
+          totalSkippedDuplicate: 1,
+          totalSkippedTodMismatch: 0,
+          totalError: 0,
+          results: [
+            {
+              externalId: "ABCC-001",
+              registrationNumber: "1234567890",
+              name: "TOPAZIO",
+              status: "IMPORTED",
+              message: "Animal importado com sucesso.",
+            },
+            {
+              externalId: "ABCC-002",
+              registrationNumber: "2234567890",
+              name: "DUPLICADO",
+              status: "SKIPPED_DUPLICATE",
+              message: "Registro já existente nesta fazenda. Item ignorado por duplicidade.",
+            },
+          ],
+        }}
+      />
+    );
+
+    expect(html).toContain("Selecionados nesta página: 1");
+    expect(html).toContain("Selecionar todos desta página");
+    expect(html).toContain("Importar selecionados");
+    expect(html).toContain("Resultado da importação em lote");
+    expect(html).toContain("SKIPPED_DUPLICATE");
+    expect(html).toContain("Ignorados por TOD incompatível");
+  });
+
+  it("renders admin override copy when user is admin", () => {
+    const html = renderToStaticMarkup(
+      <GoatAbccImportModalView
+        {...createBaseProps()}
+        isAdminUser={true}
+      />
+    );
+
+    expect(html).toContain("Modo administrativo de importação ABCC");
+    expect(html).toContain("pode importar animais de qualquer TOD");
   });
 
   it("renders preview and confirm area", () => {
@@ -210,3 +313,6 @@ describe("GoatAbccImportModalView", () => {
     expect(html).toContain("Importação concluída com sucesso");
   });
 });
+
+
+

--- a/src/Components/goat-abcc-import/GoatAbccImportModal.test.tsx
+++ b/src/Components/goat-abcc-import/GoatAbccImportModal.test.tsx
@@ -1,0 +1,212 @@
+﻿import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import {
+  GoatAbccImportModalView,
+  type GoatAbccImportModalViewProps,
+} from "./GoatAbccImportModal";
+
+function createBaseProps(): GoatAbccImportModalViewProps {
+  return {
+    raceOptions: [
+      { id: 9, name: "SAANEN", normalizedBreed: "SAANEN" },
+      { id: 2, name: "BOER", normalizedBreed: "BOER" },
+    ],
+    racesLoading: false,
+    racesError: null,
+    onRetryLoadRaces: vi.fn(),
+    searchFilters: {
+      raceName: "SAANEN",
+      affix: "CAPRIL VILAR",
+      page: "1",
+      sex: "",
+      tod: "",
+      toe: "",
+      name: "",
+      dna: "",
+    },
+    onSearchFieldChange: vi.fn(),
+    onSearchSubmit: vi.fn(),
+    onResetFlow: vi.fn(),
+    searching: false,
+    searched: false,
+    searchError: null,
+    searchItems: [],
+    selectedExternalId: null,
+    onSelectSearchItem: vi.fn(),
+    previewLoading: false,
+    previewError: null,
+    previewData: null,
+    previewForm: null,
+    onPreviewFieldChange: vi.fn(),
+    onConfirmImport: vi.fn(),
+    confirming: false,
+    confirmError: null,
+    confirmSuccess: null,
+  };
+}
+
+describe("GoatAbccImportModalView", () => {
+  it("renders ABCC optional import copy and search success list", () => {
+    const html = renderToStaticMarkup(
+      <GoatAbccImportModalView
+        {...createBaseProps()}
+        searched={true}
+        searchItems={[
+          {
+            externalSource: "ABCC_PUBLIC",
+            externalId: "ABCC-001",
+            nome: "TOPAZIO",
+            situacao: "RGD",
+            dna: "SIM",
+            tod: "12345",
+            toe: "67890",
+            criador: "ALBERTO",
+            afixo: "CAPRIL VILAR",
+            dataNascimento: "01/01/2020",
+            sexo: "MACHO",
+            raca: "SAANEN",
+            pelagem: "CHAMOISEE",
+            normalizedGender: "MACHO",
+            normalizedBreed: "SAANEN",
+            normalizedStatus: "ATIVO",
+            normalizationWarnings: [],
+          },
+        ]}
+      />
+    );
+
+    expect(html).toContain("Importação ABCC opcional");
+    expect(html).toContain("TOPAZIO");
+    expect(html).toContain("Pré-visualizar");
+  });
+
+  it("renders race loading state", () => {
+    const html = renderToStaticMarkup(
+      <GoatAbccImportModalView {...createBaseProps()} racesLoading={true} />
+    );
+
+    expect(html).toContain("Carregando raças da ABCC");
+  });
+
+  it("renders empty state after search with no items", () => {
+    const html = renderToStaticMarkup(
+      <GoatAbccImportModalView {...createBaseProps()} searched={true} searchItems={[]} />
+    );
+
+    expect(html).toContain("Nenhum animal encontrado na ABCC");
+  });
+
+  it("renders search error state", () => {
+    const html = renderToStaticMarkup(
+      <GoatAbccImportModalView
+        {...createBaseProps()}
+        searched={true}
+        searchError="Falha de rede na ABCC"
+      />
+    );
+
+    expect(html).toContain("Não foi possível consultar a ABCC");
+    expect(html).toContain("Falha de rede na ABCC");
+  });
+
+  it("renders preview and confirm area", () => {
+    const html = renderToStaticMarkup(
+      <GoatAbccImportModalView
+        {...createBaseProps()}
+        selectedExternalId="ABCC-001"
+        previewData={{
+          externalSource: "ABCC_PUBLIC",
+          externalId: "ABCC-001",
+          registrationNumber: "1234567890",
+          name: "TOPAZIO",
+          gender: "MACHO",
+          breed: "SAANEN",
+          color: "CHAMOISEE",
+          birthDate: "2020-01-01",
+          status: "ATIVO",
+          tod: "12345",
+          toe: "67890",
+          category: "PA",
+          fatherName: "PAI",
+          fatherRegistrationNumber: "1234511111",
+          motherName: "MAE",
+          motherRegistrationNumber: "1234522222",
+          userName: "Alberto",
+          farmId: 1,
+          farmName: "Capril Vilar",
+          normalizationWarnings: ["Categoria ABCC PCOD mapeada para PC por compatibilidade."],
+        }}
+        previewForm={{
+          registrationNumber: "1234567890",
+          name: "TOPAZIO",
+          genderLabel: "Macho",
+          breed: "SAANEN",
+          color: "CHAMOISEE",
+          birthDate: "2020-01-01",
+          statusLabel: "Ativo",
+          tod: "12345",
+          toe: "67890",
+          category: "PA",
+          fatherRegistrationNumber: "1234511111",
+          motherRegistrationNumber: "1234522222",
+        }}
+      />
+    );
+
+    expect(html).toContain("Pré-visualização e confirmação");
+    expect(html).toContain("TOPAZIO");
+    expect(html).toContain("Confirmar importação");
+    expect(html).toContain("Atenção aos campos normalizados");
+  });
+
+  it("renders confirm error and success feedback", () => {
+    const html = renderToStaticMarkup(
+      <GoatAbccImportModalView
+        {...createBaseProps()}
+        selectedExternalId="ABCC-001"
+        previewForm={{
+          registrationNumber: "1234567890",
+          name: "TOPAZIO",
+          genderLabel: "Macho",
+          breed: "SAANEN",
+          color: "CHAMOISEE",
+          birthDate: "2020-01-01",
+          statusLabel: "Ativo",
+          tod: "12345",
+          toe: "67890",
+          category: "PA",
+          fatherRegistrationNumber: "",
+          motherRegistrationNumber: "",
+        }}
+        previewData={{
+          externalSource: "ABCC_PUBLIC",
+          externalId: "ABCC-001",
+          registrationNumber: "1234567890",
+          name: "TOPAZIO",
+          gender: "MACHO",
+          breed: "SAANEN",
+          color: "CHAMOISEE",
+          birthDate: "2020-01-01",
+          status: "ATIVO",
+          tod: "12345",
+          toe: "67890",
+          category: "PA",
+          fatherName: "",
+          fatherRegistrationNumber: "",
+          motherName: "",
+          motherRegistrationNumber: "",
+          userName: "Alberto",
+          farmId: 1,
+          farmName: "Capril Vilar",
+          normalizationWarnings: [],
+        }}
+        confirmError="Registro já existente"
+        confirmSuccess="Animal 1234567890 importado com sucesso."
+      />
+    );
+
+    expect(html).toContain("Falha ao confirmar a importação");
+    expect(html).toContain("Registro já existente");
+    expect(html).toContain("Importação concluída com sucesso");
+  });
+});

--- a/src/Components/goat-abcc-import/GoatAbccImportModal.tsx
+++ b/src/Components/goat-abcc-import/GoatAbccImportModal.tsx
@@ -1,0 +1,818 @@
+﻿import { useEffect, useMemo, useState } from "react";
+import { toast } from "react-toastify";
+import {
+  confirmGoatImportFromAbcc,
+  previewGoatFromAbcc,
+  searchGoatsByAbcc,
+  type GoatAbccFilterDna,
+  type GoatAbccFilterSex,
+  type GoatAbccPreviewResponseDTO,
+  type GoatAbccSearchItemDTO,
+} from "../../api/GoatAPI/goatAbccImport";
+import {
+  mapGoatToBackend,
+  type GoatFormData,
+} from "../../Convertes/goats/goatConverter";
+import { GoatCategoryEnum, categoryLabels } from "../../types/goatEnums";
+import { getApiErrorMessage, parseApiError } from "../../utils/apiError";
+import { UI_GENDER_LABELS, UI_STATUS_LABELS } from "../../utils/i18nGoat";
+import { Alert, Button, EmptyState, ErrorState, LoadingState, Modal } from "../ui";
+import "./goatAbccImportModal.css";
+
+interface GoatAbccImportModalProps {
+  isOpen: boolean;
+  farmId: number;
+  defaultTod?: string;
+  onClose: () => void;
+  onImported: () => void;
+}
+
+interface GoatAbccSearchFilters {
+  raceId: string;
+  affix: string;
+  page: string;
+  sex: "" | GoatAbccFilterSex;
+  tod: string;
+  toe: string;
+  name: string;
+  dna: "" | GoatAbccFilterDna;
+}
+
+export interface GoatAbccPreviewFormData extends GoatFormData {
+  registrationNumber: string;
+  name: string;
+  genderLabel: "Macho" | "Fêmea";
+  breed: string;
+  color: string;
+  birthDate: string;
+  statusLabel: "Ativo" | "Inativo" | "Vendido" | "Falecido";
+  tod: string;
+  toe: string;
+  category: GoatCategoryEnum;
+  fatherRegistrationNumber: string;
+  motherRegistrationNumber: string;
+}
+
+export interface GoatAbccImportModalViewProps {
+  searchFilters: GoatAbccSearchFilters;
+  onSearchFieldChange: <K extends keyof GoatAbccSearchFilters>(
+    field: K,
+    value: GoatAbccSearchFilters[K]
+  ) => void;
+  onSearchSubmit: () => void;
+  onResetFlow: () => void;
+  searching: boolean;
+  searched: boolean;
+  searchError: string | null;
+  searchItems: GoatAbccSearchItemDTO[];
+  selectedExternalId: string | null;
+  onSelectSearchItem: (item: GoatAbccSearchItemDTO) => void;
+  previewLoading: boolean;
+  previewError: string | null;
+  previewData: GoatAbccPreviewResponseDTO | null;
+  previewForm: GoatAbccPreviewFormData | null;
+  onPreviewFieldChange: <K extends keyof GoatAbccPreviewFormData>(
+    field: K,
+    value: GoatAbccPreviewFormData[K]
+  ) => void;
+  onConfirmImport: () => void;
+  confirming: boolean;
+  confirmError: string | null;
+  confirmSuccess: string | null;
+}
+
+const BREED_OPTIONS = [
+  "ALPINE",
+  "ALPINA",
+  "ANGLO_NUBIANA",
+  "BOER",
+  "MESTICA",
+  "MURCIANA_GRANADINA",
+  "SAANEN",
+  "TOGGENBURG",
+] as const;
+
+const initialSearchFilters: GoatAbccSearchFilters = {
+  raceId: "",
+  affix: "",
+  page: "1",
+  sex: "",
+  tod: "",
+  toe: "",
+  name: "",
+  dna: "",
+};
+
+function toGenderLabel(value?: string | null): "Macho" | "Fêmea" {
+  const normalized = `${value ?? ""}`.toUpperCase();
+  if (normalized.includes("FEMEA") || normalized.includes("FÊMEA") || normalized.includes("FEMALE")) {
+    return "Fêmea";
+  }
+  return "Macho";
+}
+
+function toStatusLabel(value?: string | null): "Ativo" | "Inativo" | "Vendido" | "Falecido" {
+  const normalized = `${value ?? ""}`.toUpperCase();
+  if (normalized.includes("INAT")) {
+    return "Inativo";
+  }
+  if (normalized.includes("VEND")) {
+    return "Vendido";
+  }
+  if (normalized.includes("FALEC") || normalized.includes("OBITO") || normalized.includes("MORT")) {
+    return "Falecido";
+  }
+  return "Ativo";
+}
+
+function toCategory(value?: string | null): GoatCategoryEnum {
+  const normalized = `${value ?? ""}`.toUpperCase().trim();
+  if (normalized === GoatCategoryEnum.PO) {
+    return GoatCategoryEnum.PO;
+  }
+  if (normalized === GoatCategoryEnum.PC) {
+    return GoatCategoryEnum.PC;
+  }
+  return GoatCategoryEnum.PA;
+}
+
+function formatDate(value?: string | null): string {
+  if (!value) {
+    return "-";
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+  return parsed.toLocaleDateString("pt-BR");
+}
+
+function buildPreviewFormData(
+  preview: GoatAbccPreviewResponseDTO,
+  defaultTod?: string
+): GoatAbccPreviewFormData {
+  const tod = preview.tod?.trim() || defaultTod?.trim() || "";
+  const toe = preview.toe?.trim() || "";
+  const inferredRegistration = `${tod}${toe}`.trim();
+
+  return {
+    registrationNumber: preview.registrationNumber?.trim() || inferredRegistration,
+    name: preview.name?.trim() || "",
+    genderLabel: toGenderLabel(preview.gender),
+    breed: preview.breed?.trim() || "",
+    color: preview.color?.trim() || "",
+    birthDate: preview.birthDate?.trim() || "",
+    statusLabel: toStatusLabel(preview.status),
+    tod,
+    toe,
+    category: toCategory(preview.category),
+    fatherRegistrationNumber: preview.fatherRegistrationNumber?.trim() || "",
+    motherRegistrationNumber: preview.motherRegistrationNumber?.trim() || "",
+  };
+}
+
+function buildSearchPayload(filters: GoatAbccSearchFilters) {
+  return {
+    raceId: Number(filters.raceId),
+    affix: filters.affix.trim(),
+    page: Number(filters.page || "1"),
+    sex: filters.sex || undefined,
+    tod: filters.tod.trim() || undefined,
+    toe: filters.toe.trim() || undefined,
+    name: filters.name.trim() || undefined,
+    dna: filters.dna || undefined,
+  };
+}
+
+export function GoatAbccImportModalView({
+  searchFilters,
+  onSearchFieldChange,
+  onSearchSubmit,
+  onResetFlow,
+  searching,
+  searched,
+  searchError,
+  searchItems,
+  selectedExternalId,
+  onSelectSearchItem,
+  previewLoading,
+  previewError,
+  previewData,
+  previewForm,
+  onPreviewFieldChange,
+  onConfirmImport,
+  confirming,
+  confirmError,
+  confirmSuccess,
+}: GoatAbccImportModalViewProps) {
+  const selectedItem = useMemo(
+    () => searchItems.find((item) => item.externalId === selectedExternalId) ?? null,
+    [searchItems, selectedExternalId]
+  );
+
+  return (
+    <div className="goat-abcc-import">
+      <Alert variant="info" title="Importação ABCC opcional">
+        O cadastro manual continua disponível. Use a ABCC apenas quando quiser trazer dados públicos para conferência.
+      </Alert>
+
+      <section className="goat-abcc-import__panel">
+        <div className="goat-abcc-import__panel-head">
+          <div>
+            <h3>1. Buscar na ABCC</h3>
+            <p>Preencha os filtros mínimos para localizar o animal público antes da pré-visualização.</p>
+          </div>
+          <Button variant="ghost" onClick={onResetFlow}>
+            Limpar
+          </Button>
+        </div>
+
+        <div className="goat-abcc-import__grid">
+          <label className="goat-abcc-import__field">
+            <span>ID da raça ABCC *</span>
+            <input
+              type="number"
+              min="1"
+              value={searchFilters.raceId}
+              onChange={(event) => onSearchFieldChange("raceId", event.target.value)}
+              placeholder="Ex.: 1"
+            />
+          </label>
+
+          <label className="goat-abcc-import__field">
+            <span>Afixo *</span>
+            <input
+              type="text"
+              value={searchFilters.affix}
+              onChange={(event) => onSearchFieldChange("affix", event.target.value)}
+              placeholder="Ex.: CAPRIL VILAR"
+            />
+          </label>
+
+          <label className="goat-abcc-import__field">
+            <span>Nome</span>
+            <input
+              type="text"
+              value={searchFilters.name}
+              onChange={(event) => onSearchFieldChange("name", event.target.value)}
+              placeholder="Nome do animal"
+            />
+          </label>
+
+          <label className="goat-abcc-import__field">
+            <span>Página</span>
+            <input
+              type="number"
+              min="1"
+              value={searchFilters.page}
+              onChange={(event) => onSearchFieldChange("page", event.target.value)}
+            />
+          </label>
+
+          <label className="goat-abcc-import__field">
+            <span>Sexo</span>
+            <select
+              value={searchFilters.sex}
+              onChange={(event) =>
+                onSearchFieldChange("sex", event.target.value as GoatAbccSearchFilters["sex"])
+              }
+            >
+              <option value="">Todos</option>
+              <option value="1">Macho</option>
+              <option value="0">Fêmea</option>
+            </select>
+          </label>
+
+          <label className="goat-abcc-import__field">
+            <span>DNA</span>
+            <select
+              value={searchFilters.dna}
+              onChange={(event) =>
+                onSearchFieldChange("dna", event.target.value as GoatAbccSearchFilters["dna"])
+              }
+            >
+              <option value="">Todos</option>
+              <option value="1">Com DNA</option>
+              <option value="0">Sem DNA</option>
+            </select>
+          </label>
+
+          <label className="goat-abcc-import__field">
+            <span>TOD</span>
+            <input
+              type="text"
+              value={searchFilters.tod}
+              onChange={(event) => onSearchFieldChange("tod", event.target.value)}
+              placeholder="Orelha direita"
+            />
+          </label>
+
+          <label className="goat-abcc-import__field">
+            <span>TOE</span>
+            <input
+              type="text"
+              value={searchFilters.toe}
+              onChange={(event) => onSearchFieldChange("toe", event.target.value)}
+              placeholder="Orelha esquerda"
+            />
+          </label>
+        </div>
+
+        <div className="goat-abcc-import__actions">
+          <Button variant="primary" onClick={onSearchSubmit} loading={searching}>
+            Buscar animais
+          </Button>
+        </div>
+
+        {searching && <LoadingState label="Consultando ABCC pública..." />}
+
+        {!searching && searchError && (
+          <ErrorState
+            title="Não foi possível consultar a ABCC"
+            description={searchError}
+            onRetry={onSearchSubmit}
+          />
+        )}
+
+        {!searching && !searchError && searched && searchItems.length === 0 && (
+          <EmptyState
+            title="Nenhum animal encontrado na ABCC"
+            description="Revise os filtros de busca e tente novamente."
+          />
+        )}
+
+        {!searching && !searchError && searchItems.length > 0 && (
+          <div className="goat-abcc-import__result-list">
+            {searchItems.map((item) => {
+              const isSelected = item.externalId === selectedExternalId;
+              return (
+                <article
+                  key={item.externalId}
+                  className={`goat-abcc-import__result-item ${isSelected ? "is-selected" : ""}`}
+                >
+                  <div>
+                    <h4>{item.nome || "Animal sem nome"}</h4>
+                    <p>
+                      {item.raca || "Raça não informada"} · {item.sexo || "Sexo não informado"} · {item.situacao || "Situação não informada"}
+                    </p>
+                    <small>
+                      TOD/TOE: {(item.tod || "-") + (item.toe || "")} · Nascimento: {item.dataNascimento || "-"}
+                    </small>
+                    {!!item.normalizationWarnings?.length && (
+                      <ul className="goat-abcc-import__warning-list">
+                        {item.normalizationWarnings.map((warning) => (
+                          <li key={warning}>{warning}</li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
+
+                  <Button
+                    variant="secondary"
+                    disabled={!item.externalId}
+                    onClick={() => onSelectSearchItem(item)}
+                  >
+                    Pré-visualizar
+                  </Button>
+                </article>
+              );
+            })}
+          </div>
+        )}
+      </section>
+
+      <section className="goat-abcc-import__panel">
+        <div className="goat-abcc-import__panel-head">
+          <div>
+            <h3>2. Pré-visualização e confirmação</h3>
+            <p>Revise os dados antes de confirmar a criação do animal no CapriGestor.</p>
+          </div>
+        </div>
+
+        {!selectedExternalId && (
+          <EmptyState
+            title="Selecione um animal na busca"
+            description="Use o botão de pré-visualização para trazer os dados consolidados da ABCC."
+          />
+        )}
+
+        {selectedExternalId && previewLoading && <LoadingState label="Carregando pré-visualização..." />}
+
+        {selectedExternalId && !previewLoading && previewError && (
+          <ErrorState
+            title="Não foi possível carregar a pré-visualização"
+            description={previewError}
+          />
+        )}
+
+        {selectedExternalId && !previewLoading && !previewError && previewForm && (
+          <div className="goat-abcc-import__preview-wrap">
+            {previewData && (
+              <div className="goat-abcc-import__preview-context">
+                <div>
+                  <span>Fonte</span>
+                  <strong>{previewData.externalSource || "ABCC_PUBLIC"}</strong>
+                </div>
+                <div>
+                  <span>Fazenda</span>
+                  <strong>{previewData.farmName || "Fazenda atual"}</strong>
+                </div>
+                <div>
+                  <span>Responsável</span>
+                  <strong>{previewData.userName || "Usuário atual"}</strong>
+                </div>
+                <div>
+                  <span>Nascimento</span>
+                  <strong>{formatDate(previewData.birthDate)}</strong>
+                </div>
+              </div>
+            )}
+
+            {!!previewData?.normalizationWarnings?.length && (
+              <Alert variant="warning" title="Atenção aos campos normalizados">
+                <ul className="goat-abcc-import__warning-list">
+                  {previewData.normalizationWarnings.map((warning) => (
+                    <li key={warning}>{warning}</li>
+                  ))}
+                </ul>
+              </Alert>
+            )}
+
+            {confirmSuccess && (
+              <Alert variant="success" title="Importação concluída com sucesso">
+                {confirmSuccess}
+              </Alert>
+            )}
+
+            {confirmError && (
+              <Alert variant="error" title="Falha ao confirmar a importação">
+                {confirmError}
+              </Alert>
+            )}
+
+            <div className="goat-abcc-import__grid">
+              <label className="goat-abcc-import__field">
+                <span>Número de registro *</span>
+                <input
+                  type="text"
+                  value={previewForm.registrationNumber}
+                  onChange={(event) => onPreviewFieldChange("registrationNumber", event.target.value)}
+                />
+              </label>
+
+              <label className="goat-abcc-import__field">
+                <span>Nome *</span>
+                <input
+                  type="text"
+                  value={previewForm.name}
+                  onChange={(event) => onPreviewFieldChange("name", event.target.value)}
+                />
+              </label>
+
+              <label className="goat-abcc-import__field">
+                <span>Sexo *</span>
+                <select
+                  value={previewForm.genderLabel}
+                  onChange={(event) =>
+                    onPreviewFieldChange("genderLabel", event.target.value as GoatAbccPreviewFormData["genderLabel"])
+                  }
+                >
+                  {UI_GENDER_LABELS.map((label) => (
+                    <option key={label} value={label}>
+                      {label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <label className="goat-abcc-import__field">
+                <span>Raça *</span>
+                <select
+                  value={previewForm.breed}
+                  onChange={(event) => onPreviewFieldChange("breed", event.target.value)}
+                >
+                  <option value="">Selecione a raça</option>
+                  {BREED_OPTIONS.map((breed) => (
+                    <option key={breed} value={breed}>
+                      {breed}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <label className="goat-abcc-import__field">
+                <span>Cor *</span>
+                <input
+                  type="text"
+                  value={previewForm.color}
+                  onChange={(event) => onPreviewFieldChange("color", event.target.value)}
+                />
+              </label>
+
+              <label className="goat-abcc-import__field">
+                <span>Data de nascimento *</span>
+                <input
+                  type="date"
+                  value={previewForm.birthDate}
+                  onChange={(event) => onPreviewFieldChange("birthDate", event.target.value)}
+                />
+              </label>
+
+              <label className="goat-abcc-import__field">
+                <span>Status *</span>
+                <select
+                  value={previewForm.statusLabel}
+                  onChange={(event) =>
+                    onPreviewFieldChange("statusLabel", event.target.value as GoatAbccPreviewFormData["statusLabel"])
+                  }
+                >
+                  {UI_STATUS_LABELS.map((label) => (
+                    <option key={label} value={label}>
+                      {label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <label className="goat-abcc-import__field">
+                <span>Categoria</span>
+                <select
+                  value={previewForm.category}
+                  onChange={(event) =>
+                    onPreviewFieldChange("category", event.target.value as GoatAbccPreviewFormData["category"])
+                  }
+                >
+                  {Object.values(GoatCategoryEnum).map((category) => (
+                    <option key={category} value={category}>
+                      {categoryLabels[category]}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <label className="goat-abcc-import__field">
+                <span>TOD *</span>
+                <input
+                  type="text"
+                  value={previewForm.tod}
+                  onChange={(event) => onPreviewFieldChange("tod", event.target.value)}
+                />
+              </label>
+
+              <label className="goat-abcc-import__field">
+                <span>TOE *</span>
+                <input
+                  type="text"
+                  value={previewForm.toe}
+                  onChange={(event) => onPreviewFieldChange("toe", event.target.value)}
+                />
+              </label>
+
+              <label className="goat-abcc-import__field">
+                <span>Registro do pai</span>
+                <input
+                  type="text"
+                  value={previewForm.fatherRegistrationNumber}
+                  onChange={(event) =>
+                    onPreviewFieldChange("fatherRegistrationNumber", event.target.value)
+                  }
+                />
+              </label>
+
+              <label className="goat-abcc-import__field">
+                <span>Registro da mãe</span>
+                <input
+                  type="text"
+                  value={previewForm.motherRegistrationNumber}
+                  onChange={(event) =>
+                    onPreviewFieldChange("motherRegistrationNumber", event.target.value)
+                  }
+                />
+              </label>
+            </div>
+
+            <div className="goat-abcc-import__actions goat-abcc-import__actions--confirm">
+              <Button variant="success" loading={confirming} onClick={onConfirmImport}>
+                Confirmar importação
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {!selectedExternalId && selectedItem && (
+          <p className="goat-abcc-import__selected-tip">
+            Animal selecionado: {selectedItem.nome}
+          </p>
+        )}
+      </section>
+    </div>
+  );
+}
+
+export default function GoatAbccImportModal({
+  isOpen,
+  farmId,
+  defaultTod,
+  onClose,
+  onImported,
+}: GoatAbccImportModalProps) {
+  const [searchFilters, setSearchFilters] = useState<GoatAbccSearchFilters>(initialSearchFilters);
+  const [searching, setSearching] = useState(false);
+  const [searched, setSearched] = useState(false);
+  const [searchError, setSearchError] = useState<string | null>(null);
+  const [searchItems, setSearchItems] = useState<GoatAbccSearchItemDTO[]>([]);
+
+  const [selectedExternalId, setSelectedExternalId] = useState<string | null>(null);
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+  const [previewData, setPreviewData] = useState<GoatAbccPreviewResponseDTO | null>(null);
+  const [previewForm, setPreviewForm] = useState<GoatAbccPreviewFormData | null>(null);
+
+  const [confirming, setConfirming] = useState(false);
+  const [confirmError, setConfirmError] = useState<string | null>(null);
+  const [confirmSuccess, setConfirmSuccess] = useState<string | null>(null);
+
+  function resetFlow() {
+    setSearchFilters(initialSearchFilters);
+    setSearching(false);
+    setSearched(false);
+    setSearchError(null);
+    setSearchItems([]);
+    setSelectedExternalId(null);
+    setPreviewLoading(false);
+    setPreviewError(null);
+    setPreviewData(null);
+    setPreviewForm(null);
+    setConfirming(false);
+    setConfirmError(null);
+    setConfirmSuccess(null);
+  }
+
+  useEffect(() => {
+    if (isOpen) {
+      resetFlow();
+    }
+
+  }, [isOpen]);
+
+  function handleSearchFieldChange<K extends keyof GoatAbccSearchFilters>(
+    field: K,
+    value: GoatAbccSearchFilters[K]
+  ) {
+    setSearchFilters((previous) => ({
+      ...previous,
+      [field]: value,
+    }));
+  }
+
+  async function handleSearchSubmit() {
+    if (!searchFilters.raceId.trim()) {
+      setSearchError("Informe o ID da raça ABCC para buscar.");
+      return;
+    }
+
+    if (!searchFilters.affix.trim()) {
+      setSearchError("Informe o afixo para buscar na ABCC.");
+      return;
+    }
+
+    try {
+      setSearching(true);
+      setSearched(false);
+      setSearchError(null);
+      setSearchItems([]);
+      setSelectedExternalId(null);
+      setPreviewData(null);
+      setPreviewForm(null);
+      setPreviewError(null);
+      setConfirmError(null);
+      setConfirmSuccess(null);
+
+      const response = await searchGoatsByAbcc(farmId, buildSearchPayload(searchFilters));
+      setSearchItems(response.items ?? []);
+      setSearched(true);
+    } catch (error) {
+      setSearched(true);
+      setSearchError(getApiErrorMessage(parseApiError(error)));
+    } finally {
+      setSearching(false);
+    }
+  }
+
+  async function handleSelectSearchItem(item: GoatAbccSearchItemDTO) {
+    if (!item.externalId) {
+      toast.error("Animal sem identificador externo. Não é possível abrir o preview.");
+      return;
+    }
+
+    try {
+      setSelectedExternalId(item.externalId);
+      setPreviewLoading(true);
+      setPreviewError(null);
+      setPreviewData(null);
+      setPreviewForm(null);
+      setConfirmError(null);
+      setConfirmSuccess(null);
+
+      const response = await previewGoatFromAbcc(farmId, item.externalId);
+      setPreviewData(response);
+      setPreviewForm(buildPreviewFormData(response, defaultTod));
+    } catch (error) {
+      setPreviewError(getApiErrorMessage(parseApiError(error)));
+    } finally {
+      setPreviewLoading(false);
+    }
+  }
+
+  function handlePreviewFieldChange<K extends keyof GoatAbccPreviewFormData>(
+    field: K,
+    value: GoatAbccPreviewFormData[K]
+  ) {
+    setPreviewForm((previous) => {
+      if (!previous) {
+        return previous;
+      }
+      return {
+        ...previous,
+        [field]: value,
+      };
+    });
+  }
+
+  async function handleConfirmImport() {
+    if (!previewForm || !selectedExternalId) {
+      setConfirmError("Selecione um animal e carregue a pré-visualização antes de confirmar.");
+      return;
+    }
+
+    if (
+      !previewForm.registrationNumber?.trim() ||
+      !previewForm.name?.trim() ||
+      !previewForm.breed?.trim() ||
+      !previewForm.color?.trim() ||
+      !previewForm.birthDate?.trim() ||
+      !previewForm.tod?.trim() ||
+      !previewForm.toe?.trim()
+    ) {
+      setConfirmError(
+        "Preencha os campos obrigatórios (registro, nome, raça, cor, nascimento, TOD e TOE) antes de confirmar."
+      );
+      return;
+    }
+
+    try {
+      setConfirming(true);
+      setConfirmError(null);
+      setConfirmSuccess(null);
+
+      const payload = mapGoatToBackend(previewForm);
+      const createdGoat = await confirmGoatImportFromAbcc(farmId, {
+        externalId: selectedExternalId,
+        goat: payload,
+      });
+
+      const successMessage = `Animal ${createdGoat.registrationNumber} importado com sucesso.`;
+      setConfirmSuccess(successMessage);
+      toast.success(successMessage);
+      onImported();
+    } catch (error) {
+      const message = getApiErrorMessage(parseApiError(error));
+      setConfirmError(message);
+      toast.error(message);
+    } finally {
+      setConfirming(false);
+    }
+  }
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Importar animal da ABCC"
+      size="xl"
+      className="goat-abcc-import__modal"
+    >
+      <GoatAbccImportModalView
+        searchFilters={searchFilters}
+        onSearchFieldChange={handleSearchFieldChange}
+        onSearchSubmit={handleSearchSubmit}
+        onResetFlow={resetFlow}
+        searching={searching}
+        searched={searched}
+        searchError={searchError}
+        searchItems={searchItems}
+        selectedExternalId={selectedExternalId}
+        onSelectSearchItem={handleSelectSearchItem}
+        previewLoading={previewLoading}
+        previewError={previewError}
+        previewData={previewData}
+        previewForm={previewForm}
+        onPreviewFieldChange={handlePreviewFieldChange}
+        onConfirmImport={handleConfirmImport}
+        confirming={confirming}
+        confirmError={confirmError}
+        confirmSuccess={confirmSuccess}
+      />
+    </Modal>
+  );
+}

--- a/src/Components/goat-abcc-import/GoatAbccImportModal.tsx
+++ b/src/Components/goat-abcc-import/GoatAbccImportModal.tsx
@@ -1,19 +1,21 @@
-﻿import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "react-toastify";
 import {
   confirmGoatImportFromAbcc,
+  listAbccRaceOptions,
   previewGoatFromAbcc,
   searchGoatsByAbcc,
   type GoatAbccFilterDna,
   type GoatAbccFilterSex,
   type GoatAbccPreviewResponseDTO,
+  type GoatAbccRaceOptionDTO,
   type GoatAbccSearchItemDTO,
 } from "../../api/GoatAPI/goatAbccImport";
 import {
   mapGoatToBackend,
   type GoatFormData,
 } from "../../Convertes/goats/goatConverter";
-import { GoatCategoryEnum, categoryLabels } from "../../types/goatEnums";
+import { GoatBreedEnum, GoatCategoryEnum, breedLabels, categoryLabels } from "../../types/goatEnums";
 import { getApiErrorMessage, parseApiError } from "../../utils/apiError";
 import { UI_GENDER_LABELS, UI_STATUS_LABELS } from "../../utils/i18nGoat";
 import { Alert, Button, EmptyState, ErrorState, LoadingState, Modal } from "../ui";
@@ -28,7 +30,7 @@ interface GoatAbccImportModalProps {
 }
 
 interface GoatAbccSearchFilters {
-  raceId: string;
+  raceName: string;
   affix: string;
   page: string;
   sex: "" | GoatAbccFilterSex;
@@ -54,6 +56,10 @@ export interface GoatAbccPreviewFormData extends GoatFormData {
 }
 
 export interface GoatAbccImportModalViewProps {
+  raceOptions: GoatAbccRaceOptionDTO[];
+  racesLoading: boolean;
+  racesError: string | null;
+  onRetryLoadRaces: () => void;
   searchFilters: GoatAbccSearchFilters;
   onSearchFieldChange: <K extends keyof GoatAbccSearchFilters>(
     field: K,
@@ -81,19 +87,10 @@ export interface GoatAbccImportModalViewProps {
   confirmSuccess: string | null;
 }
 
-const BREED_OPTIONS = [
-  "ALPINE",
-  "ALPINA",
-  "ANGLO_NUBIANA",
-  "BOER",
-  "MESTICA",
-  "MURCIANA_GRANADINA",
-  "SAANEN",
-  "TOGGENBURG",
-] as const;
+const BREED_OPTIONS = Object.values(GoatBreedEnum) as GoatBreedEnum[];
 
 const initialSearchFilters: GoatAbccSearchFilters = {
-  raceId: "",
+  raceName: "",
   affix: "",
   page: "1",
   sex: "",
@@ -171,9 +168,12 @@ function buildPreviewFormData(
   };
 }
 
-function buildSearchPayload(filters: GoatAbccSearchFilters) {
+function buildSearchPayload(filters: GoatAbccSearchFilters, raceOptions: GoatAbccRaceOptionDTO[]) {
+  const selectedRace = raceOptions.find((option) => option.name === filters.raceName);
+
   return {
-    raceId: Number(filters.raceId),
+    raceId: selectedRace?.id,
+    raceName: filters.raceName.trim(),
     affix: filters.affix.trim(),
     page: Number(filters.page || "1"),
     sex: filters.sex || undefined,
@@ -185,6 +185,10 @@ function buildSearchPayload(filters: GoatAbccSearchFilters) {
 }
 
 export function GoatAbccImportModalView({
+  raceOptions,
+  racesLoading,
+  racesError,
+  onRetryLoadRaces,
   searchFilters,
   onSearchFieldChange,
   onSearchSubmit,
@@ -227,157 +231,175 @@ export function GoatAbccImportModalView({
           </Button>
         </div>
 
-        <div className="goat-abcc-import__grid">
-          <label className="goat-abcc-import__field">
-            <span>ID da raça ABCC *</span>
-            <input
-              type="number"
-              min="1"
-              value={searchFilters.raceId}
-              onChange={(event) => onSearchFieldChange("raceId", event.target.value)}
-              placeholder="Ex.: 1"
-            />
-          </label>
+        {racesLoading && <LoadingState label="Carregando raças da ABCC..." />}
 
-          <label className="goat-abcc-import__field">
-            <span>Afixo *</span>
-            <input
-              type="text"
-              value={searchFilters.affix}
-              onChange={(event) => onSearchFieldChange("affix", event.target.value)}
-              placeholder="Ex.: CAPRIL VILAR"
-            />
-          </label>
-
-          <label className="goat-abcc-import__field">
-            <span>Nome</span>
-            <input
-              type="text"
-              value={searchFilters.name}
-              onChange={(event) => onSearchFieldChange("name", event.target.value)}
-              placeholder="Nome do animal"
-            />
-          </label>
-
-          <label className="goat-abcc-import__field">
-            <span>Página</span>
-            <input
-              type="number"
-              min="1"
-              value={searchFilters.page}
-              onChange={(event) => onSearchFieldChange("page", event.target.value)}
-            />
-          </label>
-
-          <label className="goat-abcc-import__field">
-            <span>Sexo</span>
-            <select
-              value={searchFilters.sex}
-              onChange={(event) =>
-                onSearchFieldChange("sex", event.target.value as GoatAbccSearchFilters["sex"])
-              }
-            >
-              <option value="">Todos</option>
-              <option value="1">Macho</option>
-              <option value="0">Fêmea</option>
-            </select>
-          </label>
-
-          <label className="goat-abcc-import__field">
-            <span>DNA</span>
-            <select
-              value={searchFilters.dna}
-              onChange={(event) =>
-                onSearchFieldChange("dna", event.target.value as GoatAbccSearchFilters["dna"])
-              }
-            >
-              <option value="">Todos</option>
-              <option value="1">Com DNA</option>
-              <option value="0">Sem DNA</option>
-            </select>
-          </label>
-
-          <label className="goat-abcc-import__field">
-            <span>TOD</span>
-            <input
-              type="text"
-              value={searchFilters.tod}
-              onChange={(event) => onSearchFieldChange("tod", event.target.value)}
-              placeholder="Orelha direita"
-            />
-          </label>
-
-          <label className="goat-abcc-import__field">
-            <span>TOE</span>
-            <input
-              type="text"
-              value={searchFilters.toe}
-              onChange={(event) => onSearchFieldChange("toe", event.target.value)}
-              placeholder="Orelha esquerda"
-            />
-          </label>
-        </div>
-
-        <div className="goat-abcc-import__actions">
-          <Button variant="primary" onClick={onSearchSubmit} loading={searching}>
-            Buscar animais
-          </Button>
-        </div>
-
-        {searching && <LoadingState label="Consultando ABCC pública..." />}
-
-        {!searching && searchError && (
+        {!racesLoading && racesError && (
           <ErrorState
-            title="Não foi possível consultar a ABCC"
-            description={searchError}
-            onRetry={onSearchSubmit}
+            title="Não foi possível carregar as raças da ABCC"
+            description={racesError}
+            onRetry={onRetryLoadRaces}
           />
         )}
 
-        {!searching && !searchError && searched && searchItems.length === 0 && (
-          <EmptyState
-            title="Nenhum animal encontrado na ABCC"
-            description="Revise os filtros de busca e tente novamente."
-          />
-        )}
-
-        {!searching && !searchError && searchItems.length > 0 && (
-          <div className="goat-abcc-import__result-list">
-            {searchItems.map((item) => {
-              const isSelected = item.externalId === selectedExternalId;
-              return (
-                <article
-                  key={item.externalId}
-                  className={`goat-abcc-import__result-item ${isSelected ? "is-selected" : ""}`}
+        {!racesLoading && !racesError && (
+          <>
+            <div className="goat-abcc-import__grid">
+              <label className="goat-abcc-import__field">
+                <span>Raça ABCC *</span>
+                <select
+                  value={searchFilters.raceName}
+                  onChange={(event) => onSearchFieldChange("raceName", event.target.value)}
                 >
-                  <div>
-                    <h4>{item.nome || "Animal sem nome"}</h4>
-                    <p>
-                      {item.raca || "Raça não informada"} · {item.sexo || "Sexo não informado"} · {item.situacao || "Situação não informada"}
-                    </p>
-                    <small>
-                      TOD/TOE: {(item.tod || "-") + (item.toe || "")} · Nascimento: {item.dataNascimento || "-"}
-                    </small>
-                    {!!item.normalizationWarnings?.length && (
-                      <ul className="goat-abcc-import__warning-list">
-                        {item.normalizationWarnings.map((warning) => (
-                          <li key={warning}>{warning}</li>
-                        ))}
-                      </ul>
-                    )}
-                  </div>
+                  <option value="">Selecione a raça</option>
+                  {raceOptions.map((option) => (
+                    <option key={option.id} value={option.name}>
+                      {option.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
 
-                  <Button
-                    variant="secondary"
-                    disabled={!item.externalId}
-                    onClick={() => onSelectSearchItem(item)}
-                  >
-                    Pré-visualizar
-                  </Button>
-                </article>
-              );
-            })}
-          </div>
+              <label className="goat-abcc-import__field">
+                <span>Afixo *</span>
+                <input
+                  type="text"
+                  value={searchFilters.affix}
+                  onChange={(event) => onSearchFieldChange("affix", event.target.value)}
+                  placeholder="Ex.: CAPRIL VILAR"
+                />
+              </label>
+
+              <label className="goat-abcc-import__field">
+                <span>Nome</span>
+                <input
+                  type="text"
+                  value={searchFilters.name}
+                  onChange={(event) => onSearchFieldChange("name", event.target.value)}
+                  placeholder="Nome do animal"
+                />
+              </label>
+
+              <label className="goat-abcc-import__field">
+                <span>Página</span>
+                <input
+                  type="number"
+                  min="1"
+                  value={searchFilters.page}
+                  onChange={(event) => onSearchFieldChange("page", event.target.value)}
+                />
+              </label>
+
+              <label className="goat-abcc-import__field">
+                <span>Sexo</span>
+                <select
+                  value={searchFilters.sex}
+                  onChange={(event) =>
+                    onSearchFieldChange("sex", event.target.value as GoatAbccSearchFilters["sex"])
+                  }
+                >
+                  <option value="">Todos</option>
+                  <option value="1">Macho</option>
+                  <option value="0">Fêmea</option>
+                </select>
+              </label>
+
+              <label className="goat-abcc-import__field">
+                <span>DNA</span>
+                <select
+                  value={searchFilters.dna}
+                  onChange={(event) =>
+                    onSearchFieldChange("dna", event.target.value as GoatAbccSearchFilters["dna"])
+                  }
+                >
+                  <option value="">Todos</option>
+                  <option value="1">Com DNA</option>
+                  <option value="0">Sem DNA</option>
+                </select>
+              </label>
+
+              <label className="goat-abcc-import__field">
+                <span>TOD</span>
+                <input
+                  type="text"
+                  value={searchFilters.tod}
+                  onChange={(event) => onSearchFieldChange("tod", event.target.value)}
+                  placeholder="Orelha direita"
+                />
+              </label>
+
+              <label className="goat-abcc-import__field">
+                <span>TOE</span>
+                <input
+                  type="text"
+                  value={searchFilters.toe}
+                  onChange={(event) => onSearchFieldChange("toe", event.target.value)}
+                  placeholder="Orelha esquerda"
+                />
+              </label>
+            </div>
+
+            <div className="goat-abcc-import__actions">
+              <Button variant="primary" onClick={onSearchSubmit} loading={searching}>
+                Buscar animais
+              </Button>
+            </div>
+
+            {searching && <LoadingState label="Consultando ABCC pública..." />}
+
+            {!searching && searchError && (
+              <ErrorState
+                title="Não foi possível consultar a ABCC"
+                description={searchError}
+                onRetry={onSearchSubmit}
+              />
+            )}
+
+            {!searching && !searchError && searched && searchItems.length === 0 && (
+              <EmptyState
+                title="Nenhum animal encontrado na ABCC"
+                description="Revise os filtros de busca e tente novamente."
+              />
+            )}
+
+            {!searching && !searchError && searchItems.length > 0 && (
+              <div className="goat-abcc-import__result-list">
+                {searchItems.map((item) => {
+                  const isSelected = item.externalId === selectedExternalId;
+                  return (
+                    <article
+                      key={item.externalId}
+                      className={`goat-abcc-import__result-item ${isSelected ? "is-selected" : ""}`}
+                    >
+                      <div>
+                        <h4>{item.nome || "Animal sem nome"}</h4>
+                        <p>
+                          {item.raca || "Raça não informada"} · {item.sexo || "Sexo não informado"} · {item.situacao || "Situação não informada"}
+                        </p>
+                        <small>
+                          TOD/TOE: {(item.tod || "-") + (item.toe || "")} · Nascimento: {item.dataNascimento || "-"}
+                        </small>
+                        {!!item.normalizationWarnings?.length && (
+                          <ul className="goat-abcc-import__warning-list">
+                            {item.normalizationWarnings.map((warning) => (
+                              <li key={warning}>{warning}</li>
+                            ))}
+                          </ul>
+                        )}
+                      </div>
+
+                      <Button
+                        variant="secondary"
+                        disabled={!item.externalId}
+                        onClick={() => onSelectSearchItem(item)}
+                      >
+                        Pré-visualizar
+                      </Button>
+                    </article>
+                  );
+                })}
+              </div>
+            )}
+          </>
         )}
       </section>
 
@@ -494,7 +516,7 @@ export function GoatAbccImportModalView({
                   <option value="">Selecione a raça</option>
                   {BREED_OPTIONS.map((breed) => (
                     <option key={breed} value={breed}>
-                      {breed}
+                      {breedLabels[breed]}
                     </option>
                   ))}
                 </select>
@@ -616,6 +638,10 @@ export default function GoatAbccImportModal({
   onClose,
   onImported,
 }: GoatAbccImportModalProps) {
+  const [raceOptions, setRaceOptions] = useState<GoatAbccRaceOptionDTO[]>([]);
+  const [racesLoading, setRacesLoading] = useState(false);
+  const [racesError, setRacesError] = useState<string | null>(null);
+
   const [searchFilters, setSearchFilters] = useState<GoatAbccSearchFilters>(initialSearchFilters);
   const [searching, setSearching] = useState(false);
   const [searched, setSearched] = useState(false);
@@ -648,12 +674,27 @@ export default function GoatAbccImportModal({
     setConfirmSuccess(null);
   }
 
+  const loadRaceOptions = useCallback(async () => {
+    try {
+      setRacesLoading(true);
+      setRacesError(null);
+
+      const response = await listAbccRaceOptions(farmId);
+      setRaceOptions(response.items ?? []);
+    } catch (error) {
+      setRacesError(getApiErrorMessage(parseApiError(error)));
+      setRaceOptions([]);
+    } finally {
+      setRacesLoading(false);
+    }
+  }, [farmId]);
+
   useEffect(() => {
     if (isOpen) {
       resetFlow();
+      void loadRaceOptions();
     }
-
-  }, [isOpen]);
+  }, [isOpen, loadRaceOptions]);
 
   function handleSearchFieldChange<K extends keyof GoatAbccSearchFilters>(
     field: K,
@@ -666,8 +707,8 @@ export default function GoatAbccImportModal({
   }
 
   async function handleSearchSubmit() {
-    if (!searchFilters.raceId.trim()) {
-      setSearchError("Informe o ID da raça ABCC para buscar.");
+    if (!searchFilters.raceName.trim()) {
+      setSearchError("Selecione a raça ABCC para buscar.");
       return;
     }
 
@@ -688,7 +729,7 @@ export default function GoatAbccImportModal({
       setConfirmError(null);
       setConfirmSuccess(null);
 
-      const response = await searchGoatsByAbcc(farmId, buildSearchPayload(searchFilters));
+      const response = await searchGoatsByAbcc(farmId, buildSearchPayload(searchFilters, raceOptions));
       setSearchItems(response.items ?? []);
       setSearched(true);
     } catch (error) {
@@ -793,6 +834,10 @@ export default function GoatAbccImportModal({
       className="goat-abcc-import__modal"
     >
       <GoatAbccImportModalView
+        raceOptions={raceOptions}
+        racesLoading={racesLoading}
+        racesError={racesError}
+        onRetryLoadRaces={loadRaceOptions}
         searchFilters={searchFilters}
         onSearchFieldChange={handleSearchFieldChange}
         onSearchSubmit={handleSearchSubmit}

--- a/src/Components/goat-abcc-import/GoatAbccImportModal.tsx
+++ b/src/Components/goat-abcc-import/GoatAbccImportModal.tsx
@@ -1,10 +1,12 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+﻿import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "react-toastify";
 import {
+  confirmGoatImportBatchFromAbcc,
   confirmGoatImportFromAbcc,
   listAbccRaceOptions,
   previewGoatFromAbcc,
   searchGoatsByAbcc,
+  type GoatAbccBatchConfirmResponseDTO,
   type GoatAbccFilterDna,
   type GoatAbccFilterSex,
   type GoatAbccPreviewResponseDTO,
@@ -18,6 +20,7 @@ import {
 import { GoatBreedEnum, GoatCategoryEnum, breedLabels, categoryLabels } from "../../types/goatEnums";
 import { getApiErrorMessage, parseApiError } from "../../utils/apiError";
 import { UI_GENDER_LABELS, UI_STATUS_LABELS } from "../../utils/i18nGoat";
+import { usePermissions } from "../../Hooks/usePermissions";
 import { Alert, Button, EmptyState, ErrorState, LoadingState, Modal } from "../ui";
 import "./goatAbccImportModal.css";
 
@@ -56,6 +59,8 @@ export interface GoatAbccPreviewFormData extends GoatFormData {
 }
 
 export interface GoatAbccImportModalViewProps {
+  isAdminUser: boolean;
+  farmTod?: string;
   raceOptions: GoatAbccRaceOptionDTO[];
   racesLoading: boolean;
   racesError: string | null;
@@ -71,6 +76,18 @@ export interface GoatAbccImportModalViewProps {
   searched: boolean;
   searchError: string | null;
   searchItems: GoatAbccSearchItemDTO[];
+  selectedBatchExternalIds: string[];
+  onToggleBatchItemSelection: (externalId: string) => void;
+  onSelectAllCurrentPage: () => void;
+  onClearBatchSelection: () => void;
+  onImportBatch: () => void;
+  batchImporting: boolean;
+  batchResult: GoatAbccBatchConfirmResponseDTO | null;
+  batchImportError: string | null;
+  searchCurrentPage: number;
+  searchTotalPages: number;
+  onSearchPreviousPage: () => void;
+  onSearchNextPage: () => void;
   selectedExternalId: string | null;
   onSelectSearchItem: (item: GoatAbccSearchItemDTO) => void;
   previewLoading: boolean;
@@ -168,14 +185,21 @@ function buildPreviewFormData(
   };
 }
 
-function buildSearchPayload(filters: GoatAbccSearchFilters, raceOptions: GoatAbccRaceOptionDTO[]) {
+function buildSearchPayload(
+  filters: GoatAbccSearchFilters,
+  raceOptions: GoatAbccRaceOptionDTO[],
+  pageOverride?: number
+) {
   const selectedRace = raceOptions.find((option) => option.name === filters.raceName);
+  const requestedPage = Number.isFinite(pageOverride)
+    ? Math.max(1, Number(pageOverride))
+    : Math.max(1, Number(filters.page || "1"));
 
   return {
     raceId: selectedRace?.id,
     raceName: filters.raceName.trim(),
     affix: filters.affix.trim(),
-    page: Number(filters.page || "1"),
+    page: requestedPage,
     sex: filters.sex || undefined,
     tod: filters.tod.trim() || undefined,
     toe: filters.toe.trim() || undefined,
@@ -185,6 +209,8 @@ function buildSearchPayload(filters: GoatAbccSearchFilters, raceOptions: GoatAbc
 }
 
 export function GoatAbccImportModalView({
+  isAdminUser,
+  farmTod,
   raceOptions,
   racesLoading,
   racesError,
@@ -197,6 +223,18 @@ export function GoatAbccImportModalView({
   searched,
   searchError,
   searchItems,
+  selectedBatchExternalIds,
+  onToggleBatchItemSelection,
+  onSelectAllCurrentPage,
+  onClearBatchSelection,
+  onImportBatch,
+  batchImporting,
+  batchResult,
+  batchImportError,
+  searchCurrentPage,
+  searchTotalPages,
+  onSearchPreviousPage,
+  onSearchNextPage,
   selectedExternalId,
   onSelectSearchItem,
   previewLoading,
@@ -216,9 +254,17 @@ export function GoatAbccImportModalView({
 
   return (
     <div className="goat-abcc-import">
-      <Alert variant="info" title="Importação ABCC opcional">
-        O cadastro manual continua disponível. Use a ABCC apenas quando quiser trazer dados públicos para conferência.
-      </Alert>
+      {isAdminUser ? (
+        <Alert variant="warning" title="Modo administrativo de importação ABCC">
+          Você está em modo administrativo (ROLE_ADMIN). Este perfil pode importar animais de qualquer TOD para a fazenda atual.
+          O cadastro manual continua disponível e independente.
+        </Alert>
+      ) : (
+        <Alert variant="info" title="Importação ABCC opcional">
+          O cadastro manual continua disponível. A importação ABCC está restrita ao TOD da fazenda atual
+          {farmTod ? ` (${farmTod}).` : "."}
+        </Alert>
+      )}
 
       <section className="goat-abcc-import__panel">
         <div className="goat-abcc-import__panel-head">
@@ -280,16 +326,6 @@ export function GoatAbccImportModalView({
               </label>
 
               <label className="goat-abcc-import__field">
-                <span>Página</span>
-                <input
-                  type="number"
-                  min="1"
-                  value={searchFilters.page}
-                  onChange={(event) => onSearchFieldChange("page", event.target.value)}
-                />
-              </label>
-
-              <label className="goat-abcc-import__field">
                 <span>Sexo</span>
                 <select
                   value={searchFilters.sex}
@@ -321,10 +357,14 @@ export function GoatAbccImportModalView({
                 <span>TOD</span>
                 <input
                   type="text"
-                  value={searchFilters.tod}
+                  value={isAdminUser ? searchFilters.tod : farmTod ?? searchFilters.tod}
                   onChange={(event) => onSearchFieldChange("tod", event.target.value)}
-                  placeholder="Orelha direita"
+                  placeholder={isAdminUser ? "Orelha direita" : "Usando TOD da fazenda"}
+                  disabled={!isAdminUser}
                 />
+                {!isAdminUser && (
+                  <small className="goat-abcc-import__field-tip">Filtro travado para o TOD da fazenda.</small>
+                )}
               </label>
 
               <label className="goat-abcc-import__field">
@@ -362,41 +402,129 @@ export function GoatAbccImportModalView({
             )}
 
             {!searching && !searchError && searchItems.length > 0 && (
-              <div className="goat-abcc-import__result-list">
-                {searchItems.map((item) => {
-                  const isSelected = item.externalId === selectedExternalId;
-                  return (
-                    <article
-                      key={item.externalId}
-                      className={`goat-abcc-import__result-item ${isSelected ? "is-selected" : ""}`}
+              <>
+                <div className="goat-abcc-import__batch-toolbar">
+                  <strong>
+                    Selecionados nesta página: {selectedBatchExternalIds.length}
+                  </strong>
+                  <div className="goat-abcc-import__batch-toolbar-actions">
+                    <Button variant="ghost" onClick={onSelectAllCurrentPage}>
+                      Selecionar todos desta página
+                    </Button>
+                    <Button variant="ghost" onClick={onClearBatchSelection}>
+                      Limpar seleção
+                    </Button>
+                    <Button
+                      variant="success"
+                      onClick={onImportBatch}
+                      loading={batchImporting}
+                      disabled={selectedBatchExternalIds.length === 0}
                     >
-                      <div>
-                        <h4>{item.nome || "Animal sem nome"}</h4>
-                        <p>
-                          {item.raca || "Raça não informada"} · {item.sexo || "Sexo não informado"} · {item.situacao || "Situação não informada"}
-                        </p>
-                        <small>
-                          TOD/TOE: {(item.tod || "-") + (item.toe || "")} · Nascimento: {item.dataNascimento || "-"}
-                        </small>
-                        {!!item.normalizationWarnings?.length && (
-                          <ul className="goat-abcc-import__warning-list">
-                            {item.normalizationWarnings.map((warning) => (
-                              <li key={warning}>{warning}</li>
-                            ))}
-                          </ul>
-                        )}
-                      </div>
+                      Importar selecionados
+                    </Button>
+                  </div>
+                </div>
 
-                      <Button
-                        variant="secondary"
-                        disabled={!item.externalId}
-                        onClick={() => onSelectSearchItem(item)}
+                {batchImportError && (
+                  <Alert variant="error" title="Falha ao importar em lote">
+                    {batchImportError}
+                  </Alert>
+                )}
+
+                {batchResult && (
+                  <Alert
+                    variant={batchResult.totalError > 0 ? "warning" : "success"}
+                    title="Resultado da importação em lote"
+                  >
+                    <div className="goat-abcc-import__batch-summary">
+                      <span>Selecionados: {batchResult.totalSelected}</span>
+                      <span>Importados: {batchResult.totalImported}</span>
+                      <span>Ignorados por duplicidade: {batchResult.totalSkippedDuplicate}</span>
+                      <span>Ignorados por TOD incompatível: {batchResult.totalSkippedTodMismatch}</span>
+                      <span>Com erro: {batchResult.totalError}</span>
+                    </div>
+                    {!!batchResult.results?.length && (
+                      <ul className="goat-abcc-import__batch-result-list">
+                        {batchResult.results.map((result, index) => (
+                          <li key={`${result.externalId ?? "sem-id"}-${index}`}>
+                            <strong>{result.status}</strong> ·{" "}
+                            {result.registrationNumber || result.externalId || "Item sem identificador"} ·{" "}
+                            {result.message}
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </Alert>
+                )}
+
+                <div className="goat-abcc-import__result-list">
+                  {searchItems.map((item) => {
+                    const isPreviewSelected = item.externalId === selectedExternalId;
+                    const isBatchSelected = selectedBatchExternalIds.includes(item.externalId);
+                    return (
+                      <article
+                        key={item.externalId}
+                        className={`goat-abcc-import__result-item ${isPreviewSelected ? "is-selected" : ""}`}
                       >
-                        Pré-visualizar
-                      </Button>
-                    </article>
-                  );
-                })}
+                        <div className="goat-abcc-import__result-main">
+                          <label className="goat-abcc-import__checkbox">
+                            <input
+                              type="checkbox"
+                              checked={isBatchSelected}
+                              onChange={() => onToggleBatchItemSelection(item.externalId)}
+                              disabled={!item.externalId}
+                            />
+                            <span>Selecionar para lote</span>
+                          </label>
+                          <h4>{item.nome || "Animal sem nome"}</h4>
+                          <p>
+                            {item.raca || "Raça não informada"} · {item.sexo || "Sexo não informado"} · {item.situacao || "Situação não informada"}
+                          </p>
+                          <small>
+                            TOD/TOE: {(item.tod || "-") + (item.toe || "")} · Nascimento: {item.dataNascimento || "-"}
+                          </small>
+                          {!!item.normalizationWarnings?.length && (
+                            <ul className="goat-abcc-import__warning-list">
+                              {item.normalizationWarnings.map((warning) => (
+                                <li key={warning}>{warning}</li>
+                              ))}
+                            </ul>
+                          )}
+                        </div>
+
+                        <Button
+                          variant="secondary"
+                          disabled={!item.externalId}
+                          onClick={() => onSelectSearchItem(item)}
+                        >
+                          Pré-visualizar
+                        </Button>
+                      </article>
+                    );
+                  })}
+                </div>
+              </>
+            )}
+
+            {!searching && !searchError && searched && (
+              <div className="goat-abcc-import__pagination">
+                <Button
+                  variant="secondary"
+                  onClick={onSearchPreviousPage}
+                  disabled={searchCurrentPage <= 1}
+                >
+                  Página anterior
+                </Button>
+                <span>
+                  Página {searchCurrentPage} de {Math.max(searchTotalPages, 1)}
+                </span>
+                <Button
+                  variant="secondary"
+                  onClick={onSearchNextPage}
+                  disabled={searchCurrentPage >= Math.max(searchTotalPages, 1)}
+                >
+                  Próxima página
+                </Button>
               </div>
             )}
           </>
@@ -638,6 +766,9 @@ export default function GoatAbccImportModal({
   onClose,
   onImported,
 }: GoatAbccImportModalProps) {
+  const { isAdmin } = usePermissions();
+  const isAdminUser = isAdmin();
+
   const [raceOptions, setRaceOptions] = useState<GoatAbccRaceOptionDTO[]>([]);
   const [racesLoading, setRacesLoading] = useState(false);
   const [racesError, setRacesError] = useState<string | null>(null);
@@ -647,6 +778,12 @@ export default function GoatAbccImportModal({
   const [searched, setSearched] = useState(false);
   const [searchError, setSearchError] = useState<string | null>(null);
   const [searchItems, setSearchItems] = useState<GoatAbccSearchItemDTO[]>([]);
+  const [selectedBatchExternalIds, setSelectedBatchExternalIds] = useState<string[]>([]);
+  const [batchImporting, setBatchImporting] = useState(false);
+  const [batchImportError, setBatchImportError] = useState<string | null>(null);
+  const [batchResult, setBatchResult] = useState<GoatAbccBatchConfirmResponseDTO | null>(null);
+  const [searchCurrentPage, setSearchCurrentPage] = useState(1);
+  const [searchTotalPages, setSearchTotalPages] = useState(1);
 
   const [selectedExternalId, setSelectedExternalId] = useState<string | null>(null);
   const [previewLoading, setPreviewLoading] = useState(false);
@@ -659,11 +796,20 @@ export default function GoatAbccImportModal({
   const [confirmSuccess, setConfirmSuccess] = useState<string | null>(null);
 
   function resetFlow() {
-    setSearchFilters(initialSearchFilters);
+    setSearchFilters({
+      ...initialSearchFilters,
+      tod: !isAdminUser && defaultTod ? defaultTod.trim() : initialSearchFilters.tod,
+    });
     setSearching(false);
     setSearched(false);
     setSearchError(null);
     setSearchItems([]);
+    setSelectedBatchExternalIds([]);
+    setBatchImporting(false);
+    setBatchImportError(null);
+    setBatchResult(null);
+    setSearchCurrentPage(1);
+    setSearchTotalPages(1);
     setSelectedExternalId(null);
     setPreviewLoading(false);
     setPreviewError(null);
@@ -700,13 +846,17 @@ export default function GoatAbccImportModal({
     field: K,
     value: GoatAbccSearchFilters[K]
   ) {
+    if (!isAdminUser && field === "tod") {
+      return;
+    }
     setSearchFilters((previous) => ({
       ...previous,
       [field]: value,
+      ...(field === "page" ? {} : { page: "1" }),
     }));
   }
 
-  async function handleSearchSubmit() {
+  async function handleSearchSubmit(pageOverride?: number) {
     if (!searchFilters.raceName.trim()) {
       setSearchError("Selecione a raça ABCC para buscar.");
       return;
@@ -722,6 +872,9 @@ export default function GoatAbccImportModal({
       setSearched(false);
       setSearchError(null);
       setSearchItems([]);
+      setSelectedBatchExternalIds([]);
+      setBatchImportError(null);
+      setBatchResult(null);
       setSelectedExternalId(null);
       setPreviewData(null);
       setPreviewForm(null);
@@ -729,14 +882,107 @@ export default function GoatAbccImportModal({
       setConfirmError(null);
       setConfirmSuccess(null);
 
-      const response = await searchGoatsByAbcc(farmId, buildSearchPayload(searchFilters, raceOptions));
+      const requestedPage = Number.isFinite(pageOverride)
+        ? Math.max(1, Number(pageOverride))
+        : Math.max(1, Number(searchFilters.page || "1"));
+      const payload = buildSearchPayload(searchFilters, raceOptions, requestedPage);
+      if (!isAdminUser && defaultTod?.trim()) {
+        payload.tod = defaultTod.trim();
+      }
+      const response = await searchGoatsByAbcc(
+        farmId,
+        payload
+      );
       setSearchItems(response.items ?? []);
+      const currentPageFromBackend = Math.max(1, Number(response.currentPage || requestedPage));
+      const totalPagesFromBackend = Math.max(1, Number(response.totalPages || 1));
+      setSearchCurrentPage(currentPageFromBackend);
+      setSearchTotalPages(totalPagesFromBackend);
+      setSearchFilters((previous) => ({
+        ...previous,
+        page: String(currentPageFromBackend),
+      }));
       setSearched(true);
     } catch (error) {
       setSearched(true);
       setSearchError(getApiErrorMessage(parseApiError(error)));
     } finally {
       setSearching(false);
+    }
+  }
+
+  function handleSearchPreviousPage() {
+    if (searching || searchCurrentPage <= 1) {
+      return;
+    }
+    void handleSearchSubmit(searchCurrentPage - 1);
+  }
+
+  function handleSearchNextPage() {
+    if (searching || searchCurrentPage >= searchTotalPages) {
+      return;
+    }
+    void handleSearchSubmit(searchCurrentPage + 1);
+  }
+
+  function handleToggleBatchItemSelection(externalId: string) {
+    if (!externalId) {
+      return;
+    }
+    setBatchImportError(null);
+    setBatchResult(null);
+    setSelectedBatchExternalIds((previous) =>
+      previous.includes(externalId)
+        ? previous.filter((id) => id !== externalId)
+        : [...previous, externalId]
+    );
+  }
+
+  function handleSelectAllCurrentPage() {
+    const currentPageIds = searchItems
+      .map((item) => item.externalId)
+      .filter((externalId): externalId is string => Boolean(externalId));
+    setBatchImportError(null);
+    setBatchResult(null);
+    setSelectedBatchExternalIds(currentPageIds);
+  }
+
+  function handleClearBatchSelection() {
+    setBatchImportError(null);
+    setBatchResult(null);
+    setSelectedBatchExternalIds([]);
+  }
+
+  async function handleImportBatch() {
+    if (selectedBatchExternalIds.length === 0) {
+      setBatchImportError("Selecione ao menos um animal desta página para importar em lote.");
+      return;
+    }
+
+    try {
+      setBatchImporting(true);
+      setBatchImportError(null);
+      setBatchResult(null);
+      setConfirmError(null);
+      setConfirmSuccess(null);
+
+      const response = await confirmGoatImportBatchFromAbcc(farmId, {
+        items: selectedBatchExternalIds.map((externalId) => ({ externalId })),
+      });
+
+      setBatchResult(response);
+      if (response.totalImported > 0) {
+        onImported();
+      }
+      toast.success(
+        `Lote processado: ${response.totalImported} importado(s), ${response.totalSkippedDuplicate} duplicado(s), ${response.totalSkippedTodMismatch} por TOD incompatível, ${response.totalError} com erro.`
+      );
+    } catch (error) {
+      const message = getApiErrorMessage(parseApiError(error));
+      setBatchImportError(message);
+      toast.error(message);
+    } finally {
+      setBatchImporting(false);
     }
   }
 
@@ -834,6 +1080,8 @@ export default function GoatAbccImportModal({
       className="goat-abcc-import__modal"
     >
       <GoatAbccImportModalView
+        isAdminUser={isAdminUser}
+        farmTod={defaultTod}
         raceOptions={raceOptions}
         racesLoading={racesLoading}
         racesError={racesError}
@@ -846,6 +1094,18 @@ export default function GoatAbccImportModal({
         searched={searched}
         searchError={searchError}
         searchItems={searchItems}
+        selectedBatchExternalIds={selectedBatchExternalIds}
+        onToggleBatchItemSelection={handleToggleBatchItemSelection}
+        onSelectAllCurrentPage={handleSelectAllCurrentPage}
+        onClearBatchSelection={handleClearBatchSelection}
+        onImportBatch={handleImportBatch}
+        batchImporting={batchImporting}
+        batchResult={batchResult}
+        batchImportError={batchImportError}
+        searchCurrentPage={searchCurrentPage}
+        searchTotalPages={searchTotalPages}
+        onSearchPreviousPage={handleSearchPreviousPage}
+        onSearchNextPage={handleSearchNextPage}
         selectedExternalId={selectedExternalId}
         onSelectSearchItem={handleSelectSearchItem}
         previewLoading={previewLoading}
@@ -861,3 +1121,7 @@ export default function GoatAbccImportModal({
     </Modal>
   );
 }
+
+
+
+

--- a/src/Components/goat-abcc-import/goatAbccImportModal.css
+++ b/src/Components/goat-abcc-import/goatAbccImportModal.css
@@ -1,0 +1,194 @@
+﻿.goat-abcc-import__modal {
+  max-width: min(1180px, 94vw);
+}
+
+.goat-abcc-import {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.goat-abcc-import__panel {
+  border: 1px solid #dbe4ee;
+  border-radius: 1rem;
+  background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.goat-abcc-import__panel-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.goat-abcc-import__panel-head h3 {
+  margin: 0;
+  color: #0f172a;
+  font-size: 1.15rem;
+}
+
+.goat-abcc-import__panel-head p {
+  margin: 0.3rem 0 0;
+  color: #475569;
+}
+
+.goat-abcc-import__grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.goat-abcc-import__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.goat-abcc-import__field > span {
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: #334155;
+}
+
+.goat-abcc-import__field input,
+.goat-abcc-import__field select {
+  min-height: 42px;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.75rem;
+  padding: 0.55rem 0.7rem;
+  color: #0f172a;
+  background: #ffffff;
+}
+
+.goat-abcc-import__field input:focus,
+.goat-abcc-import__field select:focus {
+  outline: none;
+  border-color: #0f766e;
+  box-shadow: 0 0 0 3px rgba(15, 118, 110, 0.14);
+}
+
+.goat-abcc-import__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.6rem;
+}
+
+.goat-abcc-import__actions--confirm {
+  margin-top: 0.2rem;
+}
+
+.goat-abcc-import__result-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.goat-abcc-import__result-item {
+  border: 1px solid #d6dce5;
+  border-radius: 0.85rem;
+  padding: 0.75rem 0.9rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.goat-abcc-import__result-item.is-selected {
+  border-color: #0f766e;
+  box-shadow: 0 0 0 2px rgba(15, 118, 110, 0.14);
+}
+
+.goat-abcc-import__result-item h4 {
+  margin: 0;
+  font-size: 1rem;
+  color: #0f172a;
+}
+
+.goat-abcc-import__result-item p {
+  margin: 0.22rem 0;
+  color: #334155;
+}
+
+.goat-abcc-import__result-item small {
+  color: #64748b;
+}
+
+.goat-abcc-import__warning-list {
+  margin: 0.45rem 0 0;
+  padding-left: 1rem;
+  color: #92400e;
+}
+
+.goat-abcc-import__preview-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.goat-abcc-import__preview-context {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.65rem;
+}
+
+.goat-abcc-import__preview-context > div {
+  border: 1px solid #d7dee8;
+  border-radius: 0.7rem;
+  padding: 0.55rem 0.65rem;
+  background: #f8fafc;
+}
+
+.goat-abcc-import__preview-context span {
+  display: block;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #64748b;
+}
+
+.goat-abcc-import__preview-context strong {
+  color: #0f172a;
+  font-size: 0.94rem;
+}
+
+.goat-abcc-import__selected-tip {
+  margin: 0;
+  color: #475569;
+}
+
+@media (max-width: 1024px) {
+  .goat-abcc-import__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .goat-abcc-import__preview-context {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .goat-abcc-import__panel-head {
+    flex-direction: column;
+  }
+
+  .goat-abcc-import__grid,
+  .goat-abcc-import__preview-context {
+    grid-template-columns: 1fr;
+  }
+
+  .goat-abcc-import__result-item {
+    flex-direction: column;
+  }
+
+  .goat-abcc-import__actions {
+    justify-content: stretch;
+  }
+
+  .goat-abcc-import__actions .gf-button {
+    width: 100%;
+  }
+}

--- a/src/Components/goat-abcc-import/goatAbccImportModal.css
+++ b/src/Components/goat-abcc-import/goatAbccImportModal.css
@@ -54,6 +54,11 @@
   color: #334155;
 }
 
+.goat-abcc-import__field-tip {
+  font-size: 0.75rem;
+  color: #64748b;
+}
+
 .goat-abcc-import__field input,
 .goat-abcc-import__field select {
   min-height: 42px;
@@ -87,6 +92,63 @@
   gap: 0.6rem;
 }
 
+.goat-abcc-import__batch-toolbar {
+  border: 1px solid #dbe4ee;
+  border-radius: 0.85rem;
+  background: #f8fafc;
+  padding: 0.75rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.goat-abcc-import__batch-toolbar strong {
+  color: #0f172a;
+}
+
+.goat-abcc-import__batch-toolbar-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.goat-abcc-import__batch-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 0.4rem;
+}
+
+.goat-abcc-import__batch-summary span {
+  font-weight: 600;
+}
+
+.goat-abcc-import__batch-result-list {
+  margin: 0.55rem 0 0;
+  padding-left: 1rem;
+}
+
+.goat-abcc-import__batch-result-list li {
+  margin-bottom: 0.25rem;
+}
+
+.goat-abcc-import__pagination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  border: 1px solid #dbe4ee;
+  border-radius: 0.85rem;
+  background: #f8fafc;
+  padding: 0.65rem 0.75rem;
+}
+
+.goat-abcc-import__pagination span {
+  color: #334155;
+  font-weight: 600;
+}
+
 .goat-abcc-import__result-item {
   border: 1px solid #d6dce5;
   border-radius: 0.85rem;
@@ -95,6 +157,28 @@
   justify-content: space-between;
   align-items: flex-start;
   gap: 1rem;
+}
+
+.goat-abcc-import__result-main {
+  display: flex;
+  flex-direction: column;
+  gap: 0.18rem;
+}
+
+.goat-abcc-import__checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: #0f172a;
+  font-size: 0.82rem;
+  font-weight: 600;
+  margin-bottom: 0.35rem;
+}
+
+.goat-abcc-import__checkbox input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  accent-color: #0f766e;
 }
 
 .goat-abcc-import__result-item.is-selected {
@@ -184,11 +268,22 @@
     flex-direction: column;
   }
 
+  .goat-abcc-import__batch-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .goat-abcc-import__pagination {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
   .goat-abcc-import__actions {
     justify-content: stretch;
   }
 
-  .goat-abcc-import__actions .gf-button {
+  .goat-abcc-import__actions .gf-button,
+  .goat-abcc-import__pagination .gf-button {
     width: 100%;
   }
 }

--- a/src/Components/goat-create-form/GoatCreateForm.tsx
+++ b/src/Components/goat-create-form/GoatCreateForm.tsx
@@ -5,7 +5,7 @@ import { toast } from "react-toastify";
 import { createGoat, updateGoat } from "../../api/GoatAPI/goat";
 import { createGenealogy } from "../../api/GenealogyAPI/genealogy";
 import type { GoatResponseDTO } from "../../Models/goatResponseDTO";
-import { GoatCategoryEnum, categoryLabels } from "../../types/goatEnums";
+import { GoatBreedEnum, GoatCategoryEnum, breedLabels, categoryLabels } from "../../types/goatEnums";
 import { UI_STATUS_LABELS, UI_GENDER_LABELS } from "../../utils/i18nGoat";
 import { convertResponseToRequest, mapGoatToBackend, fromDTOToExtended } from "../../Convertes/goats/goatConverter";
 import { GoatFormData } from "../../Convertes/goats/goatConverter";
@@ -385,14 +385,11 @@ export default function GoatCreateForm({
               <span>Raça <span className="goat-create-form__required">*</span></span>
               <select name="breed" value={formData.breed} onChange={handleChange} required>
                 <option value="">Selecione a raça</option>
-                <option value="ALPINE">Alpine</option>
-                <option value="ALPINA">Alpina</option>
-                <option value="ANGLO_NUBIANA">Anglo-Nubiana</option>
-                <option value="BOER">Boer</option>
-                <option value="MESTIÇA">Mestiça</option>
-                <option value="MURCIANA_GRANADINA">Murciana-Granadina</option>
-                <option value="SAANEN">Saanen</option>
-                <option value="TOGGENBURG">Toggenburg</option>
+                {Object.values(GoatBreedEnum).map((breed) => (
+                  <option key={breed} value={breed}>
+                    {breedLabels[breed]}
+                  </option>
+                ))}
               </select>
             </label>
 

--- a/src/Pages/goat-list-page/GoatListActions.tsx
+++ b/src/Pages/goat-list-page/GoatListActions.tsx
@@ -1,0 +1,28 @@
+import { Button } from "../../Components/ui";
+
+interface GoatListActionsProps {
+  canCreate: boolean;
+  onCreateManual: () => void;
+  onImportAbcc: () => void;
+}
+
+export default function GoatListActions({
+  canCreate,
+  onCreateManual,
+  onImportAbcc,
+}: GoatListActionsProps) {
+  if (!canCreate) {
+    return null;
+  }
+
+  return (
+    <div className="goat-list-actions">
+      <Button variant="secondary" onClick={onImportAbcc}>
+        Importar da ABCC
+      </Button>
+      <Button variant="primary" onClick={onCreateManual}>
+        Cadastrar nova cabra
+      </Button>
+    </div>
+  );
+}

--- a/src/Pages/goat-list-page/GoatListPage.tsx
+++ b/src/Pages/goat-list-page/GoatListPage.tsx
@@ -4,12 +4,14 @@ import { toast } from "react-toastify";
 import { Alert, EmptyState, ErrorState, LoadingState } from "../../Components/ui";
 
 import ButtonSeeMore from "../../Components/buttons/ButtonSeeMore";
+import GoatAbccImportModal from "../../Components/goat-abcc-import/GoatAbccImportModal";
 import GoatCardList from "../../Components/goat-card-list/GoatCardList";
 import GoatCreateModal from "../../Components/goat-create-form/GoatCreateModal";
 import GoatDashboardSummary from "../../Components/dash-animal-info/GoatDashboardSummary";
 import GoatFarmHeader from "../../Components/pages-headers/GoatFarmHeader";
 import PageHeader from "../../Components/pages-headers/PageHeader";
 import SearchInputBox from "../../Components/searchs/SearchInputBox";
+import GoatListActions from "./GoatListActions";
 
 import type { GoatFarmDTO } from "../../Models/goatFarm";
 import type { GoatHerdSummaryDTO } from "../../Models/GoatHerdSummaryDTO";
@@ -38,6 +40,7 @@ export default function GoatListPage() {
 
   const [filteredGoats, setFilteredGoats] = useState<GoatResponseDTO[]>([]);
   const [showCreateModal, setShowCreateModal] = useState(false);
+  const [showAbccImportModal, setShowAbccImportModal] = useState(false);
   const [editModalOpen, setEditModalOpen] = useState(false);
   const [selectedGoat, setSelectedGoat] = useState<GoatResponseDTO | null>(null);
   const [loadingEditGoat, setLoadingEditGoat] = useState(false);
@@ -181,6 +184,15 @@ export default function GoatListPage() {
     reloadGoatListAndSummary();
   }
 
+  function handleOpenCreateModal() {
+    if (!farmData || !farmData.tod) {
+      console.warn("Dados da fazenda incompletos:", farmData);
+      return;
+    }
+
+    setShowCreateModal(true);
+  }
+
   async function openEditModal(goat: GoatResponseDTO) {
     if (!farmId) return;
 
@@ -231,20 +243,12 @@ export default function GoatListPage() {
         <PageHeader
           title="Lista de Cabras"
           description="Acompanhe o rebanho, pesquise por animal e mantenha o manejo desta fazenda em ordem."
-          rightButton={
-            canCreate
-              ? {
-                  label: "Cadastrar nova cabra",
-                  onClick: () => {
-                    if (!farmData || !farmData.tod) {
-                      console.warn("Dados da fazenda incompletos:", farmData);
-                      return;
-                    }
-
-                    setShowCreateModal(true);
-                  },
-                }
-              : undefined
+          actions={
+            <GoatListActions
+              canCreate={canCreate}
+              onCreateManual={handleOpenCreateModal}
+              onImportAbcc={() => setShowAbccImportModal(true)}
+            />
           }
         />
 
@@ -305,7 +309,7 @@ export default function GoatListPage() {
                   title="Nenhuma cabra encontrada"
                   description="Cadastre um animal ou ajuste a busca para encontrar registros desta fazenda."
                   actionLabel={canCreate ? "Cadastrar nova cabra" : undefined}
-                  onAction={canCreate ? () => setShowCreateModal(true) : undefined}
+                  onAction={canCreate ? handleOpenCreateModal : undefined}
                 />
               ) : (
                 <>
@@ -336,6 +340,16 @@ export default function GoatListPage() {
           defaultFarmId={farmData.id}
           defaultUserId={tokenPayload?.userId || 0}
           defaultTod={farmData.tod}
+        />
+      )}
+
+      {showAbccImportModal && farmData && (
+        <GoatAbccImportModal
+          isOpen={showAbccImportModal}
+          farmId={farmData.id}
+          defaultTod={farmData.tod}
+          onClose={() => setShowAbccImportModal(false)}
+          onImported={handleGoatCreated}
         />
       )}
 

--- a/src/Pages/goat-list-page/goatList.css
+++ b/src/Pages/goat-list-page/goatList.css
@@ -108,3 +108,27 @@
     width: 100%;
   }
 }
+
+.goat-list-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.goat-list-actions .gf-button {
+  min-width: 175px;
+}
+
+@media (max-width: 768px) {
+  .goat-list-actions {
+    width: 100%;
+    justify-content: stretch;
+  }
+
+  .goat-list-actions .gf-button {
+    width: 100%;
+    min-width: 0;
+  }
+}

--- a/src/api/GoatAPI/goatAbccImport.test.ts
+++ b/src/api/GoatAPI/goatAbccImport.test.ts
@@ -1,0 +1,167 @@
+﻿import { beforeEach, describe, expect, it, vi } from "vitest";
+import { requestBackEnd } from "../../utils/request";
+import {
+  confirmGoatImportFromAbcc,
+  listAbccRaceOptions,
+  previewGoatFromAbcc,
+  searchGoatsByAbcc,
+} from "./goatAbccImport";
+
+vi.mock("../../utils/request", () => ({
+  requestBackEnd: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}));
+
+describe("Goat ABCC Import API", () => {
+  const mockedGet = vi.mocked(requestBackEnd.get);
+  const mockedPost = vi.mocked(requestBackEnd.post);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads ABCC races using canonical backend route", async () => {
+    mockedGet.mockResolvedValueOnce({
+      data: {
+        items: [
+          { id: 9, name: "SAANEN", normalizedBreed: "SAANEN" },
+          { id: 2, name: "BOER", normalizedBreed: "BOER" },
+        ],
+      },
+    });
+
+    const response = await listAbccRaceOptions(7);
+
+    expect(mockedGet).toHaveBeenCalledWith("/goatfarms/7/goats/imports/abcc/races");
+    expect(response.items).toHaveLength(2);
+    expect(response.items[0].name).toBe("SAANEN");
+  });
+
+  it("executes ABCC search with race name and resolved id", async () => {
+    mockedPost.mockResolvedValueOnce({
+      data: {
+        currentPage: 1,
+        totalPages: 3,
+        pageSize: 2,
+        items: [
+          {
+            externalSource: "ABCC_PUBLIC",
+            externalId: "ABCC-001",
+            nome: "TOPAZIO",
+            raca: "SAANEN",
+            sexo: "MACHO",
+            situacao: "RGD",
+            tod: "12345",
+            toe: "67890",
+            dataNascimento: "01/01/2020",
+          },
+        ],
+      },
+    });
+
+    const response = await searchGoatsByAbcc(7, {
+      raceName: "SAANEN",
+      raceId: 9,
+      affix: "CAPRIL VILAR",
+      page: 1,
+    });
+
+    expect(mockedPost).toHaveBeenCalledWith(
+      "/goatfarms/7/goats/imports/abcc/search",
+      expect.objectContaining({ raceName: "SAANEN", raceId: 9, affix: "CAPRIL VILAR", page: 1 })
+    );
+    expect(response.items).toHaveLength(1);
+    expect(response.items[0].externalId).toBe("ABCC-001");
+  });
+
+  it("loads ABCC preview using externalId", async () => {
+    mockedPost.mockResolvedValueOnce({
+      data: {
+        externalSource: "ABCC_PUBLIC",
+        externalId: "ABCC-001",
+        registrationNumber: "1234567890",
+        name: "TOPAZIO",
+        gender: "MACHO",
+        breed: "SAANEN",
+        color: "CHAMOISEE",
+        birthDate: "2020-01-01",
+        status: "ATIVO",
+      },
+    });
+
+    const response = await previewGoatFromAbcc(7, "ABCC-001");
+
+    expect(mockedPost).toHaveBeenCalledWith(
+      "/goatfarms/7/goats/imports/abcc/preview",
+      { externalId: "ABCC-001" }
+    );
+    expect(response.registrationNumber).toBe("1234567890");
+    expect(response.name).toBe("TOPAZIO");
+  });
+
+  it("confirms import through backend and returns created goat", async () => {
+    mockedPost.mockResolvedValueOnce({
+      data: {
+        id: 91,
+        registrationNumber: "1234567890",
+        name: "TOPAZIO",
+        breed: "SAANEN",
+        color: "CHAMOISEE",
+        gender: "Macho",
+        birthDate: "2020-01-01",
+        status: "Ativo",
+        category: "PA",
+        tod: "12345",
+        toe: "67890",
+        farmId: 7,
+      },
+    });
+
+    const response = await confirmGoatImportFromAbcc(7, {
+      externalId: "ABCC-001",
+      goat: {
+        registrationNumber: "1234567890",
+        name: "TOPAZIO",
+        gender: "Macho",
+        breed: "SAANEN",
+        color: "CHAMOISEE",
+        birthDate: "2020-01-01",
+        status: "Ativo",
+        category: "PA",
+        tod: "12345",
+        toe: "67890",
+      },
+    });
+
+    expect(mockedPost).toHaveBeenCalledWith(
+      "/goatfarms/7/goats/imports/abcc/confirm",
+      expect.objectContaining({ externalId: "ABCC-001" })
+    );
+    expect(response.registrationNumber).toBe("1234567890");
+    expect(response.farmId).toBe(7);
+  });
+
+  it("propagates backend errors from confirm", async () => {
+    mockedPost.mockRejectedValueOnce(new Error("conflict"));
+
+    await expect(
+      confirmGoatImportFromAbcc(7, {
+        externalId: "ABCC-001",
+        goat: {
+          registrationNumber: "1234567890",
+          name: "TOPAZIO",
+          gender: "Macho",
+          breed: "SAANEN",
+          color: "CHAMOISEE",
+          birthDate: "2020-01-01",
+          status: "Ativo",
+          category: "PA",
+          tod: "12345",
+          toe: "67890",
+        },
+      })
+    ).rejects.toThrow("conflict");
+  });
+});

--- a/src/api/GoatAPI/goatAbccImport.test.ts
+++ b/src/api/GoatAPI/goatAbccImport.test.ts
@@ -1,6 +1,7 @@
 ﻿import { beforeEach, describe, expect, it, vi } from "vitest";
 import { requestBackEnd } from "../../utils/request";
 import {
+  confirmGoatImportBatchFromAbcc,
   confirmGoatImportFromAbcc,
   listAbccRaceOptions,
   previewGoatFromAbcc,
@@ -163,5 +164,59 @@ describe("Goat ABCC Import API", () => {
         },
       })
     ).rejects.toThrow("conflict");
+  });
+
+  it("confirms batch import through backend and returns summary", async () => {
+    mockedPost.mockResolvedValueOnce({
+      data: {
+        totalSelected: 4,
+        totalImported: 1,
+        totalSkippedDuplicate: 1,
+        totalSkippedTodMismatch: 1,
+        totalError: 1,
+        results: [
+          {
+            externalId: "A-001",
+            registrationNumber: "1111111111",
+            name: "IMPORTAVEL",
+            status: "IMPORTED",
+            message: "Animal importado com sucesso.",
+          },
+          {
+            externalId: "A-002",
+            registrationNumber: "2222222222",
+            name: "DUPLICADA",
+            status: "SKIPPED_DUPLICATE",
+            message: "Registro já existente nesta fazenda. Item ignorado por duplicidade.",
+          },
+          {
+            externalId: "A-003",
+            status: "SKIPPED_TOD_MISMATCH",
+            message: "O animal selecionado possui TOD diferente do TOD da fazenda.",
+          },
+          {
+            externalId: "A-004",
+            status: "ERROR",
+            message: "Registro ABCC ausente para importar este item.",
+          },
+        ],
+      },
+    });
+
+    const response = await confirmGoatImportBatchFromAbcc(7, {
+      items: [{ externalId: "A-001" }, { externalId: "A-002" }, { externalId: "A-003" }],
+    });
+
+    expect(mockedPost).toHaveBeenCalledWith(
+      "/goatfarms/7/goats/imports/abcc/confirm-batch",
+      expect.objectContaining({
+        items: [{ externalId: "A-001" }, { externalId: "A-002" }, { externalId: "A-003" }],
+      })
+    );
+    expect(response.totalSelected).toBe(4);
+    expect(response.totalSkippedDuplicate).toBe(1);
+    expect(response.totalSkippedTodMismatch).toBe(1);
+    expect(response.results[1].status).toBe("SKIPPED_DUPLICATE");
+    expect(response.results[2].status).toBe("SKIPPED_TOD_MISMATCH");
   });
 });

--- a/src/api/GoatAPI/goatAbccImport.ts
+++ b/src/api/GoatAPI/goatAbccImport.ts
@@ -1,4 +1,4 @@
-import type { BackendGoatPayload } from "../../Convertes/goats/goatConverter";
+﻿import type { BackendGoatPayload } from "../../Convertes/goats/goatConverter";
 import { toGoatResponseDTO } from "../../Convertes/goats/goatConverter";
 import type { GoatResponseDTO } from "../../Models/goatResponseDTO";
 import { requestBackEnd } from "../../utils/request";
@@ -20,8 +20,19 @@ function unwrap<T>(payload: Envelope<T>): T {
 export type GoatAbccFilterSex = "0" | "1";
 export type GoatAbccFilterDna = "0" | "1";
 
+export interface GoatAbccRaceOptionDTO {
+  id: number;
+  name: string;
+  normalizedBreed?: string | null;
+}
+
+export interface GoatAbccRaceOptionsResponseDTO {
+  items: GoatAbccRaceOptionDTO[];
+}
+
 export interface GoatAbccSearchRequestDTO {
-  raceId: number;
+  raceId?: number;
+  raceName?: string;
   affix: string;
   page?: number;
   sex?: GoatAbccFilterSex;
@@ -84,6 +95,19 @@ export interface GoatAbccPreviewResponseDTO {
 export interface GoatAbccConfirmRequestDTO {
   externalId: string;
   goat: BackendGoatPayload;
+}
+
+export async function listAbccRaceOptions(
+  farmId: number
+): Promise<GoatAbccRaceOptionsResponseDTO> {
+  const response = await requestBackEnd.get(
+    `/goatfarms/${farmId}/goats/imports/abcc/races`
+  );
+  const raw = unwrap(response.data);
+
+  return {
+    items: Array.isArray(raw?.items) ? raw.items : [],
+  };
 }
 
 export async function searchGoatsByAbcc(

--- a/src/api/GoatAPI/goatAbccImport.ts
+++ b/src/api/GoatAPI/goatAbccImport.ts
@@ -97,6 +97,37 @@ export interface GoatAbccConfirmRequestDTO {
   goat: BackendGoatPayload;
 }
 
+export interface GoatAbccBatchConfirmItemRequestDTO {
+  externalId: string;
+}
+
+export interface GoatAbccBatchConfirmRequestDTO {
+  items: GoatAbccBatchConfirmItemRequestDTO[];
+}
+
+export type GoatAbccBatchItemStatus =
+  | "IMPORTED"
+  | "SKIPPED_DUPLICATE"
+  | "SKIPPED_TOD_MISMATCH"
+  | "ERROR";
+
+export interface GoatAbccBatchConfirmItemResultDTO {
+  externalId?: string | null;
+  registrationNumber?: string | null;
+  name?: string | null;
+  status: GoatAbccBatchItemStatus;
+  message: string;
+}
+
+export interface GoatAbccBatchConfirmResponseDTO {
+  totalSelected: number;
+  totalImported: number;
+  totalSkippedDuplicate: number;
+  totalSkippedTodMismatch: number;
+  totalError: number;
+  results: GoatAbccBatchConfirmItemResultDTO[];
+}
+
 export async function listAbccRaceOptions(
   farmId: number
 ): Promise<GoatAbccRaceOptionsResponseDTO> {
@@ -149,4 +180,24 @@ export async function confirmGoatImportFromAbcc(
   );
   const raw = unwrap(response.data);
   return toGoatResponseDTO(raw);
+}
+
+export async function confirmGoatImportBatchFromAbcc(
+  farmId: number,
+  payload: GoatAbccBatchConfirmRequestDTO
+): Promise<GoatAbccBatchConfirmResponseDTO> {
+  const response = await requestBackEnd.post(
+    `/goatfarms/${farmId}/goats/imports/abcc/confirm-batch`,
+    payload
+  );
+  const raw = unwrap(response.data);
+
+  return {
+    totalSelected: Number(raw?.totalSelected ?? 0),
+    totalImported: Number(raw?.totalImported ?? 0),
+    totalSkippedDuplicate: Number(raw?.totalSkippedDuplicate ?? 0),
+    totalSkippedTodMismatch: Number(raw?.totalSkippedTodMismatch ?? 0),
+    totalError: Number(raw?.totalError ?? 0),
+    results: Array.isArray(raw?.results) ? raw.results : [],
+  };
 }

--- a/src/api/GoatAPI/goatAbccImport.ts
+++ b/src/api/GoatAPI/goatAbccImport.ts
@@ -1,0 +1,128 @@
+import type { BackendGoatPayload } from "../../Convertes/goats/goatConverter";
+import { toGoatResponseDTO } from "../../Convertes/goats/goatConverter";
+import type { GoatResponseDTO } from "../../Models/goatResponseDTO";
+import { requestBackEnd } from "../../utils/request";
+
+type Envelope<T> = { data: T } | T;
+
+function hasData<T>(payload: unknown): payload is { data: T } {
+  return (
+    typeof payload === "object" &&
+    payload !== null &&
+    Object.prototype.hasOwnProperty.call(payload, "data")
+  );
+}
+
+function unwrap<T>(payload: Envelope<T>): T {
+  return hasData<T>(payload) ? payload.data : (payload as T);
+}
+
+export type GoatAbccFilterSex = "0" | "1";
+export type GoatAbccFilterDna = "0" | "1";
+
+export interface GoatAbccSearchRequestDTO {
+  raceId: number;
+  affix: string;
+  page?: number;
+  sex?: GoatAbccFilterSex;
+  tod?: string;
+  toe?: string;
+  name?: string;
+  dna?: GoatAbccFilterDna;
+}
+
+export interface GoatAbccSearchItemDTO {
+  externalSource: string;
+  externalId: string;
+  nome: string;
+  situacao: string;
+  dna: string;
+  tod: string;
+  toe: string;
+  criador: string;
+  afixo: string;
+  dataNascimento: string;
+  sexo: string;
+  raca: string;
+  pelagem: string;
+  normalizedGender?: string | null;
+  normalizedBreed?: string | null;
+  normalizedStatus?: string | null;
+  normalizationWarnings?: string[];
+}
+
+export interface GoatAbccSearchResponseDTO {
+  currentPage: number;
+  totalPages: number;
+  pageSize: number;
+  items: GoatAbccSearchItemDTO[];
+}
+
+export interface GoatAbccPreviewResponseDTO {
+  externalSource: string;
+  externalId: string;
+  registrationNumber: string;
+  name: string;
+  gender?: string | null;
+  breed?: string | null;
+  color?: string | null;
+  birthDate?: string | null;
+  status?: string | null;
+  tod?: string | null;
+  toe?: string | null;
+  category?: string | null;
+  fatherName?: string | null;
+  fatherRegistrationNumber?: string | null;
+  motherName?: string | null;
+  motherRegistrationNumber?: string | null;
+  userName?: string | null;
+  farmId?: number | null;
+  farmName?: string | null;
+  normalizationWarnings?: string[];
+}
+
+export interface GoatAbccConfirmRequestDTO {
+  externalId: string;
+  goat: BackendGoatPayload;
+}
+
+export async function searchGoatsByAbcc(
+  farmId: number,
+  payload: GoatAbccSearchRequestDTO
+): Promise<GoatAbccSearchResponseDTO> {
+  const response = await requestBackEnd.post(
+    `/goatfarms/${farmId}/goats/imports/abcc/search`,
+    payload
+  );
+  const raw = unwrap(response.data);
+  return {
+    currentPage: Number(raw?.currentPage ?? 0),
+    totalPages: Number(raw?.totalPages ?? 0),
+    pageSize: Number(raw?.pageSize ?? 0),
+    items: Array.isArray(raw?.items) ? raw.items : [],
+  };
+}
+
+export async function previewGoatFromAbcc(
+  farmId: number,
+  externalId: string
+): Promise<GoatAbccPreviewResponseDTO> {
+  const response = await requestBackEnd.post(
+    `/goatfarms/${farmId}/goats/imports/abcc/preview`,
+    { externalId }
+  );
+  const raw = unwrap<GoatAbccPreviewResponseDTO>(response.data);
+  return raw;
+}
+
+export async function confirmGoatImportFromAbcc(
+  farmId: number,
+  payload: GoatAbccConfirmRequestDTO
+): Promise<GoatResponseDTO> {
+  const response = await requestBackEnd.post(
+    `/goatfarms/${farmId}/goats/imports/abcc/confirm`,
+    payload
+  );
+  const raw = unwrap(response.data);
+  return toGoatResponseDTO(raw);
+}

--- a/src/types/goatEnums.tsx
+++ b/src/types/goatEnums.tsx
@@ -1,4 +1,4 @@
-// Enums para cabras
+﻿// Enums para cabras
 
 export enum GoatCategoryEnum {
   PO = "PO", // Puro de Origem (Purebred)
@@ -8,7 +8,7 @@ export enum GoatCategoryEnum {
 
 export enum GoatStatusEnum {
   ATIVO = "ATIVO",
-  INACTIVE = "INACTIVE", 
+  INACTIVE = "INACTIVE",
   DECEASED = "DECEASED",
   SOLD = "SOLD",
 }
@@ -18,10 +18,33 @@ export enum GoatGenderEnum {
   FEMALE = "FEMALE",
 }
 
+export enum GoatBreedEnum {
+  ALPINE = "ALPINE",
+  ALPINA = "ALPINA",
+  ALPINA_AMERICANA = "ALPINA_AMERICANA",
+  ALPINA_BRITANICA = "ALPINA_BRITANICA",
+  ANGLO_NUBIANA = "ANGLO_NUBIANA",
+  ANGORA = "ANGORA",
+  BHUJ = "BHUJ",
+  BOER = "BOER",
+  CANINDE = "CANINDE",
+  JAMNAPARI = "JAMNAPARI",
+  KALAHARI = "KALAHARI",
+  MAMBRINA = "MAMBRINA",
+  MESTICA = "MESTICA",
+  MOXOTO = "MOXOTO",
+  MURCIANA = "MURCIANA",
+  MURCIANA_GRANADINA = "MURCIANA_GRANADINA",
+  SAANEN = "SAANEN",
+  SAVANA = "SAVANA",
+  SRD = "SRD",
+  TOGGENBURG = "TOGGENBURG",
+}
+
 // Labels para exibição
 export const categoryLabels: Record<GoatCategoryEnum, string> = {
   [GoatCategoryEnum.PO]: "PO - Puro de Origem",
-  [GoatCategoryEnum.PA]: "PA - Puro por Avaliação", 
+  [GoatCategoryEnum.PA]: "PA - Puro por Avaliação",
   [GoatCategoryEnum.PC]: "PC - Puro por Cruza",
 };
 
@@ -35,4 +58,27 @@ export const statusLabels: Record<GoatStatusEnum, string> = {
 export const genderLabels: Record<GoatGenderEnum, string> = {
   [GoatGenderEnum.MALE]: "Macho",
   [GoatGenderEnum.FEMALE]: "Fêmea",
+};
+
+export const breedLabels: Record<GoatBreedEnum, string> = {
+  [GoatBreedEnum.ALPINE]: "Alpine",
+  [GoatBreedEnum.ALPINA]: "Alpina",
+  [GoatBreedEnum.ALPINA_AMERICANA]: "Alpina Americana",
+  [GoatBreedEnum.ALPINA_BRITANICA]: "Alpina Britânica",
+  [GoatBreedEnum.ANGLO_NUBIANA]: "Anglo Nubiana",
+  [GoatBreedEnum.ANGORA]: "Angorá",
+  [GoatBreedEnum.BHUJ]: "Bhuj",
+  [GoatBreedEnum.BOER]: "Boer",
+  [GoatBreedEnum.CANINDE]: "Canindé",
+  [GoatBreedEnum.JAMNAPARI]: "Jamnapari",
+  [GoatBreedEnum.KALAHARI]: "Kalahari",
+  [GoatBreedEnum.MAMBRINA]: "Mambrina",
+  [GoatBreedEnum.MESTICA]: "Mestiça",
+  [GoatBreedEnum.MOXOTO]: "Moxotó",
+  [GoatBreedEnum.MURCIANA]: "Murciana",
+  [GoatBreedEnum.MURCIANA_GRANADINA]: "Murciana Granadina",
+  [GoatBreedEnum.SAANEN]: "Saanen",
+  [GoatBreedEnum.SAVANA]: "Savana",
+  [GoatBreedEnum.SRD]: "SRD",
+  [GoatBreedEnum.TOGGENBURG]: "Toggenburg",
 };


### PR DESCRIPTION
## Summary\n- replace manual race id entry with race selection by name\n- consume backend races endpoint in ABCC import flow\n- align goat breed options in manual form\n- add tests for ABCC import service and modal states