### PR TITLE
feat(alerts): consolidated farm alerts v1 frontend-first

### DIFF
--- a/docs/ALERTS_CONTRACT.md
+++ b/docs/ALERTS_CONTRACT.md
@@ -70,3 +70,33 @@ O `FarmAlertsContext` escuta o evento e refaz o fetch dos providers.
 
 - O Alert Center usa apenas chamadas farm-level para montar resumo e lista paginada.
 - Nao existe loop por cabra para montar alertas de secagem.
+
+## V1 - Alertas consolidados da fazenda (frontend-first)
+
+### Fontes consolidadas
+- `reproduction_pregnancy_diagnosis`
+- `lactation_drying`
+- `health_agenda`
+
+### Semantica canonica no frontend
+Cada item consolidado de alerta passa a usar:
+- `source`: `reproduction | lactation | health`
+- `severity`: `high | medium | low`
+- `priority`: inteiro para ordenacao cross-source
+- `title`
+- `description`
+- `date`
+- `actionLabel`
+- `link`
+
+### Regras de priorizacao e severidade
+- Reproducao e lactacao usam atraso (`daysOverdue`) para severidade/prioridade.
+- Sanidade usa bucket de origem:
+  - `overdue` -> `high`
+  - `due_today` -> `medium`
+  - `upcoming` -> `low`
+
+### Diferenca entre alertas e agenda
+- **Alertas**: pendencias priorizadas por severidade e acao.
+- **Agenda**: visao temporal operacional.
+- A V1 preserva as duas visoes separadas para evitar sobreposicao de responsabilidade.

--- a/e2e/alerts-dryoff.spec.ts
+++ b/e2e/alerts-dryoff.spec.ts
@@ -95,10 +95,10 @@ test("renders dry-off alerts page and drawer using farm-level endpoints", async 
 
   await page.goto("/app/goatfarms/1/alerts?type=lactation_drying");
 
-  await expect(page.getByRole("heading", { name: "Alertas e Pendencias" })).toBeVisible();
-  await expect(page.getByRole("columnheader", { name: "Cabra" })).toBeVisible();
-  await expect(page.getByText("GOAT-001")).toBeVisible();
-  await expect(page.getByText("+5 dia(s)")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Alertas consolidados da fazenda" })).toBeVisible();
+  await expect(page.getByText("Secagem pendente: GOAT-001")).toBeVisible();
+  await expect(page.getByText("Secagem pendente: GOAT-002")).toBeVisible();
+  await expect(page.getByRole("button", { name: /Lactação/ })).toBeVisible();
   const dryOffLinks = page.getByRole("link", { name: "Ver lactacao" });
   await expect(dryOffLinks).toHaveCount(2);
   await expect(dryOffLinks.first()).toBeVisible();

--- a/src/Pages/alerts/FarmAlertsPage.css
+++ b/src/Pages/alerts/FarmAlertsPage.css
@@ -1,14 +1,213 @@
-.dryoff-alerts-table th {
-  white-space: nowrap;
+﻿.farm-alerts-page {
+  display: grid;
+  gap: 1rem;
 }
 
-.dryoff-alerts-table td {
-  vertical-align: middle;
+.farm-alerts-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
 }
 
-.alerts-pagination {
+.farm-alerts-summary__kpi {
+  padding: 1rem;
+  border: 1px solid #dbe4ee;
+  border-radius: 0.9rem;
+  background: #ffffff;
+}
+
+.farm-alerts-summary__kpi span {
+  color: #64748b;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: 700;
+}
+
+.farm-alerts-summary__kpi strong {
+  display: block;
+  margin-top: 0.45rem;
+  font-size: 1.7rem;
+  color: #0f172a;
+}
+
+.farm-alerts-summary__kpi p {
+  margin: 0.35rem 0 0;
+  color: #475569;
+}
+
+.farm-alerts-filters {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.farm-alerts-filter-group {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.farm-alerts-filter-group--sort {
+  max-width: 360px;
+}
+
+.farm-alerts-filter-label {
+  color: #475569;
+  font-size: 0.85rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.farm-alerts-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.farm-alerts-chip {
+  border: 1px solid #cbd5e1;
+  background: #f8fafc;
+  border-radius: 999px;
+  padding: 0.4rem 0.75rem;
+  font-size: 0.85rem;
+  color: #334155;
+}
+
+.farm-alerts-chip.is-active {
+  background: #0f766e;
+  border-color: #0f766e;
+  color: #ffffff;
+}
+
+.farm-alerts-source-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+}
+
+.farm-alerts-source-card {
+  padding: 0.95rem;
+  border-radius: 0.9rem;
+  border: 1px solid #dbe4ee;
+  background: #ffffff;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.farm-alerts-source-card h2 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.farm-alerts-source-card strong {
+  font-size: 1.5rem;
+  color: #0f172a;
+}
+
+.farm-alerts-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.farm-alerts-list__group {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.farm-alerts-list__group-header {
   display: flex;
   align-items: center;
-  justify-content: center;
-  gap: 0.75rem;
+  justify-content: space-between;
+}
+
+.farm-alerts-list__group-header h3 {
+  margin: 0;
+  font-size: 1rem;
+  color: #0f172a;
+}
+
+.farm-alerts-list__group-header span {
+  color: #64748b;
+  font-size: 0.85rem;
+}
+
+.farm-alert-item {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  border-left-width: 4px;
+}
+
+.farm-alert-item--high {
+  border-left-color: #dc2626;
+}
+
+.farm-alert-item--medium {
+  border-left-color: #f59e0b;
+}
+
+.farm-alert-item--low {
+  border-left-color: #2563eb;
+}
+
+.farm-alert-item__main {
+  flex: 1;
+  min-width: 0;
+}
+
+.farm-alert-item__title-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.farm-alert-item__title-row h4 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.farm-alert-item__source {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #0f766e;
+  background: #ecfeff;
+  border: 1px solid #99f6e4;
+  border-radius: 999px;
+  padding: 0.2rem 0.55rem;
+}
+
+.farm-alert-item__main p {
+  margin: 0.45rem 0;
+  color: #334155;
+}
+
+.farm-alert-item__meta {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  color: #64748b;
+  font-size: 0.85rem;
+}
+
+.farm-alert-item__actions {
+  display: flex;
+  align-items: center;
+}
+
+@media (max-width: 720px) {
+  .farm-alert-item {
+    flex-direction: column;
+  }
+
+  .farm-alert-item__actions {
+    width: 100%;
+  }
+
+  .farm-alert-item__actions .btn {
+    width: 100%;
+  }
 }

--- a/src/Pages/alerts/FarmAlertsPage.test.tsx
+++ b/src/Pages/alerts/FarmAlertsPage.test.tsx
@@ -1,0 +1,55 @@
+﻿import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { FarmAlertsContent } from "./FarmAlertsPage";
+
+const setSearchParamsSpy = vi.fn();
+const navigateSpy = vi.fn();
+
+vi.mock("react-router-dom", () => ({
+  Link: ({ to, children, className }: { to: string; children: unknown; className?: string }) => (
+    <a href={to} className={className}>{children}</a>
+  ),
+  useParams: () => ({ farmId: "7" }),
+  useNavigate: () => navigateSpy,
+  useSearchParams: () => [new URLSearchParams(), setSearchParamsSpy]
+}));
+
+vi.mock("../../contexts/alerts/FarmAlertsContext", () => ({
+  useFarmAlerts: () => ({
+    providerStates: [
+      { providerKey: "reproduction_pregnancy_diagnosis", summary: { count: 2 }, loading: false, error: false },
+      { providerKey: "lactation_drying", summary: { count: 1 }, loading: false, error: false },
+      { providerKey: "health_agenda", summary: { count: 3 }, loading: false, error: false }
+    ],
+    getProvider: (key: string) => ({
+      key,
+      label: key,
+      priority: 1,
+      getSummary: async () => ({ count: 0 }),
+      getList: async () => [],
+      getRoute: (farmId: number) => `/app/goatfarms/${farmId}/alerts?type=${key}`
+    }),
+    refreshAlerts: async () => undefined
+  })
+}));
+
+vi.mock("../../Components/pages-headers/GoatFarmHeader", () => ({
+  default: ({ name }: { name: string }) => <div>{name}</div>
+}));
+
+vi.mock("../../Components/pages-headers/PageHeader", () => ({
+  default: ({ title }: { title: string }) => <header>{title}</header>
+}));
+
+describe("FarmAlertsContent", () => {
+  it("renders consolidated summary and filters", () => {
+    const html = renderToStaticMarkup(<FarmAlertsContent />);
+
+    expect(html).toContain("Alertas consolidados da fazenda");
+    expect(html).toContain("Origem");
+    expect(html).toContain("Reprodução");
+    expect(html).toContain("Lactação");
+    expect(html).toContain("Sanidade");
+    expect(html).toContain("Nenhum alerta encontrado com os filtros selecionados.");
+  });
+});

--- a/src/Pages/alerts/FarmAlertsPage.tsx
+++ b/src/Pages/alerts/FarmAlertsPage.tsx
@@ -1,101 +1,168 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+﻿import { useCallback, useEffect, useMemo, useState } from "react";
 import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom";
-import type { AlertItem } from "../../services/alerts/AlertRegistry";
+import type { AlertItem, AlertSeverity, AlertSource } from "../../services/alerts/AlertRegistry";
 import { FarmAlertsProvider, useFarmAlerts } from "../../contexts/alerts/FarmAlertsContext";
+import {
+  filterAndSortAlerts,
+  summarizeBySeverity,
+  type SeverityFilter,
+  type SortMode,
+  type SourceFilter
+} from "../../services/alerts/farmAlertsSemantics";
 import GoatFarmHeader from "../../Components/pages-headers/GoatFarmHeader";
 import PageHeader from "../../Components/pages-headers/PageHeader";
 import { buildFarmDashboardPath } from "../../utils/appRoutes";
 import "../../index.css";
 import "./FarmAlertsPage.css";
 
-const PAGE_SIZE = 20;
+const SOURCE_LABELS: Record<AlertSource, string> = {
+  reproduction: "Reprodução",
+  lactation: "Lactação",
+  health: "Sanidade"
+};
+
+const SEVERITY_LABELS: Record<AlertSeverity, string> = {
+  high: "Alta",
+  medium: "Média",
+  low: "Baixa"
+};
+
+const PROVIDER_BY_SOURCE: Record<AlertSource, string> = {
+  reproduction: "reproduction_pregnancy_diagnosis",
+  lactation: "lactation_drying",
+  health: "health_agenda"
+};
 
 function formatDate(value?: string): string {
   if (!value) return "-";
   return new Date(`${value}T00:00:00`).toLocaleDateString("pt-BR");
 }
 
-function FarmAlertsContent() {
+function getSeverityIcon(severity: AlertSeverity): string {
+  if (severity === "high") return "fa-solid fa-triangle-exclamation text-danger";
+  if (severity === "medium") return "fa-solid fa-circle-exclamation text-warning";
+  return "fa-solid fa-circle-info text-primary";
+}
+
+function normalizeSourceFromQuery(typeParam: string | null): SourceFilter {
+  if (!typeParam) return "all";
+  if (typeParam === "reproduction_pregnancy_diagnosis") return "reproduction";
+  if (typeParam === "lactation_drying") return "lactation";
+  if (typeParam === "health_agenda") return "health";
+  if (typeParam === "reproduction" || typeParam === "lactation" || typeParam === "health") {
+    return typeParam;
+  }
+  return "all";
+}
+
+export function FarmAlertsContent() {
   const { farmId } = useParams<{ farmId: string }>();
   const farmIdNumber = Number(farmId);
-  const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
-  const { providerStates, getProvider } = useFarmAlerts();
+  const [searchParams, setSearchParams] = useSearchParams();
 
-  const currentType = searchParams.get("type") ?? searchParams.get("tab");
+  const { providerStates, getProvider, refreshAlerts } = useFarmAlerts();
 
-  const [items, setItems] = useState<AlertItem[]>([]);
-  const [page, setPage] = useState(0);
+  const [allItems, setAllItems] = useState<AlertItem[]>([]);
   const [loadingItems, setLoadingItems] = useState(false);
   const [listError, setListError] = useState<string | null>(null);
+  const [sourceFilter, setSourceFilter] = useState<SourceFilter>(
+    normalizeSourceFromQuery(searchParams.get("type"))
+  );
+  const [severityFilter, setSeverityFilter] = useState<SeverityFilter>("all");
+  const [sortMode, setSortMode] = useState<SortMode>("priority");
 
   useEffect(() => {
-    if (!currentType && providerStates.length > 0) {
-      setSearchParams({ type: providerStates[0].providerKey }, { replace: true });
-    }
-  }, [providerStates, currentType, setSearchParams]);
+    const nextSource = normalizeSourceFromQuery(searchParams.get("type"));
+    setSourceFilter(nextSource);
+  }, [searchParams]);
 
-  useEffect(() => {
-    setPage(0);
-  }, [currentType]);
-
-  const selectedProvider = currentType ? getProvider(currentType) : undefined;
-  const selectedProviderState = providerStates.find((state) => state.providerKey === selectedProvider?.key);
-  const selectedCount = selectedProviderState?.summary.count ?? 0;
-  const totalPages = Math.max(1, Math.ceil(selectedCount / PAGE_SIZE));
-
-  useEffect(() => {
-    if (page >= totalPages) {
-      setPage(Math.max(totalPages - 1, 0));
-    }
-  }, [page, totalPages]);
-
-  const loadItems = useCallback(async () => {
-    if (!farmId || Number.isNaN(farmIdNumber) || !selectedProvider?.getList) {
-      setItems([]);
+  const loadAllItems = useCallback(async () => {
+    if (!farmId || Number.isNaN(farmIdNumber)) {
+      setAllItems([]);
       setListError(null);
       return;
     }
+
+    const providers = providerStates
+      .map((state) => getProvider(state.providerKey))
+      .filter((provider): provider is NonNullable<ReturnType<typeof getProvider>> => Boolean(provider));
 
     setLoadingItems(true);
     setListError(null);
 
     try {
-      const data = await selectedProvider.getList(farmIdNumber, {
-        page,
-        size: PAGE_SIZE
-      });
-      setItems(data);
+      const listResults = await Promise.allSettled(
+        providers.map(async (provider) => {
+          if (!provider.getList) return [] as AlertItem[];
+          return provider.getList(farmIdNumber, { page: 0, size: 20 });
+        })
+      );
+
+      const merged = listResults.flatMap((result) =>
+        result.status === "fulfilled" ? result.value : []
+      );
+
+      setAllItems(merged);
     } catch (error) {
-      console.error("Error loading alert items", error);
-      setListError("Nao foi possivel carregar os alertas desta categoria.");
-      setItems([]);
+      console.error("Error loading consolidated alerts", error);
+      setAllItems([]);
+      setListError("Nao foi possivel carregar os alertas consolidados agora.");
     } finally {
       setLoadingItems(false);
     }
-  }, [farmId, farmIdNumber, selectedProvider, page]);
+  }, [farmId, farmIdNumber, getProvider, providerStates]);
 
   useEffect(() => {
-    void loadItems();
-  }, [loadItems]);
+    void loadAllItems();
+  }, [loadAllItems]);
 
-  const isDryOffTab = selectedProvider?.key === "lactation_drying";
+  const filteredItems = useMemo(() => {
+    return filterAndSortAlerts(allItems, sourceFilter, severityFilter, sortMode);
+  }, [allItems, severityFilter, sortMode, sourceFilter]);
 
-  const tabModels = useMemo(
-    () =>
-      providerStates
-        .map((state) => ({ state, provider: getProvider(state.providerKey) }))
-        .filter(
-          (entry): entry is {
-            state: (typeof providerStates)[number];
-            provider: NonNullable<ReturnType<typeof getProvider>>;
-          } => Boolean(entry.provider)
-        ),
-    [providerStates, getProvider]
-  );
+  const itemsBySeverity = useMemo(() => {
+    return {
+      high: filteredItems.filter((item) => item.severity === "high"),
+      medium: filteredItems.filter((item) => item.severity === "medium"),
+      low: filteredItems.filter((item) => item.severity === "low")
+    };
+  }, [filteredItems]);
+
+  const summaryBySource = useMemo(() => {
+    return {
+      reproduction: providerStates.find((state) => state.providerKey === PROVIDER_BY_SOURCE.reproduction)?.summary.count ?? 0,
+      lactation: providerStates.find((state) => state.providerKey === PROVIDER_BY_SOURCE.lactation)?.summary.count ?? 0,
+      health: providerStates.find((state) => state.providerKey === PROVIDER_BY_SOURCE.health)?.summary.count ?? 0
+    };
+  }, [providerStates]);
+
+  const summaryBySeverity = useMemo(() => {
+    return summarizeBySeverity(allItems);
+  }, [allItems]);
+
+  const totalCount = summaryBySource.reproduction + summaryBySource.lactation + summaryBySource.health;
+
+  const handleSourceFilter = (nextSource: SourceFilter) => {
+    setSourceFilter(nextSource);
+
+    const nextParams = new URLSearchParams(searchParams.toString());
+    if (nextSource === "all") {
+      nextParams.delete("type");
+    } else {
+      nextParams.set("type", nextSource);
+    }
+    setSearchParams(nextParams, { replace: true });
+  };
+
+  const openSourceDetails = (source: AlertSource) => {
+    const provider = getProvider(PROVIDER_BY_SOURCE[source]);
+    if (!provider) return;
+    navigate(provider.getRoute(farmIdNumber));
+  };
 
   return (
-    <div className="page-container">
+    <div className="page-container farm-alerts-page">
       <GoatFarmHeader
         name="Central de Alertas"
         farmId={farmIdNumber}
@@ -103,173 +170,197 @@ function FarmAlertsContent() {
       />
 
       <PageHeader
-        title="Alertas e Pendencias"
-        description="Gerencie as pendencias da fazenda"
+        title="Alertas consolidados da fazenda"
+        description="Pendencias priorizadas por reprodução, lactação e sanidade, sem misturar com a agenda temporal."
         showBackButton={true}
         backButtonUrl={buildFarmDashboardPath(farmIdNumber)}
       />
 
-      <div className="card-container">
-        <div className="nav nav-tabs mb-3">
-          {tabModels.map(({ state, provider }) => {
-            const isActive = currentType === provider.key;
+      <section className="card-container farm-alerts-summary" aria-label="Resumo de alertas">
+        <article className="farm-alerts-summary__kpi">
+          <span>Total em atenção</span>
+          <strong>{totalCount}</strong>
+          <p>Visão consolidada da fazenda.</p>
+        </article>
+        <article className="farm-alerts-summary__kpi">
+          <span>Alta severidade</span>
+          <strong>{summaryBySeverity.high}</strong>
+          <p>Prioridade imediata.</p>
+        </article>
+        <article className="farm-alerts-summary__kpi">
+          <span>Média severidade</span>
+          <strong>{summaryBySeverity.medium}</strong>
+          <p>Ação no curto prazo.</p>
+        </article>
+        <article className="farm-alerts-summary__kpi">
+          <span>Baixa severidade</span>
+          <strong>{summaryBySeverity.low}</strong>
+          <p>Acompanhar próximos marcos.</p>
+        </article>
+      </section>
 
-            return (
-              <button
-                key={provider.key}
-                className={`nav-link ${isActive ? "active" : ""}`}
-                onClick={() => setSearchParams({ type: provider.key })}
-              >
-                {provider.label}
-                {state.summary.count > 0 && (
-                  <span className="badge ms-2 bg-danger">{state.summary.count}</span>
-                )}
-              </button>
-            );
-          })}
-        </div>
-
-        <div className="tab-content">
-          {!selectedProvider ? (
-            <div className="alert alert-info">Selecione uma categoria de alertas.</div>
-          ) : !selectedProvider.getList ? (
-            <div className="alert alert-info d-flex justify-content-between align-items-center gap-3 flex-wrap">
-              <span>Essa categoria possui detalhes em uma pagina dedicada.</span>
-              <button
-                className="btn btn-sm btn-outline-primary"
-                onClick={() => navigate(selectedProvider.getRoute(farmIdNumber))}
-              >
-                Abrir pagina
-              </button>
-            </div>
-          ) : loadingItems ? (
-            <div className="text-center p-5">
-              <div className="spinner-border text-primary" role="status">
-                <span className="visually-hidden">Carregando...</span>
-              </div>
-            </div>
-          ) : listError ? (
-            <div className="alert alert-danger d-flex justify-content-between align-items-center gap-3 flex-wrap">
-              <span>{listError}</span>
-              <button className="btn btn-sm btn-outline-danger" onClick={() => void loadItems()}>
-                Tentar novamente
-              </button>
-            </div>
-          ) : items.length === 0 ? (
-            <div className="alert alert-success">
-              <i className="fa-solid fa-check-circle me-2"></i>
-              {isDryOffTab
-                ? "Nenhuma secagem pendente!"
-                : `Nenhuma pendencia encontrada para ${selectedProvider.label}.`}
-            </div>
-          ) : isDryOffTab ? (
-            <div className="table-responsive">
-              <table className="table table-sm table-hover align-middle dryoff-alerts-table">
-                <thead>
-                  <tr>
-                    <th>Cabra</th>
-                    <th>Data sugerida de secagem</th>
-                    <th>Dias de gestacao</th>
-                    <th>Atraso</th>
-                    <th>Base (prenhez)</th>
-                    <th className="text-end">Acao</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {items.map((item) => {
-                    const overdue = item.daysOverdue ?? 0;
-                    return (
-                      <tr key={item.id}>
-                        <td>
-                          {item.link ? (
-                            <Link to={item.link} className="fw-semibold text-decoration-none">
-                              {item.goatId}
-                            </Link>
-                          ) : (
-                            item.goatId
-                          )}
-                        </td>
-                        <td>{formatDate(item.dryOffDate ?? item.date)}</td>
-                        <td>{item.gestationDays ?? "-"}</td>
-                        <td>
-                          {overdue > 0 ? (
-                            <span className="badge bg-danger">+{overdue} dia(s)</span>
-                          ) : (
-                            <span className="badge bg-success">No prazo</span>
-                          )}
-                        </td>
-                        <td>{formatDate(item.startDatePregnancy)}</td>
-                        <td className="text-end">
-                          {item.link && (
-                            <Link to={item.link} className="btn btn-sm btn-outline-primary">
-                              Ver lactacao
-                            </Link>
-                          )}
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
-            </div>
-          ) : (
-            <div className="list-group">
-              {items.map((item) => (
-                <div
-                  key={item.id}
-                  className={`list-group-item list-group-item-action flex-column align-items-start ${
-                    item.severity === "high" ? "border-danger" : ""
-                  }`}
-                >
-                  <div className="d-flex w-100 justify-content-between">
-                    <h5 className="mb-1">
-                      {item.severity === "high" && (
-                        <i className="fa-solid fa-triangle-exclamation text-danger me-2"></i>
-                      )}
-                      {item.title}
-                    </h5>
-                    <small>{formatDate(item.date)}</small>
-                  </div>
-                  <p className="mb-1">{item.description}</p>
-                  <div className="mt-2">
-                    {item.link ? (
-                      <Link to={item.link} className="btn btn-sm btn-outline-primary">
-                        Ver detalhes
-                      </Link>
-                    ) : item.onAction ? (
-                      <button onClick={item.onAction} className="btn btn-sm btn-outline-primary">
-                        {item.actionLabel || "Resolver"}
-                      </button>
-                    ) : null}
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
-
-        {selectedProvider?.getList && selectedCount > PAGE_SIZE && (
-          <div className="alerts-pagination mt-3">
+      <section className="card-container farm-alerts-filters" aria-label="Filtros de alertas">
+        <div className="farm-alerts-filter-group">
+          <span className="farm-alerts-filter-label">Origem</span>
+          <div className="farm-alerts-chip-row">
             <button
-              className="btn btn-outline-secondary btn-sm"
-              disabled={page === 0}
-              onClick={() => setPage((previous) => Math.max(previous - 1, 0))}
+              type="button"
+              className={`farm-alerts-chip ${sourceFilter === "all" ? "is-active" : ""}`}
+              onClick={() => handleSourceFilter("all")}
             >
-              Anterior
+              Todas ({totalCount})
             </button>
-            <span>
-              Pagina {page + 1} de {totalPages}
-            </span>
             <button
-              className="btn btn-outline-secondary btn-sm"
-              disabled={page + 1 >= totalPages}
-              onClick={() => setPage((previous) => Math.min(previous + 1, totalPages - 1))}
+              type="button"
+              className={`farm-alerts-chip ${sourceFilter === "reproduction" ? "is-active" : ""}`}
+              onClick={() => handleSourceFilter("reproduction")}
             >
-              Proxima
+              Reprodução ({summaryBySource.reproduction})
+            </button>
+            <button
+              type="button"
+              className={`farm-alerts-chip ${sourceFilter === "lactation" ? "is-active" : ""}`}
+              onClick={() => handleSourceFilter("lactation")}
+            >
+              Lactação ({summaryBySource.lactation})
+            </button>
+            <button
+              type="button"
+              className={`farm-alerts-chip ${sourceFilter === "health" ? "is-active" : ""}`}
+              onClick={() => handleSourceFilter("health")}
+            >
+              Sanidade ({summaryBySource.health})
             </button>
           </div>
+        </div>
+
+        <div className="farm-alerts-filter-group">
+          <span className="farm-alerts-filter-label">Severidade</span>
+          <div className="farm-alerts-chip-row">
+            <button
+              type="button"
+              className={`farm-alerts-chip ${severityFilter === "all" ? "is-active" : ""}`}
+              onClick={() => setSeverityFilter("all")}
+            >
+              Todas
+            </button>
+            {(["high", "medium", "low"] as AlertSeverity[]).map((severity) => (
+              <button
+                key={severity}
+                type="button"
+                className={`farm-alerts-chip ${severityFilter === severity ? "is-active" : ""}`}
+                onClick={() => setSeverityFilter(severity)}
+              >
+                {SEVERITY_LABELS[severity]}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="farm-alerts-filter-group farm-alerts-filter-group--sort">
+          <label htmlFor="alerts-sort" className="farm-alerts-filter-label">Ordenação</label>
+          <select
+            id="alerts-sort"
+            className="form-select"
+            value={sortMode}
+            onChange={(event) => setSortMode(event.target.value as SortMode)}
+          >
+            <option value="priority">Prioridade (maior para menor)</option>
+            <option value="date">Data de referência (mais próxima primeiro)</option>
+          </select>
+        </div>
+      </section>
+
+      <section className="card-container farm-alerts-source-grid" aria-label="Resumo por origem">
+        {(["reproduction", "lactation", "health"] as AlertSource[]).map((source) => (
+          <article key={source} className="farm-alerts-source-card">
+            <h2>{SOURCE_LABELS[source]}</h2>
+            <strong>{summaryBySource[source]}</strong>
+            <button
+              type="button"
+              className="btn btn-sm btn-outline-primary"
+              onClick={() => openSourceDetails(source)}
+            >
+              Abrir detalhe
+            </button>
+          </article>
+        ))}
+      </section>
+
+      <section className="card-container farm-alerts-list" aria-label="Lista consolidada de alertas">
+        {loadingItems ? (
+          <div className="text-center p-5">
+            <div className="spinner-border text-primary" role="status">
+              <span className="visually-hidden">Carregando...</span>
+            </div>
+          </div>
+        ) : listError ? (
+          <div className="alert alert-danger d-flex justify-content-between align-items-center gap-3 flex-wrap">
+            <span>{listError}</span>
+            <button
+              className="btn btn-sm btn-outline-danger"
+              onClick={() => {
+                void refreshAlerts();
+                void loadAllItems();
+              }}
+            >
+              Tentar novamente
+            </button>
+          </div>
+        ) : filteredItems.length === 0 ? (
+          <div className="alert alert-success">
+            <i className="fa-solid fa-check-circle me-2"></i>
+            Nenhum alerta encontrado com os filtros selecionados.
+          </div>
+        ) : (
+          (Object.keys(itemsBySeverity) as AlertSeverity[]).map((severity) => {
+            const severityItems = itemsBySeverity[severity];
+            if (severityItems.length === 0) return null;
+
+            return (
+              <div key={severity} className="farm-alerts-list__group">
+                <div className="farm-alerts-list__group-header">
+                  <h3>{SEVERITY_LABELS[severity]} severidade</h3>
+                  <span>{severityItems.length} item(ns)</span>
+                </div>
+                <div className="list-group">
+                  {severityItems.map((item) => (
+                    <article key={item.id} className={`list-group-item farm-alert-item farm-alert-item--${item.severity}`}>
+                      <div className="farm-alert-item__main">
+                        <div className="farm-alert-item__title-row">
+                          <i className={getSeverityIcon(item.severity)} aria-hidden="true"></i>
+                          <h4>{item.title}</h4>
+                          <span className="farm-alert-item__source">{SOURCE_LABELS[item.source]}</span>
+                        </div>
+                        <p>{item.description}</p>
+                        <div className="farm-alert-item__meta">
+                          <span>Data: {formatDate(item.date)}</span>
+                          <span>Prioridade: {item.priority}</span>
+                        </div>
+                      </div>
+                      <div className="farm-alert-item__actions">
+                        {item.link ? (
+                          <Link to={item.link} className="btn btn-sm btn-outline-primary">
+                            {item.actionLabel || "Ver ação"}
+                          </Link>
+                        ) : (
+                          <button
+                            type="button"
+                            className="btn btn-sm btn-outline-secondary"
+                            disabled
+                          >
+                            Sem ação
+                          </button>
+                        )}
+                      </div>
+                    </article>
+                  ))}
+                </div>
+              </div>
+            );
+          })
         )}
-      </div>
+      </section>
     </div>
   );
 }

--- a/src/Pages/dashboard/FarmDashboardPage.css
+++ b/src/Pages/dashboard/FarmDashboardPage.css
@@ -304,6 +304,51 @@
   line-height: 1.45;
 }
 
+.farm-dashboard-severity-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.65rem;
+  margin-top: 0.85rem;
+}
+
+.farm-dashboard-severity-card {
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.75rem 0.85rem;
+  border-radius: 0.8rem;
+  border: 1px solid transparent;
+}
+
+.farm-dashboard-severity-card span {
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.farm-dashboard-severity-card strong {
+  font-size: 1.1rem;
+  color: #0f172a;
+}
+
+.farm-dashboard-severity-card--high {
+  background: #fef2f2;
+  border-color: #fecaca;
+  color: #991b1b;
+}
+
+.farm-dashboard-severity-card--medium {
+  background: #fff7ed;
+  border-color: #fed7aa;
+  color: #9a3412;
+}
+
+.farm-dashboard-severity-card--low {
+  background: #eff6ff;
+  border-color: #bfdbfe;
+  color: #1d4ed8;
+}
+
 .farm-dashboard-agenda-list,
 .farm-dashboard-attention__list {
   display: grid;
@@ -466,7 +511,8 @@
 @media (max-width: 1080px) {
   .farm-dashboard-section-grid,
   .farm-dashboard-actions,
-  .farm-dashboard-alert-grid {
+  .farm-dashboard-alert-grid,
+  .farm-dashboard-severity-grid {
     grid-template-columns: 1fr;
   }
 }

--- a/src/Pages/dashboard/FarmDashboardPage.test.tsx
+++ b/src/Pages/dashboard/FarmDashboardPage.test.tsx
@@ -194,6 +194,9 @@ describe("FarmDashboardPageView", () => {
     expect(html).toContain("Agenda sanitária da fazenda");
     expect(html).toContain("Estoque em resumo");
     expect(html).toContain("O que precisa da sua atenção hoje");
+    expect(html).toContain("Alta");
+    expect(html).toContain("Média");
+    expect(html).toContain("Baixa");
     expect(html).toContain('href="/app/goatfarms/7/alerts"');
     expect(html).toContain('href="/app/goatfarms/7/health-agenda"');
     expect(html).toContain('href="/app/goatfarms/7/inventory"');

--- a/src/Pages/dashboard/FarmDashboardPage.tsx
+++ b/src/Pages/dashboard/FarmDashboardPage.tsx
@@ -184,6 +184,15 @@ export function FarmDashboardPageView({
   const healthDueToday = data?.healthAlerts?.dueTodayCount ?? 0;
   const healthOverdue = data?.healthAlerts?.overdueCount ?? 0;
   const healthUpcoming = data?.healthAlerts?.upcomingCount ?? 0;
+  const reproductionHigh =
+    data?.reproductionAlerts?.alerts?.filter((item) => item.daysOverdue > 0).length ?? 0;
+  const reproductionMedium = Math.max(reproductionPending - reproductionHigh, 0);
+  const lactationHigh =
+    data?.lactationAlerts?.alerts?.filter((item) => item.daysOverdue > 0).length ?? 0;
+  const lactationMedium = Math.max(lactationPending - lactationHigh, 0);
+  const highSeverityCount = reproductionHigh + lactationHigh + healthOverdue;
+  const mediumSeverityCount = reproductionMedium + lactationMedium + healthDueToday;
+  const lowSeverityCount = healthUpcoming;
   const totalAttention = reproductionPending + lactationPending + healthDueToday + healthOverdue;
   const agendaEntries = useMemo(() => buildAgendaEntries(data?.healthAlerts ?? null), [data?.healthAlerts]);
   const attentionItems = useMemo(() => buildAttentionItems(data), [data]);
@@ -418,6 +427,21 @@ export function FarmDashboardPageView({
               <p className="farm-dashboard-alert-card__description">
                 {formatCount(healthUpcoming)} próximos nos próximos 7 dias.
               </p>
+            </article>
+          </div>
+
+          <div className="farm-dashboard-severity-grid" aria-label="Resumo por severidade">
+            <article className="farm-dashboard-severity-card farm-dashboard-severity-card--high">
+              <span>Alta</span>
+              <strong>{formatCount(highSeverityCount)}</strong>
+            </article>
+            <article className="farm-dashboard-severity-card farm-dashboard-severity-card--medium">
+              <span>Média</span>
+              <strong>{formatCount(mediumSeverityCount)}</strong>
+            </article>
+            <article className="farm-dashboard-severity-card farm-dashboard-severity-card--low">
+              <span>Baixa</span>
+              <strong>{formatCount(lowSeverityCount)}</strong>
             </article>
           </div>
 

--- a/src/services/alerts/AlertRegistry.ts
+++ b/src/services/alerts/AlertRegistry.ts
@@ -1,20 +1,25 @@
-export interface AlertSummary {
+﻿export interface AlertSummary {
   count: number;
-  headline?: string; // Ex: "Maior atraso: 15 dias"
+  headline?: string;
   worstOverdueDays?: number;
   previewItems?: AlertItem[];
 }
 
+export type AlertSource = "reproduction" | "lactation" | "health";
+export type AlertSeverity = "high" | "medium" | "low";
+
 export interface AlertItem {
   id: string;
+  source: AlertSource;
   title: string;
   description: string;
-  date?: string; // ISO string
-  severity: 'high' | 'medium' | 'low';
-  link?: string; // Internal route
+  date?: string;
+  severity: AlertSeverity;
+  priority: number;
+  link?: string;
   actionLabel?: string;
   onAction?: () => void;
-  goatId?: string; // For linking to animal
+  goatId?: string;
   startDatePregnancy?: string;
   dryOffDate?: string;
   gestationDays?: number;
@@ -29,22 +34,11 @@ export interface AlertListParams {
 
 export interface AlertProvider {
   key: string;
-  label: string; // Ex: "Secagem", "Diagnóstico de Prenhez"
-  priority: number; // Higher number = higher priority in list
-  
-  /**
-   * Fetches summary for the badge/header
-   */
+  label: string;
+  priority: number;
+
   getSummary(farmId: number): Promise<AlertSummary>;
-  
-  /**
-   * Optional: Fetches detailed items for the drawer/list
-   */
   getList?(farmId: number, params?: AlertListParams): Promise<AlertItem[]>;
-  
-  /**
-   * Route to the full details page
-   */
   getRoute(farmId: number): string;
 }
 
@@ -52,14 +46,13 @@ class AlertRegistryImpl {
   private providers: AlertProvider[] = [];
 
   register(provider: AlertProvider) {
-    // Prevent duplicates
-    if (this.providers.some(p => p.key === provider.key)) {
+    if (this.providers.some((current) => current.key === provider.key)) {
       console.warn(`AlertProvider with key ${provider.key} is already registered.`);
       return;
     }
+
     this.providers.push(provider);
-    // Sort by priority desc
-    this.providers.sort((a, b) => b.priority - a.priority);
+    this.providers.sort((left, right) => right.priority - left.priority);
   }
 
   getProviders() {

--- a/src/services/alerts/farmAlertsSemantics.test.ts
+++ b/src/services/alerts/farmAlertsSemantics.test.ts
@@ -1,0 +1,79 @@
+﻿import { describe, expect, it } from "vitest";
+import type { AlertItem } from "./AlertRegistry";
+import { filterAndSortAlerts, summarizeBySeverity } from "./farmAlertsSemantics";
+
+const baseItems: AlertItem[] = [
+  {
+    id: "r-1",
+    source: "reproduction",
+    title: "Repro 1",
+    description: "",
+    date: "2026-03-12",
+    severity: "high",
+    priority: 350
+  },
+  {
+    id: "l-1",
+    source: "lactation",
+    title: "Lact 1",
+    description: "",
+    date: "2026-03-11",
+    severity: "medium",
+    priority: 240
+  },
+  {
+    id: "h-1",
+    source: "health",
+    title: "Health 1",
+    description: "",
+    date: "2026-03-10",
+    severity: "low",
+    priority: 120
+  }
+];
+
+describe("farmAlertsSemantics", () => {
+  it("filters by source", () => {
+    const filtered = filterAndSortAlerts(baseItems, "lactation", "all", "priority");
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].id).toBe("l-1");
+  });
+
+  it("filters by severity", () => {
+    const filtered = filterAndSortAlerts(baseItems, "all", "high", "priority");
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].id).toBe("r-1");
+  });
+
+  it("sorts by priority then date", () => {
+    const mixed = [
+      ...baseItems,
+      {
+        id: "r-2",
+        source: "reproduction",
+        title: "Repro 2",
+        description: "",
+        date: "2026-03-09",
+        severity: "high",
+        priority: 350
+      }
+    ] as AlertItem[];
+
+    const sorted = filterAndSortAlerts(mixed, "all", "all", "priority");
+    expect(sorted[0].id).toBe("r-2");
+    expect(sorted[1].id).toBe("r-1");
+  });
+
+  it("sorts by date then priority", () => {
+    const sorted = filterAndSortAlerts(baseItems, "all", "all", "date");
+    expect(sorted.map((item) => item.id)).toEqual(["h-1", "l-1", "r-1"]);
+  });
+
+  it("builds severity summary", () => {
+    expect(summarizeBySeverity(baseItems)).toEqual({
+      high: 1,
+      medium: 1,
+      low: 1
+    });
+  });
+});

--- a/src/services/alerts/farmAlertsSemantics.ts
+++ b/src/services/alerts/farmAlertsSemantics.ts
@@ -1,0 +1,46 @@
+﻿import type { AlertItem, AlertSeverity, AlertSource } from "./AlertRegistry";
+
+export type SourceFilter = "all" | AlertSource;
+export type SeverityFilter = "all" | AlertSeverity;
+export type SortMode = "priority" | "date";
+
+function toDateValue(value?: string): number {
+  if (!value) return Number.MAX_SAFE_INTEGER;
+  const parsed = new Date(`${value}T00:00:00`).getTime();
+  return Number.isNaN(parsed) ? Number.MAX_SAFE_INTEGER : parsed;
+}
+
+export function filterAndSortAlerts(
+  items: AlertItem[],
+  sourceFilter: SourceFilter,
+  severityFilter: SeverityFilter,
+  sortMode: SortMode
+): AlertItem[] {
+  const filtered = items.filter((item) => {
+    const sourceOk = sourceFilter === "all" || item.source === sourceFilter;
+    const severityOk = severityFilter === "all" || item.severity === severityFilter;
+    return sourceOk && severityOk;
+  });
+
+  filtered.sort((left, right) => {
+    if (sortMode === "date") {
+      const dateDelta = toDateValue(left.date) - toDateValue(right.date);
+      if (dateDelta !== 0) return dateDelta;
+      return right.priority - left.priority;
+    }
+
+    const priorityDelta = right.priority - left.priority;
+    if (priorityDelta !== 0) return priorityDelta;
+    return toDateValue(left.date) - toDateValue(right.date);
+  });
+
+  return filtered;
+}
+
+export function summarizeBySeverity(items: AlertItem[]): Record<AlertSeverity, number> {
+  return {
+    high: items.filter((item) => item.severity === "high").length,
+    medium: items.filter((item) => item.severity === "medium").length,
+    low: items.filter((item) => item.severity === "low").length
+  };
+}

--- a/src/services/alerts/providers/HealthAlertProvider.test.ts
+++ b/src/services/alerts/providers/HealthAlertProvider.test.ts
@@ -1,0 +1,110 @@
+﻿import { beforeEach, describe, expect, it, vi } from "vitest";
+import { healthAPI } from "../../../api/GoatFarmAPI/health";
+import { HealthAlertProvider } from "./HealthAlertProvider";
+
+vi.mock("../../../api/GoatFarmAPI/health", () => ({
+  healthAPI: {
+    getAlerts: vi.fn()
+  }
+}));
+
+const mockedGetAlerts = vi.mocked(healthAPI.getAlerts);
+
+describe("HealthAlertProvider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("maps summary with all categories", async () => {
+    mockedGetAlerts.mockResolvedValueOnce({
+      dueTodayCount: 2,
+      upcomingCount: 3,
+      overdueCount: 1,
+      dueTodayTop: [],
+      upcomingTop: [],
+      overdueTop: []
+    });
+
+    const summary = await HealthAlertProvider.getSummary(4);
+
+    expect(summary).toEqual({
+      count: 6,
+      headline: "1 atrasado(s)",
+      worstOverdueDays: 1
+    });
+  });
+
+  it("maps list with source/severity/priority", async () => {
+    mockedGetAlerts.mockResolvedValueOnce({
+      dueTodayCount: 1,
+      upcomingCount: 1,
+      overdueCount: 1,
+      dueTodayTop: [
+        {
+          id: 2,
+          farmId: 4,
+          goatId: "GOAT-2",
+          type: "VACINA",
+          status: "AGENDADO",
+          title: "Vacina",
+          scheduledDate: "2026-03-15",
+          overdue: false
+        }
+      ],
+      upcomingTop: [
+        {
+          id: 3,
+          farmId: 4,
+          goatId: "GOAT-3",
+          type: "VACINA",
+          status: "AGENDADO",
+          title: "Reforco",
+          scheduledDate: "2026-03-17",
+          overdue: false
+        }
+      ],
+      overdueTop: [
+        {
+          id: 1,
+          farmId: 4,
+          goatId: "GOAT-1",
+          type: "VACINA",
+          status: "AGENDADO",
+          title: "Atrasado",
+          scheduledDate: "2026-03-10",
+          overdue: true
+        }
+      ]
+    });
+
+    const list = await HealthAlertProvider.getList?.(4);
+
+    expect(list).toHaveLength(3);
+    expect(list?.[0]).toMatchObject({
+      id: "health-1-overdue",
+      source: "health",
+      severity: "high",
+      priority: 350
+    });
+    expect(list?.[1]).toMatchObject({
+      id: "health-2-due_today",
+      source: "health",
+      severity: "medium",
+      priority: 240
+    });
+    expect(list?.[2]).toMatchObject({
+      id: "health-3-upcoming",
+      source: "health",
+      severity: "low",
+      priority: 120
+    });
+  });
+
+  it("returns empty list on failure", async () => {
+    mockedGetAlerts.mockRejectedValueOnce(new Error("network"));
+
+    const list = await HealthAlertProvider.getList?.(4);
+
+    expect(list).toEqual([]);
+  });
+});

--- a/src/services/alerts/providers/HealthAlertProvider.ts
+++ b/src/services/alerts/providers/HealthAlertProvider.ts
@@ -1,29 +1,62 @@
-import { AlertProvider, AlertSummary } from "../AlertRegistry";
+﻿import { AlertItem, AlertProvider, AlertSummary } from "../AlertRegistry";
 import { healthAPI } from "../../../api/GoatFarmAPI/health";
+import type { HealthEventResponseDTO } from "../../../Models/HealthDTOs";
+
+function toHealthItem(
+  farmId: number,
+  event: HealthEventResponseDTO,
+  category: "overdue" | "due_today" | "upcoming"
+): AlertItem {
+  const severity = category === "overdue" ? "high" : category === "due_today" ? "medium" : "low";
+  const priority = category === "overdue" ? 350 : category === "due_today" ? 240 : 120;
+
+  const categoryText =
+    category === "overdue"
+      ? "Evento sanitario atrasado"
+      : category === "due_today"
+        ? "Evento sanitario para hoje"
+        : "Evento sanitario proximo";
+
+  return {
+    id: `health-${event.id}-${category}`,
+    source: "health",
+    title: event.title || "Evento sanitario",
+    description: `${categoryText} · Cabra ${event.goatId}`,
+    date: event.scheduledDate,
+    severity,
+    priority,
+    goatId: event.goatId,
+    link: `/app/goatfarms/${farmId}/goats/${event.goatId}/health/${event.id}`,
+    actionLabel: "Ver evento"
+  };
+}
 
 export const HealthAlertProvider: AlertProvider = {
-  key: 'health_agenda',
-  label: 'Agenda Sanitária',
-  priority: 80, // Lower priority than Reproduction? Or depends.
+  key: "health_agenda",
+  label: "Agenda Sanitaria",
+  priority: 80,
 
   getSummary: async (farmId: number): Promise<AlertSummary> => {
     try {
       const data = await healthAPI.getAlerts(farmId);
       const overdueCount = data.overdueCount || 0;
       const dueTodayCount = data.dueTodayCount || 0;
-      const count = overdueCount + dueTodayCount;
+      const upcomingCount = data.upcomingCount || 0;
+      const count = overdueCount + dueTodayCount + upcomingCount;
 
-      let headline = undefined;
+      let headline: string | undefined;
       if (overdueCount > 0) {
         headline = `${overdueCount} atrasado(s)`;
       } else if (dueTodayCount > 0) {
         headline = `${dueTodayCount} para hoje`;
+      } else if (upcomingCount > 0) {
+        headline = `${upcomingCount} proximo(s)`;
       }
 
       return {
         count,
         headline,
-        worstOverdueDays: 0 // API doesn't give this easily in summary, skipping
+        worstOverdueDays: overdueCount > 0 ? 1 : 0
       };
     } catch (error) {
       console.error("Failed to fetch health alerts", error);
@@ -31,6 +64,20 @@ export const HealthAlertProvider: AlertProvider = {
     }
   },
 
-  // List is not implemented here because we redirect to the Agenda page
-  getRoute: (farmId: number) => `/app/goatfarms/${farmId}/health-agenda`
+  getList: async (farmId: number): Promise<AlertItem[]> => {
+    try {
+      const data = await healthAPI.getAlerts(farmId);
+
+      return [
+        ...(data.overdueTop || []).map((event) => toHealthItem(farmId, event, "overdue")),
+        ...(data.dueTodayTop || []).map((event) => toHealthItem(farmId, event, "due_today")),
+        ...(data.upcomingTop || []).map((event) => toHealthItem(farmId, event, "upcoming"))
+      ];
+    } catch (error) {
+      console.error("Failed to fetch health alert list", error);
+      return [];
+    }
+  },
+
+  getRoute: (farmId: number) => `/app/goatfarms/${farmId}/alerts?type=health_agenda`
 };

--- a/src/services/alerts/providers/LactationDryOffAlertProvider.test.ts
+++ b/src/services/alerts/providers/LactationDryOffAlertProvider.test.ts
@@ -46,8 +46,10 @@ describe("LactationDryOffAlertProvider", () => {
     expect(summary.previewItems).toHaveLength(2);
     expect(summary.previewItems?.[0]).toMatchObject({
       id: "GOAT-001-2026-02-09",
+      source: "lactation",
       goatId: "GOAT-001",
       severity: "high",
+      priority: 264,
       dryOffDate: "2026-02-09",
       daysOverdue: 4,
       link: "/app/goatfarms/42/goats/GOAT-001/lactations/active",
@@ -86,7 +88,9 @@ describe("LactationDryOffAlertProvider", () => {
     expect(list).toHaveLength(1);
     expect(list?.[0]).toMatchObject({
       id: "GOAT-777-2026-02-20",
+      source: "lactation",
       severity: "low",
+      priority: 180,
       dryOffDate: "2026-02-20",
       daysOverdue: -2,
     });

--- a/src/services/alerts/providers/LactationDryOffAlertProvider.ts
+++ b/src/services/alerts/providers/LactationDryOffAlertProvider.ts
@@ -1,14 +1,26 @@
-import { getFarmDryOffAlerts } from "../../../api/GoatFarmAPI/lactation";
+﻿import { getFarmDryOffAlerts } from "../../../api/GoatFarmAPI/lactation";
 import type { LactationDryOffAlertItemDTO } from "../../../Models/LactationDTOs";
-import type { AlertItem, AlertProvider, AlertSummary } from "../AlertRegistry";
+import type { AlertItem, AlertProvider, AlertSeverity, AlertSummary } from "../AlertRegistry";
 
 const DETAILS_PAGE_SIZE = 20;
 const DRAWER_PREVIEW_SIZE = 5;
 
-function resolveDryOffSeverity(daysOverdue: number): "high" | "medium" | "low" {
-  if (daysOverdue > 0) return "high"; // OVERDUE
-  if (daysOverdue === 0) return "medium"; // DUE TODAY
-  return "low"; // UPCOMING
+function resolveDryOffSeverity(daysOverdue: number): AlertSeverity {
+  if (daysOverdue > 0) return "high";
+  if (daysOverdue === 0) return "medium";
+  return "low";
+}
+
+function resolvePriority(daysOverdue: number): number {
+  if (daysOverdue > 0) {
+    return 260 + Math.min(daysOverdue, 90);
+  }
+
+  if (daysOverdue === 0) {
+    return 220;
+  }
+
+  return 180;
 }
 
 function mapDryOffAlertToItem(farmId: number, alert: LactationDryOffAlertItemDTO): AlertItem {
@@ -16,14 +28,18 @@ function mapDryOffAlertToItem(farmId: number, alert: LactationDryOffAlertItemDTO
   const overdueText =
     alert.daysOverdue > 0
       ? `${alert.daysOverdue} dia(s) de atraso`
-      : "Secagem recomendada para hoje";
+      : alert.daysOverdue === 0
+        ? "Secagem recomendada para hoje"
+        : "Secagem prevista";
 
   return {
     id: `${alert.goatId}-${alert.dryOffDate}`,
+    source: "lactation",
     title: `Secagem pendente: ${alert.goatId}`,
     description: `${overdueText}. Gestacao com ${alert.gestationDays} dia(s).`,
     date: alert.dryOffDate,
     severity,
+    priority: resolvePriority(alert.daysOverdue),
     goatId: alert.goatId,
     startDatePregnancy: alert.startDatePregnancy,
     dryOffDate: alert.dryOffDate,
@@ -89,4 +105,3 @@ export const LactationDryOffAlertProvider: AlertProvider = {
 
   getRoute: (farmId: number) => `/app/goatfarms/${farmId}/alerts?type=lactation_drying`
 };
-

--- a/src/services/alerts/providers/PregnancyDiagnosisAlertProvider.test.ts
+++ b/src/services/alerts/providers/PregnancyDiagnosisAlertProvider.test.ts
@@ -1,0 +1,91 @@
+﻿import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getFarmPregnancyDiagnosisAlerts } from "../../../api/GoatFarmAPI/reproduction";
+import { PregnancyDiagnosisAlertProvider } from "./PregnancyDiagnosisAlertProvider";
+
+vi.mock("../../../api/GoatFarmAPI/reproduction", () => ({
+  getFarmPregnancyDiagnosisAlerts: vi.fn()
+}));
+
+const mockedGetFarmPregnancyDiagnosisAlerts = vi.mocked(getFarmPregnancyDiagnosisAlerts);
+
+describe("PregnancyDiagnosisAlertProvider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("maps summary with canonical source/severity/priority", async () => {
+    mockedGetFarmPregnancyDiagnosisAlerts.mockResolvedValueOnce({
+      totalPending: 2,
+      alerts: [
+        {
+          goatId: "GOAT-001",
+          eligibleDate: "2026-03-10",
+          daysOverdue: 12,
+          lastCoverageDate: "2026-01-01",
+          lastCheckDate: null
+        },
+        {
+          goatId: "GOAT-002",
+          eligibleDate: "2026-03-11",
+          daysOverdue: 0,
+          lastCoverageDate: "2026-01-05",
+          lastCheckDate: null
+        }
+      ]
+    });
+
+    const summary = await PregnancyDiagnosisAlertProvider.getSummary(7);
+
+    expect(mockedGetFarmPregnancyDiagnosisAlerts).toHaveBeenCalledWith(7, { page: 0, size: 5 });
+    expect(summary.count).toBe(2);
+    expect(summary.headline).toBe("Maior atraso: 12 dias");
+    expect(summary.previewItems?.[0]).toMatchObject({
+      source: "reproduction",
+      severity: "high",
+      priority: 312,
+      goatId: "GOAT-001"
+    });
+  });
+
+  it("maps list forwarding params", async () => {
+    mockedGetFarmPregnancyDiagnosisAlerts.mockResolvedValueOnce({
+      totalPending: 1,
+      alerts: [
+        {
+          goatId: "GOAT-003",
+          eligibleDate: "2026-03-12",
+          daysOverdue: 3,
+          lastCoverageDate: "2026-01-07",
+          lastCheckDate: null
+        }
+      ]
+    });
+
+    const list = await PregnancyDiagnosisAlertProvider.getList?.(9, {
+      referenceDate: "2026-03-12",
+      page: 2,
+      size: 20
+    });
+
+    expect(mockedGetFarmPregnancyDiagnosisAlerts).toHaveBeenCalledWith(9, {
+      referenceDate: "2026-03-12",
+      page: 2,
+      size: 20
+    });
+    expect(list).toHaveLength(1);
+    expect(list?.[0]).toMatchObject({
+      source: "reproduction",
+      severity: "medium",
+      priority: 303,
+      actionLabel: "Ver reproducao"
+    });
+  });
+
+  it("returns safe fallback on summary error", async () => {
+    mockedGetFarmPregnancyDiagnosisAlerts.mockRejectedValueOnce(new Error("network"));
+
+    const summary = await PregnancyDiagnosisAlertProvider.getSummary(7);
+
+    expect(summary).toEqual({ count: 0 });
+  });
+});

--- a/src/services/alerts/providers/PregnancyDiagnosisAlertProvider.ts
+++ b/src/services/alerts/providers/PregnancyDiagnosisAlertProvider.ts
@@ -1,36 +1,75 @@
-import { AlertProvider, AlertSummary, AlertItem, AlertListParams } from "../AlertRegistry";
+﻿import { AlertProvider, AlertSummary, AlertItem, AlertListParams, AlertSeverity } from "../AlertRegistry";
 import { getFarmPregnancyDiagnosisAlerts } from "../../../api/GoatFarmAPI/reproduction";
 
+function resolveSeverity(daysOverdue: number): AlertSeverity {
+  if (daysOverdue > 7) return "high";
+  if (daysOverdue > 0) return "medium";
+  return "low";
+}
+
+function resolvePriority(daysOverdue: number): number {
+  if (daysOverdue > 0) {
+    return 300 + Math.min(daysOverdue, 90);
+  }
+
+  return 200;
+}
+
+function toItem(farmId: number, goatId: string, eligibleDate: string, lastCoverageDate: string, daysOverdue: number): AlertItem {
+  return {
+    id: `${goatId}-${eligibleDate}`,
+    source: "reproduction",
+    title: `Diagnostico pendente: ${goatId}`,
+    description: `Atraso de ${daysOverdue} dia(s). Cobertura em ${new Date(`${lastCoverageDate}T00:00:00`).toLocaleDateString("pt-BR")}`,
+    date: eligibleDate,
+    severity: resolveSeverity(daysOverdue),
+    priority: resolvePriority(daysOverdue),
+    goatId,
+    daysOverdue,
+    link: `/app/goatfarms/${farmId}/goats/${goatId}/reproduction`,
+    actionLabel: "Ver reproducao"
+  };
+}
+
 export const PregnancyDiagnosisAlertProvider: AlertProvider = {
-  key: 'reproduction_pregnancy_diagnosis',
-  label: 'Diagnóstico de Prenhez',
-  priority: 100, // High priority
+  key: "reproduction_pregnancy_diagnosis",
+  label: "Diagnostico de Prenhez",
+  priority: 100,
 
   getSummary: async (farmId: number): Promise<AlertSummary> => {
     try {
-      const response = await getFarmPregnancyDiagnosisAlerts(farmId, { page: 0, size: 1 });
+      const response = await getFarmPregnancyDiagnosisAlerts(farmId, { page: 0, size: 5 });
       const count = response.totalPending;
-      
-      let headline = undefined;
+
+      let headline: string | undefined;
       let worstOverdueDays = 0;
 
-      // Calculate worst overdue if available
-      // Since the API returns sorted by overdue desc (usually), we check the first item
-      // But let's verify logic. The API returns a list.
       if (response.alerts && response.alerts.length > 0) {
-        // Find max daysOverdue in the first batch (or trust backend sorting)
-        // Assuming backend sorts by overdue descending
-        const worst = response.alerts.reduce((max, item) => Math.max(max, item.daysOverdue), 0);
-        worstOverdueDays = worst;
-        if (worst > 0) {
-            headline = `Maior atraso: ${worst} dias`;
+        worstOverdueDays = response.alerts.reduce(
+          (max, item) => Math.max(max, item.daysOverdue),
+          0
+        );
+
+        if (worstOverdueDays > 0) {
+          headline = `Maior atraso: ${worstOverdueDays} dias`;
+        } else {
+          headline = "Diagnostico elegivel para hoje";
         }
       }
 
       return {
         count,
         headline,
-        worstOverdueDays
+        worstOverdueDays,
+        previewItems: response.alerts.slice(0, 3).map((alert) =>
+          toItem(
+            farmId,
+            alert.goatId,
+            alert.eligibleDate,
+            alert.lastCoverageDate,
+            alert.daysOverdue
+          )
+        )
       };
     } catch (error) {
       console.error("Failed to fetch pregnancy diagnosis alerts summary", error);
@@ -40,19 +79,19 @@ export const PregnancyDiagnosisAlertProvider: AlertProvider = {
 
   getList: async (farmId: number, params?: AlertListParams): Promise<AlertItem[]> => {
     try {
-        const response = await getFarmPregnancyDiagnosisAlerts(farmId, params);
-        return response.alerts.map(alert => ({
-            id: `${alert.goatId}-${alert.eligibleDate}`,
-            title: `Diagnóstico Pendente: ${alert.goatId}`,
-            description: `Atraso de ${alert.daysOverdue} dias. Cobertura em ${new Date(alert.lastCoverageDate).toLocaleDateString()}`,
-            date: alert.eligibleDate,
-            severity: alert.daysOverdue > 30 ? 'high' : 'medium',
-            goatId: alert.goatId,
-            link: `/app/goatfarms/${farmId}/goats/${alert.goatId}/reproduction`
-        }));
+      const response = await getFarmPregnancyDiagnosisAlerts(farmId, params);
+      return response.alerts.map((alert) =>
+        toItem(
+          farmId,
+          alert.goatId,
+          alert.eligibleDate,
+          alert.lastCoverageDate,
+          alert.daysOverdue
+        )
+      );
     } catch (error) {
-        console.error("Failed to fetch pregnancy diagnosis alerts list", error);
-        return [];
+      console.error("Failed to fetch pregnancy diagnosis alerts list", error);
+      return [];
     }
   },
 


### PR DESCRIPTION
## Summary\n- unify alert semantics across reproduction, lactation and health (source/severity/priority)\n- improve consolidated farm alerts page with filters, severity grouping and clear CTAs\n- strengthen dashboard alert summary with severity highlights\n- add tests for providers, semantics, consolidated alerts page and e2e dry-off flow\n- update alerts contract documentation\n\n## Gates\n- npm test -- --run\n- npm run build\n- npm run lint\n- npm run test:e2e\n\n## Notes\n- frontend-only implementation\n- no backend contract changes\n- agenda and alerts remain separated