### PR TITLE
feat(genealogy): add dedicated genealogy view with abcc complement

### DIFF
--- a/docs/GENEALOGIA_COMPLEMENTAR_ABCC_FRONTEND.md
+++ b/docs/GENEALOGIA_COMPLEMENTAR_ABCC_FRONTEND.md
@@ -10,8 +10,10 @@ Complementar a árvore genealógica de um animal local com dados públicos da AB
 - A consulta segue pública, no mesmo contexto da genealogia do animal.
 
 ## Entrada de UI
-- Tela do animal (`Dashboard`): ação adicional `Complementar com ABCC`.
-- Ação original `Ver genealogia` permanece para consulta local.
+- Tela do animal (`Dashboard`): ação `Abrir genealogia completa`.
+- Nova página dedicada:
+  - `/app/goatfarms/{farmId}/goats/{goatId}/genealogy`
+  - ações de `Dados locais`, `Complementar com ABCC`, `Imprimir` e `Salvar em PDF`.
 
 ## Contratos consumidos
 - Genealogia local:
@@ -20,7 +22,7 @@ Complementar a árvore genealógica de um animal local com dados públicos da AB
   - `GET /goatfarms/{farmId}/goats/{goatId}/genealogies?complementaryAbcc=true`
 
 ## Comportamento visual
-- A árvore mantém o mesmo componente ReactFlow.
+- A árvore mantém o mesmo componente ReactFlow, agora em página dedicada para leitura completa.
 - Cada nó exibe origem:
   - `LOCAL`
   - `ABCC`
@@ -28,6 +30,10 @@ Complementar a árvore genealógica de um animal local com dados públicos da AB
 - A tela mostra mensagem de integração retornada pelo backend.
 - Aviso permanente:
   - dados ABCC são apenas referência externa, sem incorporação automática ao rebanho.
+- O dashboard deixa de renderizar a árvore inline para evitar poluição visual.
+- Exportação:
+  - impressão via navegador;
+  - PDF via `html2pdf.js`.
 
 ## Estados de integração
 - `FOUND`
@@ -44,3 +50,7 @@ Complementar a árvore genealógica de um animal local com dados públicos da AB
 - `src/Components/goat-genealogy/goatGenealogyTree.css`
 - `src/Components/dash-animal-info/GoatActionPanel.tsx`
 - `src/Pages/dashboard/Dashboard.tsx`
+- `src/Pages/genealogy/GoatGenealogyViewPage.tsx`
+- `src/Pages/genealogy/goatGenealogyViewPage.css`
+- `src/utils/appRoutes.ts`
+- `src/main.tsx`

--- a/docs/GENEALOGIA_COMPLEMENTAR_ABCC_FRONTEND.md
+++ b/docs/GENEALOGIA_COMPLEMENTAR_ABCC_FRONTEND.md
@@ -54,3 +54,11 @@ Complementar a árvore genealógica de um animal local com dados públicos da AB
 - `src/Pages/genealogy/goatGenealogyViewPage.css`
 - `src/utils/appRoutes.ts`
 - `src/main.tsx`
+
+## Resumo oficial da entrega
+- Feature pública preservada para consulta genealógica.
+- Fluxo somente leitura (`read-only`) com árvore híbrida local + ABCC.
+- Sem persistência de ancestrais externos no backend.
+- Sem criação de novo animal no rebanho local.
+- Separada da importação patrimonial ABCC.
+- Lookup principal por `registrationNumber`, sem heurística fraca por nome.

--- a/src/Components/dash-animal-info/GoatActionPanel.test.tsx
+++ b/src/Components/dash-animal-info/GoatActionPanel.test.tsx
@@ -40,12 +40,12 @@ describe("GoatActionPanel", () => {
         canAccessModules={true}
         gender="FEMALE"
         resourceOwnerId={7}
-        onShowGenealogy={() => {}}
         onShowEventForm={() => {}}
       />
     );
 
     expect(html).toContain("Gerenciar Fazenda");
+    expect(html).toContain("Abrir genealogia completa");
     expect(html).toContain("Sanidade");
     expect(html).toContain("Reprodução");
     expect(html).not.toContain("Estoque");

--- a/src/Components/dash-animal-info/GoatActionPanel.tsx
+++ b/src/Components/dash-animal-info/GoatActionPanel.tsx
@@ -4,6 +4,7 @@ import { PermissionService } from "../../services/PermissionService";
 import {
   buildFarmDashboardPath,
   buildGoatEventsPath,
+  buildGoatGenealogyPath,
   buildGoatHealthPath,
   buildGoatLactationsPath,
   buildGoatMilkProductionsPath,
@@ -16,8 +17,6 @@ interface Props {
   registrationNumber: string | null;
   goatId?: number;
   resourceOwnerId?: number;
-  onShowGenealogy: () => void;
-  onShowComplementaryGenealogy?: () => void;
   onShowEventForm: () => void;
   farmId?: number | null;
   canAccessModules?: boolean;
@@ -26,8 +25,6 @@ interface Props {
 
 export default function GoatActionPanel({
   registrationNumber,
-  onShowGenealogy,
-  onShowComplementaryGenealogy,
   onShowEventForm,
   resourceOwnerId,
   farmId,
@@ -80,17 +77,23 @@ export default function GoatActionPanel({
       <div className="goat-action-panel__group goat-action-panel__group--surface">
         <span className="goat-action-panel__group-label">Manejo individual</span>
 
-        <button className="action-btn" onClick={onShowGenealogy}>
+        <button
+          className="action-btn"
+          disabled={!farmId}
+          onClick={() => {
+            if (farmId) {
+              navigate(buildGoatGenealogyPath(farmId, goatRouteId));
+            }
+          }}
+          title={
+            !farmId
+              ? "Aguardando carregamento dos dados do animal..."
+              : "Abrir visualização completa da genealogia"
+          }
+        >
           <i className="fa-solid fa-dna" aria-hidden="true"></i>
-          Ver genealogia
+          {!farmId ? "Carregando..." : "Abrir genealogia completa"}
         </button>
-
-        {onShowComplementaryGenealogy && (
-          <button className="action-btn" onClick={onShowComplementaryGenealogy}>
-            <i className="fa-solid fa-network-wired" aria-hidden="true"></i>
-            Complementar com ABCC
-          </button>
-        )}
 
         {canAccessModules && (
           <>

--- a/src/Components/goat-genealogy/GoatGenealogyTree.tsx
+++ b/src/Components/goat-genealogy/GoatGenealogyTree.tsx
@@ -1,7 +1,8 @@
-﻿import React, { useMemo } from 'react';
+﻿import React, { useEffect, useMemo, useRef } from 'react';
 import ReactFlow, {
   Background,
   Controls,
+  ReactFlowInstance,
   useNodesState,
   useEdgesState,
   NodeProps,
@@ -10,7 +11,7 @@ import ReactFlow, {
 import 'reactflow/dist/style.css';
 import './goatGenealogyTree.css';
 
-import { useLayoutedElements } from '../../Hooks/useLayoutedElements';
+import { useLayoutedElements as layoutElements } from '../../Hooks/useLayoutedElements';
 import type { GoatGenealogyDTO } from '../../Models/goatGenealogyDTO';
 import { convertGenealogyDTOToReactFlowData } from '../../Convertes/genealogies/convertGenealogyDTOToReactFlowData';
 
@@ -50,9 +51,32 @@ export default function GoatGenealogyTree({ data }: { data: GoatGenealogyDTO }) 
     [data]
   );
 
-  const layoutedNodes = useLayoutedElements(initialNodes, initialEdges);
-  const [nodes, , onNodesChange] = useNodesState(layoutedNodes);
-  const [edges, , onEdgesChange] = useEdgesState(initialEdges);
+  const layoutedNodes = useMemo(
+    () => layoutElements(initialNodes, initialEdges),
+    [initialNodes, initialEdges]
+  );
+
+  const [nodes, setNodes, onNodesChange] = useNodesState(layoutedNodes);
+  const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
+  const flowInstanceRef = useRef<ReactFlowInstance | null>(null);
+
+  useEffect(() => {
+    setNodes(layoutedNodes);
+    setEdges(initialEdges);
+  }, [layoutedNodes, initialEdges, setNodes, setEdges]);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      flowInstanceRef.current?.fitView({
+        padding: 0.34,
+        duration: 280,
+        maxZoom: 1.15,
+        minZoom: 0.28,
+      });
+    }, 40);
+
+    return () => window.clearTimeout(timer);
+  }, [nodes.length, edges.length, data]);
 
   return (
     <div className="genealogy-tree-shell">
@@ -62,14 +86,19 @@ export default function GoatGenealogyTree({ data }: { data: GoatGenealogyDTO }) 
         <span className="genealogy-tree__legend-item genealogy-tree__legend-item--ausente">AUSENTE</span>
       </div>
 
-      <div style={{ width: '100%', height: '80vh' }}>
+      <div style={{ width: '100%', height: '76vh' }}>
         <ReactFlow
           nodes={nodes}
           edges={edges}
           onNodesChange={onNodesChange}
           onEdgesChange={onEdgesChange}
           nodeTypes={nodeTypes}
+          onInit={(instance) => {
+            flowInstanceRef.current = instance;
+          }}
           fitView
+          fitViewOptions={{ padding: 0.34 }}
+          defaultEdgeOptions={{ type: 'smoothstep' }}
           nodesDraggable={true}
         >
           <Background />

--- a/src/Components/goat-genealogy/goatGenealogyTree.css
+++ b/src/Components/goat-genealogy/goatGenealogyTree.css
@@ -38,18 +38,19 @@
 }
 
 .react-flow__node-customNode {
-  min-width: 150px !important;
-  min-height: 88px !important;
-  padding: 7px !important;
+  min-width: 184px !important;
+  min-height: 96px !important;
+  padding: 8px !important;
   border: 1.5px solid var(--gf-color-darkgreen);
   border-radius: 8px;
   background: #f8fafc;
-  font-size: 11px;
+  font-size: 12px;
   text-align: left;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-start;
+  overflow: hidden;
 }
 
 .custom-node--local {
@@ -76,10 +77,19 @@
 }
 
 .custom-node strong {
-  font-size: 11px;
+  font-size: 13px;
   font-weight: 700;
   color: #1f2937;
   margin: 0;
+  line-height: 1.2;
+  white-space: normal;
+  word-break: break-word;
+}
+
+.custom-node > div {
+  line-height: 1.25;
+  white-space: normal;
+  word-break: break-word;
 }
 
 .custom-node__badge {
@@ -107,8 +117,9 @@
 }
 
 .custom-node small {
-  font-size: 9px;
+  font-size: 11px;
   color: #64748b;
+  word-break: break-all;
 }
 
 /* Cor das conexões */

--- a/src/Convertes/genealogies/convertGenealogyDTOToReactFlowData.ts
+++ b/src/Convertes/genealogies/convertGenealogyDTOToReactFlowData.ts
@@ -22,6 +22,33 @@ function getNodeDisplayRegistration(registration: string | undefined, source?: G
   return source === "AUSENTE" ? "-" : "XXXX";
 }
 
+function getRelationLabel(relation: string | undefined): string {
+  const raw = (relation || "").trim();
+  if (!raw) {
+    return "";
+  }
+
+  const relationMap: Record<string, string> = {
+    animalPrincipal: "Animal principal",
+    pai: "Pai",
+    mae: "Mãe",
+    avoPaterno: "Avô paterno",
+    avoPaterna: "Avó paterna",
+    avoMaterno: "Avô materno",
+    avoMaterna: "Avó materna",
+    bisavoPaternoPai: "Bisavô paterno (pai)",
+    bisavoPaternaPai: "Bisavó paterna (pai)",
+    bisavoPaternoMae: "Bisavô paterno (mãe)",
+    bisavoPaternaMae: "Bisavó paterna (mãe)",
+    bisavoMaternoPai: "Bisavô materno (pai)",
+    bisavoMaternaPai: "Bisavó materna (pai)",
+    bisavoMaternoMae: "Bisavô materno (mãe)",
+    bisavoMaternaMae: "Bisavó materna (mãe)",
+  };
+
+  return relationMap[raw] ?? raw;
+}
+
 export function convertGenealogyDTOToReactFlowData(
   dto: GoatGenealogyDTO
 ): { nodes: Node[]; edges: Edge[] } {
@@ -37,7 +64,7 @@ export function convertGenealogyDTOToReactFlowData(
     type: "customNode",
     data: {
       name: getNodeDisplayName(name, source),
-      relation,
+      relation: getRelationLabel(relation),
       registration: getNodeDisplayRegistration(registration, source),
       source,
       ...extraData,

--- a/src/Hooks/useLayoutedElements.ts
+++ b/src/Hooks/useLayoutedElements.ts
@@ -1,30 +1,31 @@
-import * as dagre from 'dagre';
+﻿import * as dagre from 'dagre';
 import type { Node, Edge } from 'reactflow';
 
-const NODE_WIDTH = 130;  // Reduzido de 140 para 130
-const NODE_HEIGHT = 75;  // Reduzido de 80 para 75
+const NODE_WIDTH = 210;
+const NODE_HEIGHT = 108;
 
 export function useLayoutedElements(nodes: Node[], edges: Edge[]) {
   const graph = new dagre.graphlib.Graph();
   graph.setDefaultEdgeLabel(() => ({}));
-  
-  // Configuração modificada para inverter a hierarquia
+
   graph.setGraph({
-  rankdir: 'BT' as 'TB', // finge que é 'TB' apenas para satisfazer o TS
-  ranksep: 40,  // Reduzido de 60 para 40 - espaçamento vertical entre níveis
-  nodesep: 15   // Reduzido de 20 para 15 - espaçamento horizontal entre nós
-}); 
+    rankdir: 'TB',
+    ranksep: 110,
+    nodesep: 54,
+    edgesep: 28,
+    marginx: 24,
+    marginy: 24,
+  });
 
   nodes.forEach((node) => {
     graph.setNode(node.id, {
       width: NODE_WIDTH,
-      height: NODE_HEIGHT
+      height: NODE_HEIGHT,
     });
   });
 
   edges.forEach((edge) => {
-    // Inverte a direção das arestas
-    graph.setEdge(edge.target, edge.source); // Note a inversão aqui
+    graph.setEdge(edge.source, edge.target);
   });
 
   dagre.layout(graph);
@@ -34,13 +35,14 @@ export function useLayoutedElements(nodes: Node[], edges: Edge[]) {
     return {
       ...node,
       position: {
-        x: nodeWithPosition.x - NODE_WIDTH/2,
-        y: nodeWithPosition.y - NODE_HEIGHT/2
+        x: nodeWithPosition.x - NODE_WIDTH / 2,
+        y: nodeWithPosition.y - NODE_HEIGHT / 2,
       },
       style: {
         width: NODE_WIDTH,
-        height: NODE_HEIGHT
-      }
+        height: NODE_HEIGHT,
+      },
     };
   });
 }
+

--- a/src/Pages/dashboard/Dashboard.tsx
+++ b/src/Pages/dashboard/Dashboard.tsx
@@ -9,16 +9,13 @@ import {
 
 import GoatActionPanel from "../../Components/dash-animal-info/GoatActionPanel";
 import GoatInfoCard from "../../Components/goat-info-card/GoatInfoCard";
-import GoatGenealogyTree from "../../Components/goat-genealogy/GoatGenealogyTree";
 import GoatEventModal from "../../Components/goat-event-form/GoatEventModal";
 import SearchInputBox from "../../Components/searchs/SearchInputBox";
 import GoatCardList from "../../Components/goat-card-list/GoatCardList";
 import ContextBreadcrumb from "../../Components/pages-headers/ContextBreadcrumb";
 
-import { getComplementaryGenealogyAbcc, getGenealogy } from "../../api/GenealogyAPI/genealogy";
 import { fetchGoatById, findGoatsByFarmAndName } from "../../api/GoatAPI/goat";
 import type { GoatFarmDTO } from "../../Models/goatFarm";
-import type { GoatGenealogyDTO } from "../../Models/goatGenealogyDTO";
 import type { GoatResponseDTO } from "../../Models/goatResponseDTO";
 import {
   buildFarmDashboardPath,
@@ -58,10 +55,6 @@ export default function AnimalDashboard() {
   const [canAccessFarmModules, setCanAccessFarmModules] = useState(false);
   const [searchResults, setSearchResults] = useState<GoatResponseDTO[]>([]);
   const [isSearching, setIsSearching] = useState(false);
-  const [genealogyData, setGenealogyData] = useState<GoatGenealogyDTO | null>(
-    null
-  );
-  const [genealogyIntegrationMessage, setGenealogyIntegrationMessage] = useState<string | null>(null);
   const [showEventForm, setShowEventForm] = useState(false);
 
   useEffect(() => {
@@ -245,33 +238,6 @@ export default function AnimalDashboard() {
     void resolveFarmAccess();
   }, [resolvedFarmId, tokenPayload?.userId, permissions]);
 
-  const showGenealogy = () => {
-    if (goat?.registrationNumber && goat?.farmId != null) {
-      setGenealogyIntegrationMessage(null);
-      getGenealogy(Number(goat.farmId), goat.registrationNumber)
-        .then((response) => {
-          setGenealogyData(response);
-          setGenealogyIntegrationMessage(response.integration?.message ?? null);
-        })
-        .catch((error) => {
-          console.error("Erro ao buscar genealogia:", error);
-        });
-    }
-  };
-
-  const showComplementaryGenealogy = () => {
-    if (goat?.registrationNumber && goat?.farmId != null) {
-      getComplementaryGenealogyAbcc(Number(goat.farmId), goat.registrationNumber)
-        .then((response) => {
-          setGenealogyData(response);
-          setGenealogyIntegrationMessage(response.integration?.message ?? null);
-        })
-        .catch((error) => {
-          console.error("Erro ao buscar genealogia complementar ABCC:", error);
-        });
-    }
-  };
-
   const handleShowEventForm = () => setShowEventForm(true);
 
   async function handleSearch(term: string) {
@@ -410,8 +376,6 @@ export default function AnimalDashboard() {
                   registrationNumber={goat.registrationNumber}
                   resourceOwnerId={goat.ownerId ?? goat.userId ?? farmOwnerId}
                   canAccessModules={canAccessFarmModules}
-                  onShowGenealogy={showGenealogy}
-                  onShowComplementaryGenealogy={showComplementaryGenealogy}
                   onShowEventForm={handleShowEventForm}
                   farmId={resolvedFarmId ?? goat.farmId}
                   goatId={goat.id}
@@ -441,20 +405,6 @@ export default function AnimalDashboard() {
             </div>
           )}
 
-          {genealogyData && (
-            <div className="goat-genealogy-wrapper">
-              <h3>🧬 Árvore genealógica</h3>
-              <p>
-                Dados ABCC são somente referência externa; não foram incorporados ao rebanho.
-              </p>
-              {genealogyIntegrationMessage && (
-                <p>
-                  <strong>Integração ABCC:</strong> {genealogyIntegrationMessage}
-                </p>
-              )}
-              <GoatGenealogyTree data={genealogyData} />
-            </div>
-          )}
         </>
       )}
     </div>

--- a/src/Pages/genealogy/GoatGenealogyViewPage.tsx
+++ b/src/Pages/genealogy/GoatGenealogyViewPage.tsx
@@ -1,0 +1,543 @@
+import { useEffect, useRef, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import html2pdf from "html2pdf.js";
+
+import ContextBreadcrumb from "../../Components/pages-headers/ContextBreadcrumb";
+import GoatGenealogyTree from "../../Components/goat-genealogy/GoatGenealogyTree";
+import { getComplementaryGenealogyAbcc, getGenealogy } from "../../api/GenealogyAPI/genealogy";
+import { fetchGoatById } from "../../api/GoatAPI/goat";
+import type { GenealogyNodeSource, GoatGenealogyDTO } from "../../Models/goatGenealogyDTO";
+import type { GoatResponseDTO } from "../../Models/goatResponseDTO";
+import {
+  buildFarmDashboardPath,
+  buildFarmGoatsPath,
+  buildGoatDetailPath,
+} from "../../utils/appRoutes";
+import "./goatGenealogyViewPage.css";
+
+type GenealogyMode = "LOCAL" | "ABCC";
+type PrintCard = {
+  relation: string;
+  name: string;
+  registration: string;
+  source: GenealogyNodeSource;
+};
+
+function toNumberOrNull(value?: string): number | null {
+  if (!value) {
+    return null;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function normalizeSource(source?: GenealogyNodeSource): GenealogyNodeSource {
+  if (source === "LOCAL" || source === "ABCC" || source === "AUSENTE") {
+    return source;
+  }
+  return "AUSENTE";
+}
+
+function buildPrintCard(
+  relation: string,
+  input?: { nome?: string; registro?: string; source?: GenealogyNodeSource }
+): PrintCard {
+  const source = normalizeSource(input?.source);
+  return {
+    relation,
+    name: input?.nome?.trim() || (source === "AUSENTE" ? "Não informado" : "XXXX"),
+    registration: input?.registro?.trim() || (source === "AUSENTE" ? "-" : "XXXX"),
+    source,
+  };
+}
+
+function formatBirthDate(value?: string): string {
+  const raw = (value || "").trim();
+  if (!raw) {
+    return "";
+  }
+
+  const parts = raw.split("-");
+  if (parts.length === 3) {
+    const [year, month, day] = parts;
+    if (year && month && day) {
+      return `${day}/${month}/${year}`;
+    }
+  }
+
+  return raw;
+}
+
+function getPrintableStyles(): string {
+  return `
+    * { box-sizing: border-box; }
+    body { font-family: Arial, sans-serif; margin: 0; padding: 12px; color: #0f172a; }
+    .genealogy-export-document { width: 100%; max-width: 1180px; margin: 0 auto; }
+    .genealogy-export-document__header h2 { margin: 0 0 4px; font-size: 20px; }
+    .genealogy-export-document__header p { margin: 2px 0; color: #475569; font-size: 14px; }
+    .genealogy-export-document__note { margin-bottom: 8px !important; color: #334155; font-size: 12px; }
+    .genealogy-export-tree { display: flex; flex-direction: column; gap: 8px; }
+    .genealogy-export-row { display: grid; gap: 8px; grid-template-columns: repeat(8, minmax(0, 1fr)); }
+    .genealogy-export-row--principal .genealogy-export-card { grid-column: 3 / span 4; }
+    .genealogy-export-row--parents .genealogy-export-card { grid-column: span 4; }
+    .genealogy-export-row--grandparents .genealogy-export-card { grid-column: span 2; }
+    .genealogy-export-row--greatgrandparents .genealogy-export-card { grid-column: span 1; }
+    .genealogy-export-card { border: 1.2px solid #9eb9e9; border-radius: 8px; min-height: 92px; padding: 8px; overflow: hidden; background: #ffffff; }
+    .genealogy-export-card header { align-items: center; display: flex; justify-content: space-between; margin-bottom: 6px; gap: 8px; }
+    .genealogy-export-card header strong { font-size: 12px; line-height: 1.2; }
+    .genealogy-export-card header span { border-radius: 999px; font-size: 10px; font-weight: 700; padding: 2px 7px; }
+    .genealogy-export-card > div { font-size: 15px; font-weight: 700; line-height: 1.25; word-break: break-word; }
+    .genealogy-export-card small { color: #64748b; font-size: 12px; word-break: break-all; }
+    .genealogy-export-card--principal { min-height: 152px; }
+    .genealogy-export-card__meta { display: grid; gap: 4px; grid-template-columns: repeat(4, minmax(0, 1fr)); margin-top: 6px; }
+    .genealogy-export-card__meta-item { background: rgba(255, 255, 255, 0.65); border: 1px solid rgba(148, 163, 184, 0.45); border-radius: 6px; padding: 3px 5px; }
+    .genealogy-export-card__meta-item span { color: #475569; display: block; font-size: 10px; line-height: 1.1; text-transform: uppercase; }
+    .genealogy-export-card__meta-item strong { color: #0f172a; display: block; font-size: 12px; line-height: 1.2; margin-top: 1px; word-break: break-word; }
+    .genealogy-export-card__line { color: #334155; font-size: 11px; line-height: 1.2; margin-top: 4px; word-break: break-word; }
+    .genealogy-export-card--local { background: #eff9f3; border-color: #2f9462; }
+    .genealogy-export-card--local header span { background: #dff3e7; color: #0f6b3d; }
+    .genealogy-export-card--abcc { background: #f2f7ff; border-color: #5f8fd6; }
+    .genealogy-export-card--abcc header span { background: #e2ecff; color: #1d4f9b; }
+    .genealogy-export-card--ausente { background: #f7f8fa; border-color: #a0a9b8; }
+    .genealogy-export-card--ausente header span { background: #eceff4; color: #4f5b6f; }
+    @page { size: A4 landscape; margin: 8mm; }
+  `;
+}
+
+export default function GoatGenealogyViewPage() {
+  const { farmId: farmIdParam, goatId: goatIdParam } = useParams<{
+    farmId: string;
+    goatId: string;
+  }>();
+
+  const farmId = toNumberOrNull(farmIdParam);
+  const goatId = goatIdParam ?? "";
+
+  const [goat, setGoat] = useState<GoatResponseDTO | null>(null);
+  const [genealogy, setGenealogy] = useState<GoatGenealogyDTO | null>(null);
+  const [mode, setMode] = useState<GenealogyMode>("LOCAL");
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [integrationMessage, setIntegrationMessage] = useState<string | null>(null);
+
+  const printableRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!farmId || !goatId) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const loadGoat = async () => {
+      try {
+        const goatData = await fetchGoatById(farmId, goatId);
+        if (!cancelled) {
+          setGoat(goatData);
+        }
+      } catch (error) {
+        if (!cancelled) {
+          console.error("Genealogia: falha ao carregar dados do animal", error);
+        }
+      }
+    };
+
+    void loadGoat();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [farmId, goatId]);
+
+  useEffect(() => {
+    if (!farmId || !goatId) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const loadInitialGenealogy = async () => {
+      setIsLoading(true);
+      setErrorMessage(null);
+      try {
+        const response = await getGenealogy(farmId, goatId);
+        if (cancelled) {
+          return;
+        }
+        setGenealogy(response);
+        setIntegrationMessage(response.integration?.message ?? null);
+        setMode("LOCAL");
+      } catch (error) {
+        if (!cancelled) {
+          console.error("Genealogia: falha ao carregar genealogia local", error);
+          setErrorMessage("Não foi possível carregar a genealogia local deste animal.");
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void loadInitialGenealogy();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [farmId, goatId]);
+
+  const loadLocalGenealogy = async () => {
+    if (!farmId || !goatId) {
+      return;
+    }
+
+    setIsLoading(true);
+    setErrorMessage(null);
+    try {
+      const response = await getGenealogy(farmId, goatId);
+      setGenealogy(response);
+      setIntegrationMessage(response.integration?.message ?? null);
+      setMode("LOCAL");
+    } catch (error) {
+      console.error("Genealogia: falha ao recarregar genealogia local", error);
+      setErrorMessage("Não foi possível recarregar a genealogia local.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const loadComplementaryAbcc = async () => {
+    if (!farmId || !goatId) {
+      return;
+    }
+
+    setIsLoading(true);
+    setErrorMessage(null);
+    try {
+      const response = await getComplementaryGenealogyAbcc(farmId, goatId);
+      setGenealogy(response);
+      setIntegrationMessage(response.integration?.message ?? null);
+      setMode("ABCC");
+    } catch (error) {
+      console.error("Genealogia: falha ao carregar complemento ABCC", error);
+      setErrorMessage("Não foi possível complementar a árvore com dados da ABCC agora.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handlePrint = () => {
+    if (!printableRef.current) {
+      return;
+    }
+
+    const printWindow = window.open("", "_blank", "width=1400,height=900");
+    if (!printWindow) {
+      return;
+    }
+
+    const fileKey = goat?.registrationNumber || goatId || "genealogia";
+    const content = printableRef.current.outerHTML;
+    const styles = getPrintableStyles();
+
+    printWindow.document.open();
+    printWindow.document.write(`
+      <!doctype html>
+      <html lang="pt-BR">
+        <head>
+          <meta charset="UTF-8" />
+          <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+          <title>Genealogia ${fileKey}</title>
+          <style>${styles}</style>
+        </head>
+        <body>${content}</body>
+      </html>
+    `);
+    printWindow.document.close();
+    printWindow.focus();
+    window.setTimeout(() => {
+      printWindow.print();
+      printWindow.close();
+    }, 250);
+  };
+
+  const handleSavePdf = () => {
+    if (!printableRef.current) {
+      return;
+    }
+
+    const fileKey = goat?.registrationNumber || goatId || "genealogia";
+    const clone = printableRef.current.cloneNode(true) as HTMLDivElement;
+    clone.style.position = "fixed";
+    clone.style.left = "-12000px";
+    clone.style.top = "0";
+    clone.style.width = "1120px";
+    clone.style.background = "#ffffff";
+    document.body.appendChild(clone);
+
+    html2pdf()
+      .set({
+        margin: 0.25,
+        filename: `genealogia_${fileKey}.pdf`,
+        image: { type: "jpeg", quality: 0.98 },
+        html2canvas: { scale: 2, backgroundColor: "#ffffff", useCORS: true },
+        jsPDF: { unit: "in", format: "a4", orientation: "landscape" },
+        pagebreak: { mode: ["avoid-all", "css"] },
+      })
+      .from(clone)
+      .save()
+      .finally(() => {
+        document.body.removeChild(clone);
+      });
+  };
+
+  const resolvedFarmPath = farmId ? buildFarmDashboardPath(farmId) : "/goatfarms";
+  const goatDetailPath = farmId && goatId ? buildGoatDetailPath(farmId, goatId) : "/cabras";
+  const goatListPath = farmId ? buildFarmGoatsPath(farmId) : "/cabras";
+
+  const breadcrumbItems = [
+    { label: "Fazendas", to: "/goatfarms" },
+    { label: goat?.farmName || "Fazenda", to: resolvedFarmPath },
+    { label: "Cabras", to: goatListPath },
+    { label: goat?.name || "Animal", to: goatDetailPath },
+    { label: "Genealogia" },
+  ];
+
+  const principalCard = genealogy
+    ? buildPrintCard("Animal principal", {
+        nome: genealogy.animalPrincipal.nome,
+        registro: genealogy.animalPrincipal.registro,
+        source: genealogy.animalPrincipal.source || "LOCAL",
+      })
+    : null;
+
+  const principalMetaItems = genealogy
+    ? [
+        {
+          label: "Sexo",
+          value: genealogy.animalPrincipal.sexo?.trim() || String(goat?.gender || "").trim(),
+        },
+        {
+          label: "Raça",
+          value: genealogy.animalPrincipal.raca?.trim() || goat?.breed?.trim() || "",
+        },
+        {
+          label: "Pelagem",
+          value: genealogy.animalPrincipal.pelagem?.trim() || goat?.color?.trim() || "",
+        },
+        {
+          label: "Categoria",
+          value:
+            genealogy.animalPrincipal.categoria?.trim() || String(goat?.category || "").trim(),
+        },
+        {
+          label: "Situação",
+          value: genealogy.animalPrincipal.situacao?.trim() || String(goat?.status || "").trim(),
+        },
+        {
+          label: "Nascimento",
+          value: formatBirthDate(genealogy.animalPrincipal.dataNasc || goat?.birthDate),
+        },
+        {
+          label: "TOD",
+          value: genealogy.animalPrincipal.tod?.trim() || goat?.tod?.trim() || "",
+        },
+        {
+          label: "TOE",
+          value: genealogy.animalPrincipal.toe?.trim() || goat?.toe?.trim() || "",
+        },
+      ].map((item) => ({
+        ...item,
+        value: item.value?.trim() || "Não informado",
+      }))
+    : [];
+
+  const principalCreator =
+    genealogy?.animalPrincipal.criador?.trim() ||
+    goat?.userName?.trim() ||
+    goat?.ownerName?.trim() ||
+    "Não informado";
+  const principalOwner =
+    genealogy?.animalPrincipal.proprietario?.trim() ||
+    goat?.ownerName?.trim() ||
+    goat?.farmName?.trim() ||
+    "Não informado";
+
+  const parentCards = genealogy
+    ? [
+        buildPrintCard("Pai", genealogy.pai),
+        buildPrintCard("Mãe", genealogy.mae),
+      ]
+    : [];
+
+  const grandparentCards = genealogy
+    ? [
+        buildPrintCard("Avô paterno", genealogy.avoPaterno),
+        buildPrintCard("Avó paterna", genealogy.avoPaterna),
+        buildPrintCard("Avô materno", genealogy.avoMaterno),
+        buildPrintCard("Avó materna", genealogy.avoMaterna),
+      ]
+    : [];
+
+  const bisavoPaternos = genealogy?.bisavosPaternos ?? [];
+  const bisavoMaternos = genealogy?.bisavosMaternos ?? [];
+  const greatGrandparentCards = genealogy
+    ? [
+        buildPrintCard("Bisavô paterno (pai)", bisavoPaternos[0]),
+        buildPrintCard("Bisavó paterna (pai)", bisavoPaternos[1]),
+        buildPrintCard("Bisavô paterno (mãe)", bisavoPaternos[2]),
+        buildPrintCard("Bisavó paterna (mãe)", bisavoPaternos[3]),
+        buildPrintCard("Bisavô materno (pai)", bisavoMaternos[0]),
+        buildPrintCard("Bisavó materna (pai)", bisavoMaternos[1]),
+        buildPrintCard("Bisavô materno (mãe)", bisavoMaternos[2]),
+        buildPrintCard("Bisavó materna (mãe)", bisavoMaternos[3]),
+      ]
+    : [];
+
+  return (
+    <div className="content-in genealogy-view-page">
+      <ContextBreadcrumb items={breadcrumbItems} />
+
+      <section className="genealogy-view-page__hero">
+        <div>
+          <span className="genealogy-view-page__eyebrow">Genealogia do animal</span>
+          <h1>Visualização completa</h1>
+          <p>
+            Consulte a árvore genealógica local e complemente com dados públicos da ABCC
+            sem incorporar ancestrais ao rebanho.
+          </p>
+          <div className="genealogy-view-page__animal">
+            <strong>{goat?.name || "Animal"}</strong>
+            <span>Registro {goat?.registrationNumber || goatId}</span>
+          </div>
+        </div>
+
+        <div className="genealogy-view-page__actions genealogy-view-print-actions">
+          <button className="btn-secondary" onClick={loadLocalGenealogy} disabled={isLoading}>
+            Dados locais
+          </button>
+          <button className="btn-secondary" onClick={loadComplementaryAbcc} disabled={isLoading}>
+            Complementar com ABCC
+          </button>
+          <button className="btn-secondary" onClick={handlePrint} disabled={!genealogy}>
+            Imprimir
+          </button>
+          <button className="btn-secondary" onClick={handleSavePdf} disabled={!genealogy}>
+            Salvar em PDF
+          </button>
+          <Link className="btn-secondary" to={goatDetailPath}>
+            Voltar ao animal
+          </Link>
+        </div>
+      </section>
+
+      <div className="genealogy-view-page__status">
+        <span className={`genealogy-view-page__mode genealogy-view-page__mode--${mode.toLowerCase()}`}>
+          Modo: {mode === "ABCC" ? "Complementar ABCC" : "Genealogia local"}
+        </span>
+        {integrationMessage && <span>{integrationMessage}</span>}
+        <span>Dados ABCC são somente referência externa; não foram incorporados ao rebanho.</span>
+      </div>
+
+      {errorMessage && <div className="genealogy-view-page__error">{errorMessage}</div>}
+
+      {isLoading && <div className="genealogy-view-page__loading">Carregando genealogia...</div>}
+
+      {!isLoading && genealogy && (
+        <div className="genealogy-view-page__canvas genealogy-view-page__canvas--interactive">
+          <GoatGenealogyTree data={genealogy} />
+        </div>
+      )}
+
+      {genealogy && principalCard && (
+        <div ref={printableRef} className="genealogy-export-document">
+          <header className="genealogy-export-document__header">
+            <h2>Genealogia do animal</h2>
+            <p>
+              {goat?.name || genealogy.animalPrincipal.nome} · Registro{" "}
+              {goat?.registrationNumber || genealogy.animalPrincipal.registro}
+            </p>
+            <p className="genealogy-export-document__note">
+              Dados ABCC são somente referência externa; não foram incorporados ao rebanho.
+            </p>
+          </header>
+
+          <section className="genealogy-export-tree">
+            <div className="genealogy-export-row genealogy-export-row--principal">
+              <article
+                className={`genealogy-export-card genealogy-export-card--principal genealogy-export-card--${principalCard.source.toLowerCase()}`}
+              >
+                <header>
+                  <strong>{principalCard.relation}</strong>
+                  <span>{principalCard.source}</span>
+                </header>
+                <div>{principalCard.name}</div>
+                <small>{principalCard.registration}</small>
+                {principalMetaItems.length > 0 && (
+                  <div className="genealogy-export-card__meta">
+                    {principalMetaItems.map((item) => (
+                      <div key={item.label} className="genealogy-export-card__meta-item">
+                        <span>{item.label}</span>
+                        <strong>{item.value}</strong>
+                      </div>
+                    ))}
+                  </div>
+                )}
+                <div className="genealogy-export-card__line">Criador: {principalCreator}</div>
+                <div className="genealogy-export-card__line">Proprietário: {principalOwner}</div>
+              </article>
+            </div>
+
+            <div className="genealogy-export-row genealogy-export-row--parents">
+              {parentCards.map((card) => (
+                <article
+                  key={card.relation}
+                  className={`genealogy-export-card genealogy-export-card--${card.source.toLowerCase()}`}
+                >
+                  <header>
+                    <strong>{card.relation}</strong>
+                    <span>{card.source}</span>
+                  </header>
+                  <div>{card.name}</div>
+                  <small>{card.registration}</small>
+                </article>
+              ))}
+            </div>
+
+            <div className="genealogy-export-row genealogy-export-row--grandparents">
+              {grandparentCards.map((card) => (
+                <article
+                  key={card.relation}
+                  className={`genealogy-export-card genealogy-export-card--${card.source.toLowerCase()}`}
+                >
+                  <header>
+                    <strong>{card.relation}</strong>
+                    <span>{card.source}</span>
+                  </header>
+                  <div>{card.name}</div>
+                  <small>{card.registration}</small>
+                </article>
+              ))}
+            </div>
+
+            <div className="genealogy-export-row genealogy-export-row--greatgrandparents">
+              {greatGrandparentCards.map((card) => (
+                <article
+                  key={card.relation}
+                  className={`genealogy-export-card genealogy-export-card--${card.source.toLowerCase()}`}
+                >
+                  <header>
+                    <strong>{card.relation}</strong>
+                    <span>{card.source}</span>
+                  </header>
+                  <div>{card.name}</div>
+                  <small>{card.registration}</small>
+                </article>
+              ))}
+            </div>
+          </section>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/Pages/genealogy/goatGenealogyViewPage.css
+++ b/src/Pages/genealogy/goatGenealogyViewPage.css
@@ -1,0 +1,333 @@
+.genealogy-view-page {
+  padding: 0 1.5rem 2rem;
+}
+
+.genealogy-view-page__hero {
+  background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
+  border: 1px solid rgba(226, 232, 240, 0.9);
+  border-radius: 1.2rem;
+  box-shadow: 0 12px 26px rgba(15, 23, 42, 0.06);
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: minmax(0, 1fr) auto;
+  margin-bottom: 1rem;
+  padding: 1.25rem;
+}
+
+.genealogy-view-page__eyebrow {
+  color: #1d4ed8;
+  display: inline-flex;
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  margin-bottom: 0.35rem;
+  text-transform: uppercase;
+}
+
+.genealogy-view-page__hero h1 {
+  color: #0f172a;
+  font-size: clamp(1.6rem, 2.4vw, 2.1rem);
+  margin: 0;
+}
+
+.genealogy-view-page__hero p {
+  color: #475569;
+  margin: 0.55rem 0 0;
+}
+
+.genealogy-view-page__animal {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  margin-top: 0.85rem;
+}
+
+.genealogy-view-page__actions {
+  align-content: start;
+  display: grid;
+  gap: 0.6rem;
+  grid-template-columns: 1fr;
+  min-width: 220px;
+}
+
+.genealogy-view-page__status {
+  align-items: center;
+  background: #ffffff;
+  border: 1px solid rgba(226, 232, 240, 0.9);
+  border-radius: 1rem;
+  color: #334155;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+  margin-bottom: 1rem;
+  padding: 0.9rem 1rem;
+}
+
+.genealogy-view-page__mode {
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  padding: 0.3rem 0.7rem;
+}
+
+.genealogy-view-page__mode--local {
+  background: #e7f3ec;
+  color: #0f6b3d;
+}
+
+.genealogy-view-page__mode--abcc {
+  background: #eef5ff;
+  color: #1d4f9b;
+}
+
+.genealogy-view-page__loading,
+.genealogy-view-page__error {
+  background: #ffffff;
+  border: 1px solid rgba(226, 232, 240, 0.9);
+  border-radius: 1rem;
+  margin-bottom: 1rem;
+  padding: 0.95rem 1rem;
+}
+
+.genealogy-view-page__error {
+  background: #fff5f5;
+  border-color: #fecaca;
+  color: #991b1b;
+}
+
+.genealogy-view-page__canvas {
+  background: #ffffff;
+  border: 1px solid rgba(226, 232, 240, 0.9);
+  border-radius: 1.1rem;
+  padding: 1rem;
+}
+
+.genealogy-view-page .genealogy-tree-shell {
+  gap: 12px;
+}
+
+.genealogy-export-document {
+  background: #ffffff;
+  border: 1px solid rgba(226, 232, 240, 0.9);
+  border-radius: 0.8rem;
+  left: -12000px;
+  padding: 0.7rem;
+  position: fixed;
+  top: 0;
+  width: 1120px;
+}
+
+.genealogy-export-document__header h2 {
+  color: #0f172a;
+  font-size: 1.05rem;
+  margin: 0;
+}
+
+.genealogy-export-document__header p {
+  color: #475569;
+  margin: 0.1rem 0;
+}
+
+.genealogy-export-document__note {
+  color: #334155;
+  font-size: 0.8rem;
+  margin-bottom: 0.35rem !important;
+}
+
+.genealogy-export-tree {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.genealogy-export-row {
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: repeat(8, minmax(0, 1fr));
+}
+
+.genealogy-export-row--principal .genealogy-export-card {
+  grid-column: 3 / span 4;
+}
+
+.genealogy-export-row--parents .genealogy-export-card {
+  grid-column: span 4;
+}
+
+.genealogy-export-row--grandparents .genealogy-export-card {
+  grid-column: span 2;
+}
+
+.genealogy-export-row--greatgrandparents .genealogy-export-card {
+  grid-column: span 1;
+}
+
+.genealogy-export-card {
+  border: 1.3px solid #9eb9e9;
+  border-radius: 0.55rem;
+  min-height: 78px;
+  overflow: hidden;
+  padding: 0.35rem 0.45rem 0.4rem;
+}
+
+.genealogy-export-card header {
+  align-items: center;
+  display: flex;
+  font-size: 0.68rem;
+  justify-content: space-between;
+  margin-bottom: 0.22rem;
+}
+
+.genealogy-export-card header strong {
+  color: #0f172a;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.genealogy-export-card header span {
+  border-radius: 999px;
+  font-size: 0.58rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  padding: 0.09rem 0.36rem;
+}
+
+.genealogy-export-card > div {
+  color: #0f172a;
+  font-size: 0.78rem;
+  font-weight: 600;
+  line-height: 1.25;
+  word-break: break-word;
+}
+
+.genealogy-export-card small {
+  color: #64748b;
+  font-size: 0.69rem;
+  word-break: break-all;
+}
+
+.genealogy-export-card--principal {
+  min-height: 152px;
+}
+
+.genealogy-export-card__meta {
+  display: grid;
+  gap: 4px;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin-top: 6px;
+}
+
+.genealogy-export-card__meta-item {
+  background: rgba(255, 255, 255, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  border-radius: 6px;
+  padding: 3px 5px;
+}
+
+.genealogy-export-card__meta-item span {
+  color: #475569;
+  display: block;
+  font-size: 0.6rem;
+  line-height: 1.1;
+  text-transform: uppercase;
+}
+
+.genealogy-export-card__meta-item strong {
+  color: #0f172a;
+  display: block;
+  font-size: 0.72rem;
+  line-height: 1.2;
+  margin-top: 1px;
+  word-break: break-word;
+}
+
+.genealogy-export-card__line {
+  color: #334155;
+  font-size: 0.66rem;
+  line-height: 1.2;
+  margin-top: 4px;
+  word-break: break-word;
+}
+
+.genealogy-export-card--local {
+  background: #eff9f3;
+  border-color: #2f9462;
+}
+
+.genealogy-export-card--local header span {
+  background: #dff3e7;
+  color: #0f6b3d;
+}
+
+.genealogy-export-card--abcc {
+  background: #f2f7ff;
+  border-color: #5f8fd6;
+}
+
+.genealogy-export-card--abcc header span {
+  background: #e2ecff;
+  color: #1d4f9b;
+}
+
+.genealogy-export-card--ausente {
+  background: #f7f8fa;
+  border-color: #a0a9b8;
+}
+
+.genealogy-export-card--ausente header span {
+  background: #eceff4;
+  color: #4f5b6f;
+}
+
+@media (max-width: 960px) {
+  .genealogy-view-page {
+    padding: 0 1rem 1.5rem;
+  }
+
+  .genealogy-view-page__hero {
+    grid-template-columns: 1fr;
+  }
+
+  .genealogy-view-page__actions {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    min-width: 0;
+  }
+
+  .genealogy-export-document {
+    width: 980px;
+  }
+}
+
+@media print {
+  @page {
+    size: A4 landscape;
+    margin: 6mm;
+  }
+
+  .genealogy-view-page {
+    padding: 0;
+  }
+
+  .genealogy-view-page__hero,
+  .genealogy-view-page__status,
+  .genealogy-view-page__error,
+  .genealogy-view-page__loading,
+  .genealogy-view-page__canvas--interactive,
+  .genealogy-view-print-actions,
+  .react-flow__controls,
+  .react-flow__attribution {
+    display: none !important;
+  }
+
+  .genealogy-export-document {
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
+    left: 0;
+    margin: 0;
+    padding: 0;
+    position: static;
+    width: 100%;
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -39,6 +39,7 @@ import Logout from "./routes/PrivateRoute";
 import LactationPage from "./Pages/lactation/LactationPage";
 import MilkProductionPage from "./Pages/lactation/MilkProductionPage";
 import ReproductionPage from "./Pages/reproduction/ReproductionPage";
+import GoatGenealogyViewPage from "./Pages/genealogy/GoatGenealogyViewPage";
 import LactationActivePage from "./Pages/lactation/LactationActivePage";
 import LactationDetailPage from "./Pages/lactation/LactationDetailPage";
 import LactationSummaryPage from "./Pages/lactation/LactationSummaryPage";
@@ -151,6 +152,14 @@ const router = createBrowserRouter([
         element: (
           <PrivateRoute roles={[RoleEnum.ROLE_FARM_OWNER, RoleEnum.ROLE_OPERATOR, RoleEnum.ROLE_ADMIN]}>
             <ReproductionPage />
+          </PrivateRoute>
+        ),
+      },
+      {
+        path: "app/goatfarms/:farmId/goats/:goatId/genealogy",
+        element: (
+          <PrivateRoute roles={[RoleEnum.ROLE_FARM_OWNER, RoleEnum.ROLE_OPERATOR, RoleEnum.ROLE_ADMIN]}>
+            <GoatGenealogyViewPage />
           </PrivateRoute>
         ),
       },

--- a/src/utils/appRoutes.ts
+++ b/src/utils/appRoutes.ts
@@ -46,6 +46,12 @@ export const buildGoatReproductionPath = (
 ): string =>
   `${buildGoatDetailPath(farmId, goatId)}/reproduction`;
 
+export const buildGoatGenealogyPath = (
+  farmId: string | number,
+  goatId: string | number
+): string =>
+  `${buildGoatDetailPath(farmId, goatId)}/genealogy`;
+
 export const buildGoatEventsPath = (
   registrationNumber: string,
   farmId?: string | number | null


### PR DESCRIPTION
## Summary
- add dedicated goat genealogy page with local and ABCC complementary modes
- route genealogy access from goat action panel and remove inline tree from dashboard
- improve genealogy tree layout and dedicated print/PDF document flow
- update frontend documentation for complementary ABCC genealogy

## Validation
- npm test -- --run
- npm run build
- npm run lint
- npm run test:e2e