### PR TITLE
Feat: add operational finance farm flows

### DIFF
--- a/src/Components/commercial/MonthlyOperationalSummarySection.tsx
+++ b/src/Components/commercial/MonthlyOperationalSummarySection.tsx
@@ -1,0 +1,113 @@
+import { useEffect, useMemo, useState } from "react";
+import { fetchMonthlyOperationalSummary } from "../../api/CommercialAPI/commercial";
+import type { MonthlyOperationalSummaryDTO } from "../../Models/CommercialDTOs";
+import { formatCommercialCurrency } from "../../Pages/commercial/commercial.helpers";
+import { buildMonthlyOperationalSummaryCards } from "./operationalFinance.helpers";
+
+type MonthlyOperationalSummarySectionProps = {
+  farmId: number;
+  reloadToken?: number;
+};
+
+const today = new Date().toISOString().slice(0, 7);
+
+const emptySummary: MonthlyOperationalSummaryDTO = {
+  year: new Date().getFullYear(),
+  month: new Date().getMonth() + 1,
+  totalRevenue: 0,
+  totalExpenses: 0,
+  balance: 0,
+  animalSalesRevenue: 0,
+  milkSalesRevenue: 0,
+  operationalExpensesTotal: 0,
+  inventoryPurchaseCostsTotal: 0,
+};
+
+export default function MonthlyOperationalSummarySection({
+  farmId,
+  reloadToken = 0,
+}: MonthlyOperationalSummarySectionProps) {
+  const [selectedMonth, setSelectedMonth] = useState(today);
+  const [summary, setSummary] = useState<MonthlyOperationalSummaryDTO>(emptySummary);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const cards = useMemo(() => buildMonthlyOperationalSummaryCards(summary), [summary]);
+
+  useEffect(() => {
+    let active = true;
+
+    async function loadSummary() {
+      const [yearValue, monthValue] = selectedMonth.split("-").map(Number);
+
+      setLoading(true);
+      setError("");
+
+      try {
+        const result = await fetchMonthlyOperationalSummary(farmId, yearValue, monthValue);
+        if (!active) return;
+        setSummary(result);
+      } catch (loadError) {
+        console.error("Financeiro operacional: erro ao carregar resumo mensal", loadError);
+        if (!active) return;
+        setError("Nao foi possivel carregar o resumo mensal.");
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void loadSummary();
+
+    return () => {
+      active = false;
+    };
+  }, [farmId, selectedMonth, reloadToken]);
+
+  return (
+    <section className="commercial-card">
+      <div className="commercial-card__header">
+        <div>
+          <p className="commercial-card__eyebrow">Financeiro operacional minimo</p>
+          <h2>Resumo mensal da fazenda</h2>
+        </div>
+        <label className="commercial-inline-field">
+          <span>Mes</span>
+          <input type="month" value={selectedMonth} onChange={(event) => setSelectedMonth(event.target.value)} />
+        </label>
+      </div>
+
+      {loading ? <div className="commercial-feedback">Carregando resumo mensal...</div> : null}
+      {error ? <div className="commercial-feedback commercial-feedback--error">{error}</div> : null}
+
+      {!loading && !error ? (
+        <>
+          <div className="commercial-summary-grid commercial-summary-grid--finance">
+            {cards.map((card) => (
+              <article key={card.label} className="commercial-card commercial-card--metric commercial-card--nested">
+                <span>{card.label}</span>
+                <strong>{card.value}</strong>
+              </article>
+            ))}
+          </div>
+
+          <div className="commercial-card commercial-card--nested commercial-finance-breakdown">
+            <div>
+              <span>Receita recebida</span>
+              <strong>{formatCommercialCurrency(summary.totalRevenue)}</strong>
+            </div>
+            <div>
+              <span>Despesa total</span>
+              <strong>{formatCommercialCurrency(summary.totalExpenses)}</strong>
+            </div>
+            <div>
+              <span>Saldo do periodo</span>
+              <strong>{formatCommercialCurrency(summary.balance)}</strong>
+            </div>
+          </div>
+        </>
+      ) : null}
+    </section>
+  );
+}

--- a/src/Components/commercial/OperationalExpenseSection.tsx
+++ b/src/Components/commercial/OperationalExpenseSection.tsx
@@ -1,0 +1,223 @@
+import { useEffect, useState } from "react";
+import { toast } from "react-toastify";
+import {
+  createOperationalExpense,
+  listOperationalExpenses,
+} from "../../api/CommercialAPI/commercial";
+import type {
+  OperationalExpenseCategory,
+  OperationalExpenseRequestDTO,
+  OperationalExpenseResponseDTO,
+} from "../../Models/CommercialDTOs";
+import { formatCommercialCurrency, formatCommercialDate } from "../../Pages/commercial/commercial.helpers";
+import { formatOperationalExpenseCategoryLabel } from "./operationalFinance.helpers";
+
+type OperationalExpenseSectionProps = {
+  farmId: number;
+  onChanged?: () => void;
+};
+
+const today = new Date().toISOString().slice(0, 10);
+
+const defaultForm: OperationalExpenseRequestDTO = {
+  category: "OTHER",
+  description: "",
+  amount: 0,
+  expenseDate: today,
+  notes: "",
+};
+
+const categoryOptions: OperationalExpenseCategory[] = [
+  "ENERGY",
+  "WATER",
+  "FREIGHT",
+  "MAINTENANCE",
+  "VETERINARY",
+  "FUEL",
+  "LABOR",
+  "FEES",
+  "OTHER",
+];
+
+export default function OperationalExpenseSection({
+  farmId,
+  onChanged,
+}: OperationalExpenseSectionProps) {
+  const [expenses, setExpenses] = useState<OperationalExpenseResponseDTO[]>([]);
+  const [form, setForm] = useState<OperationalExpenseRequestDTO>(defaultForm);
+  const [loading, setLoading] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let active = true;
+
+    async function loadExpenses() {
+      setLoading(true);
+      setError("");
+
+      try {
+        const result = await listOperationalExpenses(farmId);
+        if (!active) return;
+        setExpenses(result);
+      } catch (loadError) {
+        console.error("Financeiro operacional: erro ao carregar despesas", loadError);
+        if (!active) return;
+        setError("Nao foi possivel carregar as despesas operacionais.");
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void loadExpenses();
+
+    return () => {
+      active = false;
+    };
+  }, [farmId]);
+
+  async function refreshExpenses() {
+    const result = await listOperationalExpenses(farmId);
+    setExpenses(result);
+  }
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    try {
+      setSubmitting(true);
+      await createOperationalExpense(farmId, {
+        ...form,
+        description: form.description.trim(),
+        notes: form.notes?.trim() || undefined,
+      });
+      toast.success("Despesa operacional registrada com sucesso.");
+      setForm({ ...defaultForm, expenseDate: today });
+      await refreshExpenses();
+      onChanged?.();
+    } catch (submitError) {
+      console.error("Financeiro operacional: erro ao registrar despesa", submitError);
+      toast.error("Nao foi possivel registrar a despesa operacional.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <section className="commercial-card">
+      <div className="commercial-card__header">
+        <div>
+          <p className="commercial-card__eyebrow">Saidas operacionais</p>
+          <h2>Despesas da fazenda</h2>
+        </div>
+        <span className="commercial-card__chip">{expenses.length} registro(s)</span>
+      </div>
+
+      <form className="commercial-form" onSubmit={handleSubmit}>
+        <label>
+          <span>Categoria</span>
+          <select
+            value={form.category}
+            onChange={(event) =>
+              setForm((prev) => ({
+                ...prev,
+                category: event.target.value as OperationalExpenseCategory,
+              }))
+            }
+            required
+          >
+            {categoryOptions.map((category) => (
+              <option key={category} value={category}>
+                {formatOperationalExpenseCategoryLabel(category)}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label>
+          <span>Data da despesa</span>
+          <input
+            type="date"
+            value={form.expenseDate}
+            onChange={(event) => setForm((prev) => ({ ...prev, expenseDate: event.target.value }))}
+            required
+          />
+        </label>
+
+        <label className="commercial-form__full">
+          <span>Descricao</span>
+          <input
+            type="text"
+            value={form.description}
+            onChange={(event) => setForm((prev) => ({ ...prev, description: event.target.value }))}
+            maxLength={200}
+            required
+          />
+        </label>
+
+        <label>
+          <span>Valor</span>
+          <input
+            type="number"
+            min="0.01"
+            step="0.01"
+            value={form.amount || ""}
+            onChange={(event) => setForm((prev) => ({ ...prev, amount: Number(event.target.value) }))}
+            required
+          />
+        </label>
+
+        <label className="commercial-form__full">
+          <span>Observacoes</span>
+          <textarea
+            rows={3}
+            value={form.notes || ""}
+            onChange={(event) => setForm((prev) => ({ ...prev, notes: event.target.value }))}
+          />
+        </label>
+
+        <button type="submit" className="commercial-btn commercial-btn--primary" disabled={submitting}>
+          {submitting ? "Salvando..." : "Registrar despesa"}
+        </button>
+      </form>
+
+      {loading ? <div className="commercial-feedback">Carregando despesas...</div> : null}
+      {error ? <div className="commercial-feedback commercial-feedback--error">{error}</div> : null}
+
+      {!loading && !error ? (
+        <div className="commercial-table-shell">
+          <table className="commercial-table">
+            <thead>
+              <tr>
+                <th>Data</th>
+                <th>Categoria</th>
+                <th>Descricao</th>
+                <th>Valor</th>
+              </tr>
+            </thead>
+            <tbody>
+              {expenses.map((expense) => (
+                <tr key={expense.id}>
+                  <td>{formatCommercialDate(expense.expenseDate)}</td>
+                  <td>{formatOperationalExpenseCategoryLabel(expense.category)}</td>
+                  <td>
+                    <strong>{expense.description}</strong>
+                    <small>{expense.notes || "-"}</small>
+                  </td>
+                  <td>{formatCommercialCurrency(expense.amount)}</td>
+                </tr>
+              ))}
+              {expenses.length === 0 ? (
+                <tr>
+                  <td colSpan={4}>Nenhuma despesa operacional registrada ainda.</td>
+                </tr>
+              ) : null}
+            </tbody>
+          </table>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/src/Components/commercial/operationalFinance.helpers.test.ts
+++ b/src/Components/commercial/operationalFinance.helpers.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildMonthlyOperationalSummaryCards,
+  formatOperationalExpenseCategoryLabel,
+} from "./operationalFinance.helpers";
+
+describe("operational finance helpers", () => {
+  it("formata categorias e cards do resumo mensal", () => {
+    expect(formatOperationalExpenseCategoryLabel("VETERINARY")).toBe("Servico veterinario");
+
+    const cards = buildMonthlyOperationalSummaryCards({
+      year: 2026,
+      month: 3,
+      totalRevenue: 1780,
+      totalExpenses: 750,
+      balance: 1030,
+      animalSalesRevenue: 1400,
+      milkSalesRevenue: 380,
+      operationalExpensesTotal: 250,
+      inventoryPurchaseCostsTotal: 500,
+    });
+
+    expect(cards[0]).toEqual({ label: "Entrou no mes", value: "R$ 1.780,00" });
+    expect(cards[6]).toEqual({ label: "Compras de estoque", value: "R$ 500,00" });
+  });
+});

--- a/src/Components/commercial/operationalFinance.helpers.ts
+++ b/src/Components/commercial/operationalFinance.helpers.ts
@@ -1,0 +1,40 @@
+import type {
+  MonthlyOperationalSummaryDTO,
+  OperationalExpenseCategory,
+} from "../../Models/CommercialDTOs";
+import { formatCommercialCurrency } from "../../Pages/commercial/commercial.helpers";
+
+export function formatOperationalExpenseCategoryLabel(category: OperationalExpenseCategory): string {
+  switch (category) {
+    case "ENERGY":
+      return "Energia";
+    case "WATER":
+      return "Agua";
+    case "FREIGHT":
+      return "Frete";
+    case "MAINTENANCE":
+      return "Manutencao";
+    case "VETERINARY":
+      return "Servico veterinario";
+    case "FUEL":
+      return "Combustivel";
+    case "LABOR":
+      return "Mao de obra";
+    case "FEES":
+      return "Taxas";
+    default:
+      return "Outras";
+  }
+}
+
+export function buildMonthlyOperationalSummaryCards(summary: MonthlyOperationalSummaryDTO) {
+  return [
+    { label: "Entrou no mes", value: formatCommercialCurrency(summary.totalRevenue) },
+    { label: "Saiu no mes", value: formatCommercialCurrency(summary.totalExpenses) },
+    { label: "Saldo operacional", value: formatCommercialCurrency(summary.balance) },
+    { label: "Vendas de animais recebidas", value: formatCommercialCurrency(summary.animalSalesRevenue) },
+    { label: "Vendas de leite recebidas", value: formatCommercialCurrency(summary.milkSalesRevenue) },
+    { label: "Despesas operacionais", value: formatCommercialCurrency(summary.operationalExpensesTotal) },
+    { label: "Compras de estoque", value: formatCommercialCurrency(summary.inventoryPurchaseCostsTotal) },
+  ];
+}

--- a/src/Models/CommercialDTOs.ts
+++ b/src/Models/CommercialDTOs.ts
@@ -1,5 +1,15 @@
 export type SalePaymentStatus = "OPEN" | "PAID";
 export type ReceivableSourceType = "ANIMAL_SALE" | "MILK_SALE";
+export type OperationalExpenseCategory =
+  | "ENERGY"
+  | "WATER"
+  | "FREIGHT"
+  | "MAINTENANCE"
+  | "VETERINARY"
+  | "FUEL"
+  | "LABOR"
+  | "FEES"
+  | "OTHER";
 
 export interface CustomerRequestDTO {
   name: string;
@@ -95,4 +105,34 @@ export interface CommercialSummaryDTO {
   openReceivablesTotal: number;
   paidReceivablesCount: number;
   paidReceivablesTotal: number;
+}
+
+export interface OperationalExpenseRequestDTO {
+  category: OperationalExpenseCategory;
+  description: string;
+  amount: number;
+  expenseDate: string;
+  notes?: string;
+}
+
+export interface OperationalExpenseResponseDTO {
+  id: number;
+  category: OperationalExpenseCategory;
+  description: string;
+  amount: number;
+  expenseDate: string | number[];
+  notes?: string | null;
+  createdAt?: string | number[] | null;
+}
+
+export interface MonthlyOperationalSummaryDTO {
+  year: number;
+  month: number;
+  totalRevenue: number;
+  totalExpenses: number;
+  balance: number;
+  animalSalesRevenue: number;
+  milkSalesRevenue: number;
+  operationalExpensesTotal: number;
+  inventoryPurchaseCostsTotal: number;
 }

--- a/src/Models/InventoryDTOs.ts
+++ b/src/Models/InventoryDTOs.ts
@@ -74,6 +74,10 @@ export interface InventoryMovementCreateRequestDTO {
   adjustDirection?: InventoryAdjustDirection;
   movementDate?: string;
   reason?: string;
+  unitCost?: number;
+  totalCost?: number;
+  purchaseDate?: string;
+  supplierName?: string;
 }
 
 export interface InventoryMovementResponseDTO {
@@ -84,6 +88,10 @@ export interface InventoryMovementResponseDTO {
   lotId?: number | null;
   movementDate: string;
   resultingBalance: number;
+  unitCost?: number | null;
+  totalCost?: number | null;
+  purchaseDate?: string | null;
+  supplierName?: string | null;
   createdAt: string;
 }
 
@@ -98,6 +106,10 @@ export interface InventoryMovementHistoryEntry {
   movementDate: string;
   reason?: string | null;
   resultingBalance: number;
+  unitCost?: number | null;
+  totalCost?: number | null;
+  purchaseDate?: string | null;
+  supplierName?: string | null;
   createdAt: string;
 }
 

--- a/src/Pages/commercial/CommercialPage.tsx
+++ b/src/Pages/commercial/CommercialPage.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { toast } from "react-toastify";
+import MonthlyOperationalSummarySection from "../../Components/commercial/MonthlyOperationalSummarySection";
+import OperationalExpenseSection from "../../Components/commercial/OperationalExpenseSection";
 import GoatFarmHeader from "../../Components/pages-headers/GoatFarmHeader";
 import { listOperationalAuditEntries } from "../../api/AuditAPI/audit";
 import {
@@ -76,6 +78,7 @@ export default function CommercialPage() {
   const [pageError, setPageError] = useState("");
   const [submitting, setSubmitting] = useState<"customer" | "animalSale" | "milkSale" | null>(null);
   const [paymentSubmittingKey, setPaymentSubmittingKey] = useState<string | null>(null);
+  const [financeReloadToken, setFinanceReloadToken] = useState(0);
 
   const [customerForm, setCustomerForm] = useState<CustomerRequestDTO>({
     name: "",
@@ -290,6 +293,7 @@ export default function CommercialPage() {
       toast.success("Venda de animal registrada com sucesso.");
       setAnimalSaleForm((prev) => ({ ...prev, amount: 0, paymentDate: "", notes: "" }));
       await loadCommercialData();
+      setFinanceReloadToken((current) => current + 1);
     } catch (error) {
       console.error("Comercial: erro ao registrar venda de animal", error);
       toast.error("Nao foi possivel registrar a venda do animal.");
@@ -312,6 +316,7 @@ export default function CommercialPage() {
       toast.success("Venda de leite registrada com sucesso.");
       setMilkSaleForm((prev) => ({ ...prev, quantityLiters: 0, unitPrice: 0, paymentDate: "", notes: "" }));
       await loadCommercialData();
+      setFinanceReloadToken((current) => current + 1);
     } catch (error) {
       console.error("Comercial: erro ao registrar venda de leite", error);
       toast.error("Nao foi possivel registrar a venda de leite.");
@@ -335,6 +340,7 @@ export default function CommercialPage() {
       }
       toast.success("Recebimento registrado com sucesso.");
       await loadCommercialData();
+      setFinanceReloadToken((current) => current + 1);
     } catch (error) {
       console.error("Comercial: erro ao marcar recebivel como pago", error);
       toast.error("Nao foi possivel registrar o recebimento.");
@@ -403,6 +409,8 @@ export default function CommercialPage() {
               <strong>{String(overdueReceivables.length)}</strong>
             </article>
           </section>
+
+          <MonthlyOperationalSummarySection farmId={farmIdNumber} reloadToken={financeReloadToken} />
 
           <section className="commercial-grid">
             <article className="commercial-card">
@@ -585,6 +593,11 @@ export default function CommercialPage() {
               </form>
             </article>
           </section>
+
+          <OperationalExpenseSection
+            farmId={farmIdNumber}
+            onChanged={() => setFinanceReloadToken((current) => current + 1)}
+          />
 
           <section className="commercial-grid commercial-grid--tables">
             <article className="commercial-card">

--- a/src/Pages/commercial/commercialPage.css
+++ b/src/Pages/commercial/commercialPage.css
@@ -43,6 +43,10 @@
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
 }
 
+.commercial-summary-grid--finance {
+  margin-bottom: 18px;
+}
+
 .commercial-grid {
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
 }
@@ -61,6 +65,13 @@
 
 .commercial-card--metric {
   padding: 20px;
+}
+
+.commercial-card--nested {
+  box-shadow: none;
+  border-radius: 18px;
+  background: #f8fafc;
+  padding: 18px;
 }
 
 .commercial-card--metric span {
@@ -107,6 +118,21 @@
   color: #0f766e;
   font-size: 0.85rem;
   font-weight: 700;
+}
+
+.commercial-inline-field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-weight: 600;
+  color: #334155;
+}
+
+.commercial-inline-field input {
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  border-radius: 14px;
+  padding: 10px 12px;
+  background: #f8fafc;
 }
 
 .commercial-form {
@@ -196,6 +222,25 @@
   flex-direction: column;
   gap: 8px;
   min-width: 170px;
+}
+
+.commercial-finance-breakdown {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+}
+
+.commercial-finance-breakdown span {
+  display: block;
+  color: #64748b;
+  font-size: 0.9rem;
+}
+
+.commercial-finance-breakdown strong {
+  display: block;
+  margin-top: 6px;
+  color: #0f172a;
+  font-size: 1.15rem;
 }
 
 .commercial-muted {

--- a/src/Pages/inventory/InventoryPage.tsx
+++ b/src/Pages/inventory/InventoryPage.tsx
@@ -63,6 +63,7 @@ import {
   type InventoryItemFormState,
   type InventoryLotFormState,
 } from "./inventoryPageState";
+import InventoryPurchaseFields from "./InventoryPurchaseFields";
 
 type FieldError = {
   fieldName?: string;
@@ -549,6 +550,14 @@ export default function InventoryPage() {
         return "Direção do ajuste";
       case "quantity":
         return "Quantidade";
+      case "unitCost":
+        return "Custo unitario";
+      case "totalCost":
+        return "Custo total";
+      case "purchaseDate":
+        return "Data da compra";
+      case "supplierName":
+        return "Fornecedor";
       default:
         return fieldName ?? null;
     }
@@ -605,6 +614,13 @@ export default function InventoryPage() {
 
     if (key === "type" && value !== "ADJUST") {
       nextForm.adjustDirection = "";
+    }
+
+    if (key === "type" && value !== "IN") {
+      nextForm.unitCost = "";
+      nextForm.totalCost = "";
+      nextForm.purchaseDate = new Date().toISOString().slice(0, 10);
+      nextForm.supplierName = "";
     }
 
     setForm(nextForm);
@@ -1517,6 +1533,13 @@ export default function InventoryPage() {
                   />
                   {renderFieldFeedback("reason")}
                 </div>
+
+                <InventoryPurchaseFields
+                  form={form}
+                  disabled={submitting || !canManageInventory}
+                  onChange={(field, value) => updateField(field, value)}
+                  renderFieldFeedback={renderFieldFeedback}
+                />
               </div>
 
               <div className="d-flex gap-2 flex-wrap mt-4">
@@ -2038,6 +2061,13 @@ export default function InventoryPage() {
                           <div className="fw-semibold">{entry.itemName}</div>
                           {entry.reason && (
                             <div className="small text-muted">{entry.reason}</div>
+                          )}
+                          {entry.totalCost != null && (
+                            <div className="small text-muted">
+                              Compra: R$ {Number(entry.totalCost).toLocaleString("pt-BR", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                              {entry.unitCost != null ? ` • unit. R$ ${Number(entry.unitCost).toLocaleString("pt-BR", { minimumFractionDigits: 2, maximumFractionDigits: 4 })}` : ""}
+                              {entry.supplierName ? ` • ${entry.supplierName}` : ""}
+                            </div>
                           )}
                         </td>
                         <td>{getLotDisplay(entry.lotId)}</td>

--- a/src/Pages/inventory/InventoryPurchaseFields.tsx
+++ b/src/Pages/inventory/InventoryPurchaseFields.tsx
@@ -1,0 +1,92 @@
+import type { ReactNode } from "react";
+import type { InventoryFormState } from "./inventoryPageState";
+
+type PurchaseFieldKey = "unitCost" | "totalCost" | "purchaseDate" | "supplierName";
+
+type InventoryPurchaseFieldsProps = {
+  form: InventoryFormState;
+  disabled: boolean;
+  onChange: (field: PurchaseFieldKey, value: string) => void;
+  renderFieldFeedback: (fieldName: string) => ReactNode;
+};
+
+export default function InventoryPurchaseFields({
+  form,
+  disabled,
+  onChange,
+  renderFieldFeedback,
+}: InventoryPurchaseFieldsProps) {
+  if (form.type !== "IN") {
+    return null;
+  }
+
+  return (
+    <>
+      <div className="col-12">
+        <div className="alert alert-light border mb-0" role="note">
+          Preencha os dados de compra apenas quando esta entrada representar aquisicao de estoque.
+        </div>
+      </div>
+
+      <div className="col-12 col-md-6">
+        <label className="form-label" htmlFor="inventory-unit-cost">Custo unitario</label>
+        <input
+          id="inventory-unit-cost"
+          className={`form-control ${renderFieldFeedback("unitCost") ? "is-invalid" : ""}`}
+          type="number"
+          min="0.0001"
+          step="0.0001"
+          value={form.unitCost}
+          onChange={(event) => onChange("unitCost", event.target.value)}
+          disabled={disabled}
+          placeholder="Ex.: 18,5000"
+        />
+        {renderFieldFeedback("unitCost")}
+      </div>
+
+      <div className="col-12 col-md-6">
+        <label className="form-label" htmlFor="inventory-total-cost">Custo total</label>
+        <input
+          id="inventory-total-cost"
+          className={`form-control ${renderFieldFeedback("totalCost") ? "is-invalid" : ""}`}
+          type="number"
+          min="0.01"
+          step="0.01"
+          value={form.totalCost}
+          onChange={(event) => onChange("totalCost", event.target.value)}
+          disabled={disabled}
+          placeholder="Ex.: 185,00"
+        />
+        {renderFieldFeedback("totalCost")}
+      </div>
+
+      <div className="col-12 col-md-6">
+        <label className="form-label" htmlFor="inventory-purchase-date">Data da compra</label>
+        <input
+          id="inventory-purchase-date"
+          className={`form-control ${renderFieldFeedback("purchaseDate") ? "is-invalid" : ""}`}
+          type="date"
+          value={form.purchaseDate}
+          onChange={(event) => onChange("purchaseDate", event.target.value)}
+          disabled={disabled}
+        />
+        {renderFieldFeedback("purchaseDate")}
+      </div>
+
+      <div className="col-12 col-md-6">
+        <label className="form-label" htmlFor="inventory-supplier-name">Fornecedor</label>
+        <input
+          id="inventory-supplier-name"
+          className={`form-control ${renderFieldFeedback("supplierName") ? "is-invalid" : ""}`}
+          type="text"
+          maxLength={120}
+          value={form.supplierName}
+          onChange={(event) => onChange("supplierName", event.target.value)}
+          disabled={disabled}
+          placeholder="Ex.: Casa do Campo"
+        />
+        {renderFieldFeedback("supplierName")}
+      </div>
+    </>
+  );
+}

--- a/src/Pages/inventory/inventoryPageState.purchase-cost.test.ts
+++ b/src/Pages/inventory/inventoryPageState.purchase-cost.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { buildInitialForm, buildPayloadFromForm } from "./inventoryPageState";
+
+describe("inventoryPageState purchase cost", () => {
+  it("gera payload com dados de compra quando a entrada for IN", () => {
+    const form = {
+      ...buildInitialForm(),
+      type: "IN" as const,
+      quantity: "10",
+      movementDate: "2026-03-28",
+      reason: "Compra de racao",
+      unitCost: "18.5",
+      totalCost: "185",
+      purchaseDate: "2026-03-28",
+      supplierName: "Casa do Campo",
+    };
+
+    const result = buildPayloadFromForm({
+      form,
+      selectedItemId: "101",
+      selectedTrackLot: false,
+    });
+
+    expect(result.payload).toEqual({
+      type: "IN",
+      quantity: 10,
+      itemId: 101,
+      movementDate: "2026-03-28",
+      reason: "Compra de racao",
+      unitCost: 18.5,
+      totalCost: 185,
+      purchaseDate: "2026-03-28",
+      supplierName: "Casa do Campo",
+    });
+  });
+
+  it("bloqueia custo de compra fora de entrada", () => {
+    const form = {
+      ...buildInitialForm(),
+      type: "OUT" as const,
+      quantity: "4",
+      unitCost: "10",
+      totalCost: "",
+      purchaseDate: "2026-03-28",
+      supplierName: "",
+    };
+
+    const result = buildPayloadFromForm({
+      form,
+      selectedItemId: "101",
+      selectedTrackLot: false,
+    });
+
+    expect(result.error).toBe("Custo de compra só pode ser informado em entradas de estoque.");
+  });
+});

--- a/src/Pages/inventory/inventoryPageState.ts
+++ b/src/Pages/inventory/inventoryPageState.ts
@@ -1,4 +1,4 @@
-import type {
+﻿import type {
   InventoryAdjustDirection,
   InventoryItemCreateRequest,
   InventoryLotCreateRequest,
@@ -13,6 +13,10 @@ export type InventoryFormState = {
   adjustDirection: InventoryAdjustDirection | "";
   movementDate: string;
   reason: string;
+  unitCost: string;
+  totalCost: string;
+  purchaseDate: string;
+  supplierName: string;
 };
 
 export type InventoryItemFormState = {
@@ -41,6 +45,10 @@ export const buildInitialForm = (): InventoryFormState => ({
   adjustDirection: "",
   movementDate: new Date().toISOString().slice(0, 10),
   reason: "",
+  unitCost: "",
+  totalCost: "",
+  purchaseDate: new Date().toISOString().slice(0, 10),
+  supplierName: "",
 });
 
 export const buildInitialItemForm = (): InventoryItemFormState => ({
@@ -64,6 +72,10 @@ export const mapPayloadToForm = (
   adjustDirection: payload.type === "ADJUST" ? payload.adjustDirection ?? "" : "",
   movementDate: payload.movementDate ?? new Date().toISOString().slice(0, 10),
   reason: payload.reason ?? "",
+  unitCost: payload.unitCost != null ? `${payload.unitCost}` : "",
+  totalCost: payload.totalCost != null ? `${payload.totalCost}` : "",
+  purchaseDate: payload.purchaseDate ?? new Date().toISOString().slice(0, 10),
+  supplierName: payload.supplierName ?? "",
 });
 
 export const parsePositiveNumber = (value: string): number | null => {
@@ -94,8 +106,14 @@ export const buildPayloadFromForm = ({
   const quantity = parsePositiveNumber(form.quantity);
   const itemId = parsePositiveNumber(selectedItemId);
   const requiresLotId = shouldRequireLotId(selectedTrackLot);
-  const hasLotIdValue = Boolean(form.lotId.trim());
-  const rawLotId = hasLotIdValue ? parsePositiveNumber(form.lotId) : undefined;
+  const lotIdText = form.lotId?.trim() ?? "";
+  const reasonText = form.reason?.trim() ?? "";
+  const unitCostText = form.unitCost?.trim() ?? "";
+  const totalCostText = form.totalCost?.trim() ?? "";
+  const purchaseDateText = form.purchaseDate?.trim() ?? "";
+  const supplierNameText = form.supplierName?.trim() ?? "";
+  const hasLotIdValue = Boolean(lotIdText);
+  const rawLotId = hasLotIdValue ? parsePositiveNumber(lotIdText) : undefined;
   const lotId = requiresLotId ? rawLotId : undefined;
 
   if (itemId == null) {
@@ -118,6 +136,34 @@ export const buildPayloadFromForm = ({
     return { error: "Selecione a direção do ajuste." };
   }
 
+  const hasPurchaseDetails = Boolean(
+    unitCostText || totalCostText || purchaseDateText || supplierNameText
+  );
+  const unitCost = unitCostText ? parsePositiveNumber(unitCostText) : null;
+  const totalCost = totalCostText ? parsePositiveNumber(totalCostText) : null;
+
+  if (hasPurchaseDetails) {
+    if (form.type !== "IN") {
+      return { error: "Custo de compra só pode ser informado em entradas de estoque." };
+    }
+
+    if (!purchaseDateText) {
+      return { error: "Informe a data da compra." };
+    }
+
+    if (unitCost == null && totalCost == null) {
+      return { error: "Informe o custo unitário ou o custo total da compra." };
+    }
+
+    if (unitCostText && unitCost == null) {
+      return { error: "Informe um custo unitário válido." };
+    }
+
+    if (totalCostText && totalCost == null) {
+      return { error: "Informe um custo total válido." };
+    }
+  }
+
   return {
     payload: {
       type: form.type,
@@ -128,7 +174,13 @@ export const buildPayloadFromForm = ({
         ? { adjustDirection: form.adjustDirection }
         : {}),
       ...(form.movementDate ? { movementDate: form.movementDate } : {}),
-      ...(form.reason.trim() ? { reason: form.reason.trim() } : {}),
+      ...(reasonText ? { reason: reasonText } : {}),
+      ...(hasPurchaseDetails && unitCost != null ? { unitCost } : {}),
+      ...(hasPurchaseDetails && totalCost != null ? { totalCost } : {}),
+      ...(hasPurchaseDetails && purchaseDateText ? { purchaseDate: purchaseDateText } : {}),
+      ...(hasPurchaseDetails && supplierNameText
+        ? { supplierName: supplierNameText }
+        : {}),
     },
   };
 };

--- a/src/api/CommercialAPI/commercial.operational-finance.test.ts
+++ b/src/api/CommercialAPI/commercial.operational-finance.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { requestBackEnd } from "../../utils/request";
+import {
+  createOperationalExpense,
+  fetchMonthlyOperationalSummary,
+  listOperationalExpenses,
+} from "./commercial";
+
+vi.mock("../../utils/request", () => ({
+  requestBackEnd: {
+    get: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+  },
+}));
+
+describe("Commercial API operational finance", () => {
+  const mockedGet = vi.mocked(requestBackEnd.get);
+  const mockedPost = vi.mocked(requestBackEnd.post);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("cria despesa operacional na rota comercial da fazenda", async () => {
+    mockedPost.mockResolvedValueOnce({
+      data: {
+        id: 1,
+        category: "ENERGY",
+        description: "Conta de luz",
+        amount: 210,
+        expenseDate: "2026-03-28",
+        notes: "Marco",
+      },
+    });
+
+    const result = await createOperationalExpense(17, {
+      category: "ENERGY",
+      description: "Conta de luz",
+      amount: 210,
+      expenseDate: "2026-03-28",
+      notes: "Marco",
+    });
+
+    expect(mockedPost).toHaveBeenCalledWith("/goatfarms/17/commercial/operational-expenses", {
+      category: "ENERGY",
+      description: "Conta de luz",
+      amount: 210,
+      expenseDate: "2026-03-28",
+      notes: "Marco",
+    });
+    expect(result.id).toBe(1);
+  });
+
+  it("lista despesas e resumo mensal da rota comercial", async () => {
+    mockedGet
+      .mockResolvedValueOnce({
+        data: [
+          {
+            id: 1,
+            category: "ENERGY",
+            description: "Conta de luz",
+            amount: 210,
+            expenseDate: "2026-03-28",
+            notes: null,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        data: {
+          year: 2026,
+          month: 3,
+          totalRevenue: 1780,
+          totalExpenses: 750,
+          balance: 1030,
+          animalSalesRevenue: 1400,
+          milkSalesRevenue: 380,
+          operationalExpensesTotal: 250,
+          inventoryPurchaseCostsTotal: 500,
+        },
+      });
+
+    const expenses = await listOperationalExpenses(17);
+    const summary = await fetchMonthlyOperationalSummary(17, 2026, 3);
+
+    expect(mockedGet).toHaveBeenNthCalledWith(1, "/goatfarms/17/commercial/operational-expenses");
+    expect(mockedGet).toHaveBeenNthCalledWith(2, "/goatfarms/17/commercial/monthly-summary", {
+      params: { year: 2026, month: 3 },
+    });
+    expect(expenses).toHaveLength(1);
+    expect(summary.balance).toBe(1030);
+  });
+});

--- a/src/api/CommercialAPI/commercial.ts
+++ b/src/api/CommercialAPI/commercial.ts
@@ -6,6 +6,9 @@ import type {
   CustomerResponseDTO,
   MilkSaleRequestDTO,
   MilkSaleResponseDTO,
+  MonthlyOperationalSummaryDTO,
+  OperationalExpenseRequestDTO,
+  OperationalExpenseResponseDTO,
   ReceivableResponseDTO,
   SalePaymentRequestDTO,
 } from "../../Models/CommercialDTOs";
@@ -83,4 +86,31 @@ export async function listReceivables(farmId: number): Promise<ReceivableRespons
 export async function fetchCommercialSummary(farmId: number): Promise<CommercialSummaryDTO> {
   const { data } = await requestBackEnd.get(`${basePath(farmId)}/summary`);
   return unwrap<CommercialSummaryDTO>(data);
+}
+
+export async function createOperationalExpense(
+  farmId: number,
+  payload: OperationalExpenseRequestDTO
+): Promise<OperationalExpenseResponseDTO> {
+  const { data } = await requestBackEnd.post(`${basePath(farmId)}/operational-expenses`, payload);
+  return unwrap<OperationalExpenseResponseDTO>(data);
+}
+
+export async function listOperationalExpenses(
+  farmId: number
+): Promise<OperationalExpenseResponseDTO[]> {
+  const { data } = await requestBackEnd.get(`${basePath(farmId)}/operational-expenses`);
+  const body = unwrap<OperationalExpenseResponseDTO[] | { content?: OperationalExpenseResponseDTO[] }>(data);
+  return Array.isArray(body) ? body : body.content ?? [];
+}
+
+export async function fetchMonthlyOperationalSummary(
+  farmId: number,
+  year: number,
+  month: number
+): Promise<MonthlyOperationalSummaryDTO> {
+  const { data } = await requestBackEnd.get(`${basePath(farmId)}/monthly-summary`, {
+    params: { year, month },
+  });
+  return unwrap<MonthlyOperationalSummaryDTO>(data);
 }

--- a/src/api/GoatFarmAPI/inventory.ts
+++ b/src/api/GoatFarmAPI/inventory.ts
@@ -85,6 +85,10 @@ export const normalizeInventoryMovementPayload = (
   ...(request.adjustDirection ? { adjustDirection: request.adjustDirection } : {}),
   ...(request.movementDate ? { movementDate: request.movementDate } : {}),
   ...(request.reason?.trim() ? { reason: request.reason.trim() } : {}),
+  ...(request.unitCost != null ? { unitCost: request.unitCost } : {}),
+  ...(request.totalCost != null ? { totalCost: request.totalCost } : {}),
+  ...(request.purchaseDate ? { purchaseDate: request.purchaseDate } : {}),
+  ...(request.supplierName?.trim() ? { supplierName: request.supplierName.trim() } : {}),
 });
 
 export const createInventoryPayloadHash = (


### PR DESCRIPTION
## Resumo
- adiciona secao de resumo mensal simples na pagina comercial
- adiciona formulario e listagem de despesas operacionais
- adiciona suporte a custo de compra na entrada de estoque
- preserva a estrutura visual atual sem abrir dashboard nova

## Validacao
- `npm test -- --run`
- `npm run build`
- `npm run lint`
- `npm run test:e2e`
- smoke real com frontend conectado ao backend local

## Smoke real executado
- pagina comercial exibindo resumo mensal do capril de testes
- cliente e despesa QA visiveis na UI
- pagina de estoque exibindo o fluxo de entrada com campos de custo (`unitCost`, `totalCost`, `purchaseDate`, `supplierName`)

## Observacoes
- repositório frontend segue sem `origin/develop`, entao a promocao segura permanece `feature -> main`