### PR TITLE
Feat: add password reset public flow

### DIFF
--- a/src/Pages/login/LoginPage.test.tsx
+++ b/src/Pages/login/LoginPage.test.tsx
@@ -1,0 +1,29 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import LoginPage from './LoginPage';
+
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    isAuthenticated: false,
+    tokenPayload: null,
+    login: vi.fn(),
+    logout: vi.fn(),
+  }),
+}));
+
+vi.mock('../../services/auth-service', () => ({
+  loginRequest: vi.fn(),
+}));
+
+describe('LoginPage', () => {
+  it('exibe o link de esqueci minha senha no login', () => {
+    const html = renderToStaticMarkup(
+      <MemoryRouter>
+        <LoginPage />
+      </MemoryRouter>
+    );
+
+    expect(html).toContain('href="/forgot-password"');
+  });
+});

--- a/src/Pages/login/LoginPage.tsx
+++ b/src/Pages/login/LoginPage.tsx
@@ -25,7 +25,7 @@ export default function LoginPage() {
     try {
       const res = await loginRequest({ email, password });
       const token = res?.data?.access_token || res?.data?.accessToken;
-      if (!token) throw new Error('Token não encontrado na resposta');
+      if (!token) throw new Error('Token nao encontrado na resposta');
 
       login(token);
 
@@ -34,7 +34,7 @@ export default function LoginPage() {
       navigate(dest, { replace: true });
     } catch (error) {
       console.error(error);
-      setErr('Falha no login. Verifique usuário e senha.');
+      setErr('Falha no login. Verifique usuario e senha.');
     } finally {
       setLoading(false);
     }
@@ -48,16 +48,15 @@ export default function LoginPage() {
         {isAuthenticated && (
           <div className="already-logged">
             <p>
-              Você já está logado como{' '}
+              Voce ja esta logado como{' '}
               <strong>{tokenPayload?.userName ?? tokenPayload?.user_name}</strong>.
             </p>
             <button type="button" className="btn-secondary" onClick={logout}>
-              Sair para trocar de usuário
+              Sair para trocar de usuario
             </button>
           </div>
         )}
 
-        {/* ✅ 2. O FORMULÁRIO ANTIGO FOI SUBSTITUÍDO POR ESTE COMPONENTE */}
         <LoginForm
           handleSubmit={handleSubmit}
           username={email}
@@ -69,7 +68,11 @@ export default function LoginPage() {
         />
 
         <div className="login-footer">
-          <span>Não tem uma conta? </span>
+          <a href="/forgot-password">Esqueci minha senha</a>
+        </div>
+
+        <div className="login-footer">
+          <span>Nao tem uma conta? </span>
           <a href="/fazendas/novo">Cadastre-se</a>
         </div>
       </div>

--- a/src/Pages/password-reset/ForgotPasswordPage.test.tsx
+++ b/src/Pages/password-reset/ForgotPasswordPage.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot, Root } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import ForgotPasswordPage from './ForgotPasswordPage';
+import { requestPasswordReset } from '../../services/auth-service';
+
+vi.mock('../../services/auth-service', () => ({
+  requestPasswordReset: vi.fn(),
+}));
+
+const requestPasswordResetMock = vi.mocked(requestPasswordReset);
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function setInputValue(input: HTMLInputElement, value: string) {
+  const descriptor = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value');
+  descriptor?.set?.call(input, value);
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+describe('ForgotPasswordPage', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  afterEach(async () => {
+    requestPasswordResetMock.mockReset();
+    if (root) {
+      await act(async () => {
+        root.unmount();
+      });
+    }
+    if (container?.parentNode) {
+      container.parentNode.removeChild(container);
+    }
+  });
+
+  it('renderiza e envia a solicitacao exibindo a mensagem neutra', async () => {
+    requestPasswordResetMock.mockResolvedValue({
+      data: { message: 'Se existir uma conta com esse email, enviaremos um link de redefinicao.' },
+    } as never);
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root.render(<ForgotPasswordPage />);
+    });
+
+    const input = container.querySelector('input[type="email"]') as HTMLInputElement;
+    const form = container.querySelector('form') as HTMLFormElement;
+
+    await act(async () => {
+      setInputValue(input, 'qa.reset@example.com');
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+      await Promise.resolve();
+    });
+
+    expect(requestPasswordResetMock).toHaveBeenCalledWith({ email: 'qa.reset@example.com' });
+    expect(container.textContent).toContain('Se existir uma conta com esse email, enviaremos um link de redefinicao.');
+  });
+});

--- a/src/Pages/password-reset/ForgotPasswordPage.tsx
+++ b/src/Pages/password-reset/ForgotPasswordPage.tsx
@@ -1,0 +1,66 @@
+import { FormEvent, useState } from 'react';
+import { requestPasswordReset } from '../../services/auth-service';
+import '../login/login.css';
+
+const NEUTRAL_MESSAGE = 'Se existir uma conta com esse email, enviaremos um link de redefinicao.';
+const GENERIC_ERROR = 'Nao foi possivel processar sua solicitacao agora. Tente novamente em instantes.';
+
+export default function ForgotPasswordPage() {
+  const [email, setEmail] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+    if (loading) return;
+
+    setLoading(true);
+    setError(null);
+    setMessage(null);
+
+    try {
+      const response = await requestPasswordReset({ email });
+      setMessage(response?.data?.message || NEUTRAL_MESSAGE);
+    } catch (requestError) {
+      console.error(requestError);
+      setError(GENERIC_ERROR);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="login-container">
+      <div className="login-box">
+        <h1 className="login-title">Esqueci minha senha</h1>
+        <p className="login-footer">
+          Informe seu email. Se ele existir no sistema, enviaremos um link de redefinicao.
+        </p>
+
+        <form className="login-form" onSubmit={handleSubmit}>
+          <input
+            className="login-input"
+            type="email"
+            autoComplete="email"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            placeholder="Seu email"
+            required
+          />
+
+          {message && <div className="already-logged"><p>{message}</p></div>}
+          {error && <div className="error">{error}</div>}
+
+          <button type="submit" className="btn-primary" disabled={loading}>
+            {loading ? 'Enviando...' : 'Enviar link'}
+          </button>
+        </form>
+
+        <div className="login-footer">
+          <a href="/login">Voltar para o login</a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/Pages/password-reset/ResetPasswordPage.test.tsx
+++ b/src/Pages/password-reset/ResetPasswordPage.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot, Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import ResetPasswordPage from './ResetPasswordPage';
+import { confirmPasswordReset } from '../../services/auth-service';
+
+vi.mock('../../services/auth-service', () => ({
+  confirmPasswordReset: vi.fn(),
+}));
+
+const confirmPasswordResetMock = vi.mocked(confirmPasswordReset);
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function setInputValue(input: HTMLInputElement, value: string) {
+  const descriptor = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value');
+  descriptor?.set?.call(input, value);
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+describe('ResetPasswordPage', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    window.history.pushState({}, '', '/reset-password?token=raw-token');
+  });
+
+  afterEach(async () => {
+    confirmPasswordResetMock.mockReset();
+    if (root) {
+      await act(async () => {
+        root.unmount();
+      });
+    }
+    if (container?.parentNode) {
+      container.parentNode.removeChild(container);
+    }
+    window.history.pushState({}, '', '/reset-password');
+  });
+
+  it('trata sucesso na redefinicao', async () => {
+    confirmPasswordResetMock.mockResolvedValue({
+      data: { message: 'Senha redefinida com sucesso.' },
+    } as never);
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root.render(<ResetPasswordPage />);
+    });
+
+    const inputs = container.querySelectorAll('input[type="password"]');
+    const form = container.querySelector('form') as HTMLFormElement;
+
+    await act(async () => {
+      setInputValue(inputs[0] as HTMLInputElement, 'NovaSenha123');
+      setInputValue(inputs[1] as HTMLInputElement, 'NovaSenha123');
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+      await Promise.resolve();
+    });
+
+    expect(confirmPasswordResetMock).toHaveBeenCalledWith({
+      token: 'raw-token',
+      newPassword: 'NovaSenha123',
+      confirmPassword: 'NovaSenha123',
+    });
+    expect(container.textContent).toContain('Senha redefinida com sucesso.');
+  });
+
+  it('trata token expirado retornado pelo backend', async () => {
+    confirmPasswordResetMock.mockRejectedValue({
+      response: {
+        data: {
+          message: 'Token de redefinicao expirado.',
+        },
+      },
+    });
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root.render(<ResetPasswordPage />);
+    });
+
+    const inputs = container.querySelectorAll('input[type="password"]');
+    const form = container.querySelector('form') as HTMLFormElement;
+
+    await act(async () => {
+      setInputValue(inputs[0] as HTMLInputElement, 'NovaSenha123');
+      setInputValue(inputs[1] as HTMLInputElement, 'NovaSenha123');
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain('Token de redefinicao expirado.');
+  });
+});

--- a/src/Pages/password-reset/ResetPasswordPage.tsx
+++ b/src/Pages/password-reset/ResetPasswordPage.tsx
@@ -1,0 +1,101 @@
+import { FormEvent, useMemo, useState } from 'react';
+import { confirmPasswordReset } from '../../services/auth-service';
+import '../login/login.css';
+
+const INVALID_TOKEN_MESSAGE = 'Link de redefinicao invalido. Solicite um novo email.';
+const GENERIC_ERROR = 'Nao foi possivel redefinir a senha agora. Tente novamente em instantes.';
+
+function extractApiMessage(error: unknown): string {
+  if (typeof error === 'object' && error !== null) {
+    const candidate = error as {
+      response?: { data?: { message?: string; errors?: Array<{ message?: string }> } };
+      message?: string;
+    };
+
+    const responseMessage = candidate.response?.data?.message;
+    if (responseMessage) return responseMessage;
+
+    const nestedMessage = candidate.response?.data?.errors?.[0]?.message;
+    if (nestedMessage) return nestedMessage;
+
+    if (candidate.message) return candidate.message;
+  }
+
+  return GENERIC_ERROR;
+}
+
+export default function ResetPasswordPage() {
+  const searchParams = useMemo(() => new URLSearchParams(window.location.search), []);
+  const token = searchParams.get('token')?.trim() || '';
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(token ? null : INVALID_TOKEN_MESSAGE);
+
+  async function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+    if (loading || !token) return;
+
+    setLoading(true);
+    setError(null);
+    setMessage(null);
+
+    try {
+      const response = await confirmPasswordReset({ token, newPassword, confirmPassword });
+      setMessage(response?.data?.message || 'Senha redefinida com sucesso.');
+      setNewPassword('');
+      setConfirmPassword('');
+    } catch (requestError) {
+      console.error(requestError);
+      setError(extractApiMessage(requestError));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="login-container">
+      <div className="login-box">
+        <h1 className="login-title">Redefinir senha</h1>
+        <p className="login-footer">
+          Defina uma nova senha para concluir a recuperacao da sua conta.
+        </p>
+
+        <form className="login-form" onSubmit={handleSubmit}>
+          <input
+            className="login-input"
+            type="password"
+            autoComplete="new-password"
+            value={newPassword}
+            onChange={(event) => setNewPassword(event.target.value)}
+            placeholder="Nova senha"
+            required
+            disabled={!token || loading}
+          />
+          <input
+            className="login-input"
+            type="password"
+            autoComplete="new-password"
+            value={confirmPassword}
+            onChange={(event) => setConfirmPassword(event.target.value)}
+            placeholder="Confirme a nova senha"
+            required
+            disabled={!token || loading}
+          />
+
+          {message && <div className="already-logged"><p>{message}</p></div>}
+          {error && <div className="error">{error}</div>}
+
+          <button type="submit" className="btn-primary" disabled={!token || loading}>
+            {loading ? 'Redefinindo...' : 'Redefinir senha'}
+          </button>
+        </form>
+
+        <div className="login-footer">
+          <a href="/login">Voltar para o login</a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -20,6 +20,8 @@ import GoatEventsPage from "./Pages/goat-events/GoatEventsPage";
 import GoatCreatePage from "./Pages/goat/GoatCreatePage";
 
 import LoginPage from "./Pages/login/LoginPage";
+import ForgotPasswordPage from "./Pages/password-reset/ForgotPasswordPage";
+import ResetPasswordPage from "./Pages/password-reset/ResetPasswordPage";
 import ForbiddenPage from "./Pages/error/ForbiddenPage";
 
 import { AuthProvider } from "./contexts/AuthContext";
@@ -59,6 +61,8 @@ import CommercialPage from "./Pages/commercial/CommercialPage";
 
 const router = createBrowserRouter([
   { path: "/login", element: <LoginPage /> },
+  { path: "/forgot-password", element: <ForgotPasswordPage /> },
+  { path: "/reset-password", element: <ResetPasswordPage /> },
   { path: "/signup", element: <SignupPage /> }, // ✅ 2. Adiciona a nova rota pública
   { path: "/logout", element: <Logout /> }, // ✅ 3. Adiciona rota de logout
   { path: "/403", element: <ForbiddenPage /> },

--- a/src/services/auth-service.password-reset.test.ts
+++ b/src/services/auth-service.password-reset.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest';
+import { confirmPasswordReset, isPublicEndpoint, requestPasswordReset } from './auth-service';
+import { requestBackEnd } from '../utils/request';
+
+vi.mock('../utils/request', () => ({
+  requestBackEnd: vi.fn(),
+}));
+
+describe('auth-service password reset', () => {
+  it('marca os endpoints de recuperacao de senha como publicos', () => {
+    expect(isPublicEndpoint('/auth/password-reset/request', 'POST')).toBe(true);
+    expect(isPublicEndpoint('/auth/password-reset/confirm', 'POST')).toBe(true);
+  });
+
+  it('envia a solicitacao de reset para o endpoint publico correto', () => {
+    requestPasswordReset({ email: 'qa.reset@example.com' });
+
+    expect(requestBackEnd).toHaveBeenCalledWith({
+      method: 'POST',
+      url: '/auth/password-reset/request',
+      data: { email: 'qa.reset@example.com' },
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+  });
+
+  it('envia a confirmacao de reset para o endpoint publico correto', () => {
+    confirmPasswordReset({
+      token: 'raw-token',
+      newPassword: 'NovaSenha123',
+      confirmPassword: 'NovaSenha123',
+    });
+
+    expect(requestBackEnd).toHaveBeenCalledWith({
+      method: 'POST',
+      url: '/auth/password-reset/confirm',
+      data: {
+        token: 'raw-token',
+        newPassword: 'NovaSenha123',
+        confirmPassword: 'NovaSenha123',
+      },
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+  });
+});

--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -38,6 +38,16 @@ interface ApiResponse<T> {
   message?: string;
 }
 
+interface PasswordResetRequestData {
+  email: string;
+}
+
+interface PasswordResetConfirmData {
+  token: string;
+  newPassword: string;
+  confirmPassword: string;
+}
+
 interface ApiError {
   message: string;
   status?: number;
@@ -62,6 +72,8 @@ const PUBLIC_ENDPOINTS = [
   '/auth/login',
   '/auth/refresh',
   '/auth/register-farm',
+  '/auth/password-reset/request',
+  '/auth/password-reset/confirm',
   '/genealogies',
 ];
 
@@ -126,6 +138,32 @@ export function loginRequest(loginData: CredentialsDTO) {
  * @returns Promise com a resposta tipada da API
  * @throws ApiError com detalhes específicos do erro
  */
+export function requestPasswordReset(data: PasswordResetRequestData) {
+  const config: AxiosRequestConfig = {
+    method: "POST",
+    url: "/auth/password-reset/request",
+    data,
+    headers: {
+      "Content-Type": "application/json",
+    },
+  };
+
+  return requestBackEnd(config);
+}
+
+export function confirmPasswordReset(data: PasswordResetConfirmData) {
+  const config: AxiosRequestConfig = {
+    method: "POST",
+    url: "/auth/password-reset/confirm",
+    data,
+    headers: {
+      "Content-Type": "application/json",
+    },
+  };
+
+  return requestBackEnd(config);
+}
+
 export async function registerUser(formData: UserFormData): Promise<ApiResponse<RegistrationResponse>> {
   try {
     // Validações de entrada


### PR DESCRIPTION
## Resumo
- adiciona as telas publicas de esqueci minha senha e redefinicao
- integra o auth-service com os endpoints publicos do reset
- preserva o login atual e adiciona apenas a UX minima necessaria

## Validacao
- npm test -- --run
- npm run build
- npm run lint
- npm run test:e2e
- validacao pratica fim a fim com backend real e Mailpit