### PR TITLE
Feat: expose critical operational audit trail in UI

### DIFF
--- a/src/Components/goat-operational-history/GoatOperationalHistoryPanel.test.ts
+++ b/src/Components/goat-operational-history/GoatOperationalHistoryPanel.test.ts
@@ -46,4 +46,41 @@ describe("GoatOperationalHistoryPanel helpers", () => {
     expect(timeline[1].title).toBe("Parto registrado");
     expect(timeline[1].detail).toBe("Parto");
   });
+
+  it("inclui a trilha de auditoria nas operacoes criticas da cabra", () => {
+    const timeline = buildOperationalTimeline(
+      {
+        registrationNumber: "MATRIZ-02",
+        name: "Cabra auditada",
+        breed: "SAANEN",
+        color: "Branca",
+        gender: "FEMEA",
+        birthDate: "2024-01-01",
+        status: "ATIVO",
+        category: "PO",
+        toe: "002",
+        tod: "16432",
+        farmId: 7,
+      },
+      [],
+      [],
+      [
+        {
+          id: 10,
+          goatRegistrationNumber: "MATRIZ-02",
+          actionType: "GOAT_EXIT",
+          actionLabel: "Saida do rebanho",
+          targetId: "MATRIZ-02",
+          description: "Saida auditada",
+          actorUserId: 7,
+          actorName: "Operador QA",
+          actorEmail: "operator@example.com",
+          createdAt: "2026-03-28T10:15:00",
+        },
+      ]
+    );
+
+    expect(timeline[0].title).toBe("Saida do rebanho");
+    expect(timeline[0].detail).toContain("Operador QA");
+  });
 });

--- a/src/Components/goat-operational-history/GoatOperationalHistoryPanel.tsx
+++ b/src/Components/goat-operational-history/GoatOperationalHistoryPanel.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
+import { listOperationalAuditEntries } from "../../api/AuditAPI/audit";
 import { listGoatOffspring, type GoatExitType } from "../../api/GoatAPI/goat";
 import {
   listPregnancies,
   listReproductiveEvents,
 } from "../../api/GoatFarmAPI/reproduction";
+import type { OperationalAuditEntryDTO } from "../../Models/OperationalAuditDTOs";
 import type { GoatResponseDTO } from "../../Models/goatResponseDTO";
 import type {
   PregnancyResponseDTO,
@@ -37,6 +39,7 @@ export default function GoatOperationalHistoryPanel({
   const [events, setEvents] = useState<ReproductiveEventResponseDTO[]>([]);
   const [pregnancies, setPregnancies] = useState<PregnancyResponseDTO[]>([]);
   const [offspring, setOffspring] = useState<GoatResponseDTO[]>([]);
+  const [auditEntries, setAuditEntries] = useState<OperationalAuditEntryDTO[]>([]);
   const [loading, setLoading] = useState(false);
   const [warning, setWarning] = useState<string | null>(null);
 
@@ -46,11 +49,12 @@ export default function GoatOperationalHistoryPanel({
     const load = async () => {
       setLoading(true);
       setWarning(null);
-      const [eventsResult, pregnanciesResult, offspringResult] =
+      const [eventsResult, pregnanciesResult, offspringResult, auditResult] =
         await Promise.allSettled([
           listReproductiveEvents(farmId, goat.registrationNumber, { page: 0, size: 50 }),
           listPregnancies(farmId, goat.registrationNumber, { page: 0, size: 50 }),
           listGoatOffspring(farmId, goat.registrationNumber),
+          listOperationalAuditEntries(farmId, { goatId: goat.registrationNumber, limit: 20 }),
         ]);
 
       if (cancelled) return;
@@ -62,6 +66,8 @@ export default function GoatOperationalHistoryPanel({
       else { setPregnancies([]); failed.push("gestacoes"); }
       if (offspringResult.status === "fulfilled") setOffspring(offspringResult.value);
       else { setOffspring([]); failed.push("crias vinculadas"); }
+      if (auditResult && auditResult.status === "fulfilled") setAuditEntries(auditResult.value);
+      else { setAuditEntries([]); failed.push("auditoria operacional"); }
 
       setWarning(failed.length ? `Parte do historico nao pode ser carregada agora (${failed.join(", ")}).` : null);
       setLoading(false);
@@ -74,8 +80,8 @@ export default function GoatOperationalHistoryPanel({
   }, [farmId, goat.registrationNumber]);
 
   const timeline = useMemo(
-    () => buildOperationalTimeline(goat, events, pregnancies),
-    [events, goat, pregnancies]
+    () => buildOperationalTimeline(goat, events, pregnancies, auditEntries),
+    [auditEntries, events, goat, pregnancies]
   );
   const lastCoverage = useMemo(
     () => events.filter((item) => item.eventType === "COVERAGE").map((item) => item.eventDate).sort((a, b) => b.localeCompare(a))[0] ?? null,

--- a/src/Components/goat-operational-history/goatOperationalHistory.helpers.ts
+++ b/src/Components/goat-operational-history/goatOperationalHistory.helpers.ts
@@ -1,3 +1,4 @@
+import type { OperationalAuditEntryDTO } from "../../Models/OperationalAuditDTOs";
 import type { GoatExitType } from "../../api/GoatAPI/goat";
 import type { GoatResponseDTO } from "../../Models/goatResponseDTO";
 import type {
@@ -33,7 +34,8 @@ const closeReasonLabels: Record<string, string> = {
 export function buildOperationalTimeline(
   goat: GoatResponseDTO,
   events: ReproductiveEventResponseDTO[],
-  pregnancies: PregnancyResponseDTO[]
+  pregnancies: PregnancyResponseDTO[],
+  auditEntries: OperationalAuditEntryDTO[] = []
 ): TimelineItem[] {
   const pregnancyById = new Map(pregnancies.map((item) => [item.id, item]));
   const items: TimelineItem[] = [
@@ -96,6 +98,17 @@ export function buildOperationalTimeline(
           tone: "warning" as const,
         }]
       : []),
+    ...auditEntries.map((entry) => ({
+      key: `audit-${entry.id}`,
+      date: entry.createdAt?.split("T")[0] ?? null,
+      title: entry.actionLabel,
+      detail: `${entry.description} - por ${entry.actorName}`,
+      tone: entry.actionType === "GOAT_EXIT"
+        ? "warning"
+        : entry.actionType.endsWith("_PAYMENT_REGISTERED")
+          ? "success"
+          : "neutral",
+    })),
   ];
 
   return items.sort((left, right) => (right.date ?? "").localeCompare(left.date ?? ""));

--- a/src/Models/OperationalAuditDTOs.ts
+++ b/src/Models/OperationalAuditDTOs.ts
@@ -1,0 +1,19 @@
+export type OperationalAuditActionType =
+  | "GOAT_EXIT"
+  | "ANIMAL_SALE_CREATED"
+  | "ANIMAL_SALE_PAYMENT_REGISTERED"
+  | "MILK_SALE_CREATED"
+  | "MILK_SALE_PAYMENT_REGISTERED";
+
+export interface OperationalAuditEntryDTO {
+  id: number;
+  goatRegistrationNumber?: string | null;
+  actionType: OperationalAuditActionType;
+  actionLabel: string;
+  targetId?: string | null;
+  description: string;
+  actorUserId: number;
+  actorName: string;
+  actorEmail: string;
+  createdAt: string;
+}

--- a/src/Pages/commercial/CommercialPage.tsx
+++ b/src/Pages/commercial/CommercialPage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { toast } from "react-toastify";
 import GoatFarmHeader from "../../Components/pages-headers/GoatFarmHeader";
+import { listOperationalAuditEntries } from "../../api/AuditAPI/audit";
 import {
   createAnimalSale,
   createCustomer,
@@ -26,6 +27,7 @@ import type {
   MilkSaleResponseDTO,
   ReceivableResponseDTO,
 } from "../../Models/CommercialDTOs";
+import type { OperationalAuditEntryDTO } from "../../Models/OperationalAuditDTOs";
 import type { GoatFarmDTO } from "../../Models/goatFarm";
 import type { GoatResponseDTO } from "../../Models/goatResponseDTO";
 import { buildFarmDashboardPath } from "../../utils/appRoutes";
@@ -68,6 +70,7 @@ export default function CommercialPage() {
   const [animalSales, setAnimalSales] = useState<AnimalSaleResponseDTO[]>([]);
   const [milkSales, setMilkSales] = useState<MilkSaleResponseDTO[]>([]);
   const [receivables, setReceivables] = useState<ReceivableResponseDTO[]>([]);
+  const [auditEntries, setAuditEntries] = useState<OperationalAuditEntryDTO[]>([]);
   const [summary, setSummary] = useState<CommercialSummaryDTO>(emptySummary);
   const [loading, setLoading] = useState(false);
   const [pageError, setPageError] = useState("");
@@ -113,6 +116,10 @@ export default function CommercialPage() {
     () => formatCommercialCurrency((milkSaleForm.quantityLiters || 0) * (milkSaleForm.unitPrice || 0)),
     [milkSaleForm.quantityLiters, milkSaleForm.unitPrice]
   );
+  const formatAuditDateTime = useCallback(
+    (value?: string | null) => (value ? new Date(value).toLocaleString("pt-BR") : "-"),
+    []
+  );
 
   useEffect(() => {
     if (activeCustomers.length === 0) return;
@@ -144,7 +151,7 @@ export default function CommercialPage() {
     setPageError("");
 
     try {
-      const [farm, goatPage, summaryData, customersData, animalSalesData, milkSalesData, receivablesData] = await Promise.all([
+      const [farm, goatPage, summaryData, customersData, animalSalesData, milkSalesData, receivablesData, auditEntriesData] = await Promise.all([
         getGoatFarmById(farmIdNumber),
         findGoatsByFarmIdPaginated(farmIdNumber, 0, 100),
         fetchCommercialSummary(farmIdNumber),
@@ -152,6 +159,7 @@ export default function CommercialPage() {
         listAnimalSales(farmIdNumber),
         listMilkSales(farmIdNumber),
         listReceivables(farmIdNumber),
+        listOperationalAuditEntries(farmIdNumber, { limit: 12 }),
       ]);
 
       setFarmData(farm);
@@ -161,6 +169,7 @@ export default function CommercialPage() {
       setAnimalSales(animalSalesData);
       setMilkSales(milkSalesData);
       setReceivables(receivablesData);
+      setAuditEntries(auditEntriesData);
       setPaymentDrafts(
         Object.fromEntries(receivablesData.map((item) => [`${item.sourceType}-${item.sourceId}`, today]))
       );
@@ -755,6 +764,49 @@ export default function CommercialPage() {
                   {receivables.length === 0 ? (
                     <tr>
                       <td colSpan={6}>Nenhum recebivel registrado ainda.</td>
+                    </tr>
+                  ) : null}
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          <section className="commercial-card">
+            <div className="commercial-card__header">
+              <div>
+                <p className="commercial-card__eyebrow">Auditabilidade minima</p>
+                <h2>Operacoes criticas recentes</h2>
+              </div>
+              <span className="commercial-card__chip">{auditEntries.length} registros</span>
+            </div>
+            <div className="commercial-table-shell">
+              <table className="commercial-table">
+                <thead>
+                  <tr>
+                    <th>Quando</th>
+                    <th>Operacao</th>
+                    <th>Ator</th>
+                    <th>Descricao</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {auditEntries.map((entry) => (
+                    <tr key={entry.id}>
+                      <td>{formatAuditDateTime(entry.createdAt)}</td>
+                      <td>
+                        <strong>{entry.actionLabel}</strong>
+                        <small>{entry.goatRegistrationNumber || "-"}</small>
+                      </td>
+                      <td>
+                        <span>{entry.actorName}</span>
+                        <small>{entry.actorEmail}</small>
+                      </td>
+                      <td>{entry.description}</td>
+                    </tr>
+                  ))}
+                  {auditEntries.length === 0 ? (
+                    <tr>
+                      <td colSpan={4}>Nenhuma operacao critica auditada ainda nesta fazenda.</td>
                     </tr>
                   ) : null}
                 </tbody>

--- a/src/api/AuditAPI/audit.ts
+++ b/src/api/AuditAPI/audit.ts
@@ -1,0 +1,32 @@
+import type { OperationalAuditEntryDTO } from "../../Models/OperationalAuditDTOs";
+import { requestBackEnd } from "../../utils/request";
+
+type Envelope<T> = { data: T } | T;
+
+function hasData<T>(value: unknown): value is { data: T } {
+  return typeof value === "object" && value !== null && Object.prototype.hasOwnProperty.call(value, "data");
+}
+
+function unwrap<T>(value: Envelope<T>): T {
+  return hasData<T>(value) ? value.data : (value as T);
+}
+
+const basePath = (farmId: number) => `/goatfarms/${farmId}/audit`;
+
+export async function listOperationalAuditEntries(
+  farmId: number,
+  params?: { goatId?: string; limit?: number }
+): Promise<OperationalAuditEntryDTO[]> {
+  const search = new URLSearchParams();
+  if (params?.goatId) {
+    search.set("goatId", params.goatId);
+  }
+  if (params?.limit) {
+    search.set("limit", String(params.limit));
+  }
+
+  const suffix = search.toString() ? `?${search.toString()}` : "";
+  const { data } = await requestBackEnd.get(`${basePath(farmId)}/entries${suffix}`);
+  const body = unwrap<OperationalAuditEntryDTO[] | { content?: OperationalAuditEntryDTO[] }>(data);
+  return Array.isArray(body) ? body : body.content ?? [];
+}


### PR DESCRIPTION
## Resumo\n- exibir operacoes criticas recentes na pagina comercial\n- incorporar eventos auditados na linha operacional do animal\n- manter leitura coerente com o backend real\n\n## Validacao\n- npm test -- --run\n- npm run build\n- npm run lint\n- npm run test:e2e\n- smoke real no frontend com backend em localhost:8080