### PR TITLE
Feat: surface operational health withdrawal alerts

### DIFF
--- a/src/Components/goat-operational-history/GoatOperationalHistoryPanel.tsx
+++ b/src/Components/goat-operational-history/GoatOperationalHistoryPanel.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
+import { healthAPI } from "../../api/GoatFarmAPI/health";
 import { listOperationalAuditEntries } from "../../api/AuditAPI/audit";
 import { listGoatOffspring, type GoatExitType } from "../../api/GoatAPI/goat";
 import {
   listPregnancies,
   listReproductiveEvents,
 } from "../../api/GoatFarmAPI/reproduction";
+import type { GoatWithdrawalStatusDTO } from "../../Models/HealthDTOs";
 import type { OperationalAuditEntryDTO } from "../../Models/OperationalAuditDTOs";
 import type { GoatResponseDTO } from "../../Models/goatResponseDTO";
 import type {
@@ -40,6 +42,7 @@ export default function GoatOperationalHistoryPanel({
   const [pregnancies, setPregnancies] = useState<PregnancyResponseDTO[]>([]);
   const [offspring, setOffspring] = useState<GoatResponseDTO[]>([]);
   const [auditEntries, setAuditEntries] = useState<OperationalAuditEntryDTO[]>([]);
+  const [withdrawalStatus, setWithdrawalStatus] = useState<GoatWithdrawalStatusDTO | null>(null);
   const [loading, setLoading] = useState(false);
   const [warning, setWarning] = useState<string | null>(null);
 
@@ -49,27 +52,49 @@ export default function GoatOperationalHistoryPanel({
     const load = async () => {
       setLoading(true);
       setWarning(null);
-      const [eventsResult, pregnanciesResult, offspringResult, auditResult] =
+      const [eventsResult, pregnanciesResult, offspringResult, auditResult, withdrawalResult] =
         await Promise.allSettled([
           listReproductiveEvents(farmId, goat.registrationNumber, { page: 0, size: 50 }),
           listPregnancies(farmId, goat.registrationNumber, { page: 0, size: 50 }),
           listGoatOffspring(farmId, goat.registrationNumber),
           listOperationalAuditEntries(farmId, { goatId: goat.registrationNumber, limit: 20 }),
+          healthAPI.getWithdrawalStatus(farmId, goat.registrationNumber),
         ]);
 
       if (cancelled) return;
 
       const failed: string[] = [];
       if (eventsResult.status === "fulfilled") setEvents(eventsResult.value.content ?? []);
-      else { setEvents([]); failed.push("eventos reprodutivos"); }
+      else {
+        setEvents([]);
+        failed.push("eventos reprodutivos");
+      }
       if (pregnanciesResult.status === "fulfilled") setPregnancies(pregnanciesResult.value.content ?? []);
-      else { setPregnancies([]); failed.push("gestacoes"); }
+      else {
+        setPregnancies([]);
+        failed.push("gestacoes");
+      }
       if (offspringResult.status === "fulfilled") setOffspring(offspringResult.value);
-      else { setOffspring([]); failed.push("crias vinculadas"); }
-      if (auditResult && auditResult.status === "fulfilled") setAuditEntries(auditResult.value);
-      else { setAuditEntries([]); failed.push("auditoria operacional"); }
+      else {
+        setOffspring([]);
+        failed.push("crias vinculadas");
+      }
+      if (auditResult.status === "fulfilled") setAuditEntries(auditResult.value);
+      else {
+        setAuditEntries([]);
+        failed.push("auditoria operacional");
+      }
+      if (withdrawalResult.status === "fulfilled") setWithdrawalStatus(withdrawalResult.value);
+      else {
+        setWithdrawalStatus(null);
+        failed.push("carencia sanitaria");
+      }
 
-      setWarning(failed.length ? `Parte do historico nao pode ser carregada agora (${failed.join(", ")}).` : null);
+      setWarning(
+        failed.length
+          ? `Parte do historico nao pode ser carregada agora (${failed.join(", ")}).`
+          : null
+      );
       setLoading(false);
     };
 
@@ -84,26 +109,64 @@ export default function GoatOperationalHistoryPanel({
     [auditEntries, events, goat, pregnancies]
   );
   const lastCoverage = useMemo(
-    () => events.filter((item) => item.eventType === "COVERAGE").map((item) => item.eventDate).sort((a, b) => b.localeCompare(a))[0] ?? null,
+    () =>
+      events
+        .filter((item) => item.eventType === "COVERAGE")
+        .map((item) => item.eventDate)
+        .sort((a, b) => b.localeCompare(a))[0] ?? null,
     [events]
   );
   const lastWeaning = useMemo(
-    () => events.filter((item) => item.eventType === "WEANING").map((item) => item.eventDate).sort((a, b) => b.localeCompare(a))[0] ?? null,
+    () =>
+      events
+        .filter((item) => item.eventType === "WEANING")
+        .map((item) => item.eventDate)
+        .sort((a, b) => b.localeCompare(a))[0] ?? null,
     [events]
   );
   const lastBirth = useMemo(
-    () => pregnancies.filter((item) => item.closeReason === "BIRTH" && item.closeDate).map((item) => item.closeDate as string).sort((a, b) => b.localeCompare(a))[0] ?? null,
+    () =>
+      pregnancies
+        .filter((item) => item.closeReason === "BIRTH" && item.closeDate)
+        .map((item) => item.closeDate as string)
+        .sort((a, b) => b.localeCompare(a))[0] ?? null,
     [pregnancies]
   );
   const activePregnancy = pregnancies.find((item) => item.status === "ACTIVE") ?? null;
-  const isOperationallyActive = ["ATIVO", "ACTIVE"].includes(String(goat.status ?? "").trim().toUpperCase());
+  const isOperationallyActive = ["ATIVO", "ACTIVE"].includes(
+    String(goat.status ?? "").trim().toUpperCase()
+  );
+  const hasActiveWithdrawal =
+    withdrawalStatus?.hasActiveMilkWithdrawal || withdrawalStatus?.hasActiveMeatWithdrawal;
 
   return (
     <div className="animal-operational-history">
-      <section className={`animal-status-banner ${isOperationallyActive ? "animal-status-banner--active" : "animal-status-banner--inactive"}`}>
+      <section
+        className={`animal-status-banner ${
+          isOperationallyActive ? "animal-status-banner--active" : "animal-status-banner--inactive"
+        }`}
+      >
         <strong>{isOperationallyActive ? "Animal em operacao" : "Animal fora de operacao"}</strong>
-        <span>{isOperationallyActive ? "Fluxos de manejo e reproducao seguem liberados conforme permissoes e regras do dominio." : `Status atual: ${String(goat.status ?? "-")}. Escritas operacionais ficam bloqueadas.`}</span>
+        <span>
+          {isOperationallyActive
+            ? "Fluxos de manejo e reproducao seguem liberados conforme permissoes e regras do dominio."
+            : `Status atual: ${String(goat.status ?? "-")}. Escritas operacionais ficam bloqueadas.`}
+        </span>
       </section>
+
+      {hasActiveWithdrawal ? (
+        <section className="animal-status-banner animal-status-banner--inactive">
+          <strong>Carencia sanitaria ativa</strong>
+          <span>
+            {withdrawalStatus?.hasActiveMilkWithdrawal && withdrawalStatus.milkWithdrawal
+              ? `Leite bloqueado ate ${formatDate(withdrawalStatus.milkWithdrawal.withdrawalEndDate)} por ${withdrawalStatus.milkWithdrawal.productName || withdrawalStatus.milkWithdrawal.title || "tratamento sanitario"}. `
+              : ""}
+            {withdrawalStatus?.hasActiveMeatWithdrawal && withdrawalStatus.meatWithdrawal
+              ? `Carne em carencia ate ${formatDate(withdrawalStatus.meatWithdrawal.withdrawalEndDate)} por ${withdrawalStatus.meatWithdrawal.productName || withdrawalStatus.meatWithdrawal.title || "tratamento sanitario"}.`
+              : ""}
+          </span>
+        </section>
+      ) : null}
 
       <section className="animal-cycle-grid" aria-label="Resumo operacional do ciclo">
         <article className="animal-cycle-card"><span className="animal-cycle-card__label">Situacao operacional</span><strong>{String(goat.status ?? "-")}</strong><small>{activePregnancy ? `Gestacao ativa desde ${formatDate(activePregnancy.confirmDate)}` : "Sem gestacao ativa aberta no historico local."}</small></article>
@@ -125,6 +188,33 @@ export default function GoatOperationalHistoryPanel({
           </ol>
         ) : <div className="animal-history-panel__empty">Ainda nao ha marcos suficientes para compor o historico operacional deste animal.</div>}
         {warning ? <p className="animal-history-panel__warning">{warning}</p> : null}
+      </section>
+
+      <section className="animal-history-panel">
+        <div className="animal-history-panel__header">
+          <div>
+            <span className="animal-history-panel__eyebrow">Sanidade</span>
+            <h3>Carencia operacional</h3>
+          </div>
+          <span className="animal-history-panel__meta">
+            {hasActiveWithdrawal ? "Ativa" : "Sem carencia ativa"}
+          </span>
+        </div>
+        {withdrawalStatus?.hasActiveMilkWithdrawal && withdrawalStatus.milkWithdrawal ? (
+          <div className="animal-history-panel__empty">
+            Carencia de leite ate {formatDate(withdrawalStatus.milkWithdrawal.withdrawalEndDate)} por {withdrawalStatus.milkWithdrawal.productName || withdrawalStatus.milkWithdrawal.title || "tratamento sanitario"}.
+          </div>
+        ) : null}
+        {withdrawalStatus?.hasActiveMeatWithdrawal && withdrawalStatus.meatWithdrawal ? (
+          <div className="animal-history-panel__empty">
+            Carencia de carne ate {formatDate(withdrawalStatus.meatWithdrawal.withdrawalEndDate)} por {withdrawalStatus.meatWithdrawal.productName || withdrawalStatus.meatWithdrawal.title || "tratamento sanitario"}.
+          </div>
+        ) : null}
+        {!hasActiveWithdrawal ? (
+          <div className="animal-history-panel__empty">
+            Nenhuma carencia sanitaria ativa para este animal na data de referencia.
+          </div>
+        ) : null}
       </section>
 
       <section className="animal-history-panel">

--- a/src/Models/HealthAlertsDTO.ts
+++ b/src/Models/HealthAlertsDTO.ts
@@ -1,11 +1,26 @@
 import { HealthEventResponseDTO } from "./HealthDTOs";
 
+export interface WithdrawalAlertItemDTO {
+  eventId: number;
+  goatId: string;
+  title?: string;
+  productName?: string;
+  activeIngredient?: string;
+  performedDate?: string;
+  withdrawalEndDate: string;
+  daysRemaining: number;
+}
+
 export interface HealthAlertsDTO {
   dueTodayCount: number;
   upcomingCount: number;
   overdueCount: number;
+  activeMilkWithdrawalCount: number;
+  activeMeatWithdrawalCount: number;
   
   dueTodayTop: HealthEventResponseDTO[];
   upcomingTop: HealthEventResponseDTO[];
   overdueTop: HealthEventResponseDTO[];
+  milkWithdrawalTop: WithdrawalAlertItemDTO[];
+  meatWithdrawalTop: WithdrawalAlertItemDTO[];
 }

--- a/src/Models/HealthDTOs.ts
+++ b/src/Models/HealthDTOs.ts
@@ -95,7 +95,30 @@ export interface HealthEventResponseDTO {
   batchNumber?: string;
   withdrawalMilkDays?: number;
   withdrawalMeatDays?: number;
+  milkWithdrawalEndDate?: string;
+  milkWithdrawalActive: boolean;
+  meatWithdrawalEndDate?: string;
+  meatWithdrawalActive: boolean;
   createdAt?: string;
   updatedAt?: string;
   overdue: boolean;
+}
+
+export interface HealthWithdrawalOriginDTO {
+  eventId: number;
+  title?: string;
+  productName?: string;
+  activeIngredient?: string;
+  batchNumber?: string;
+  performedDate?: string;
+  withdrawalEndDate?: string;
+}
+
+export interface GoatWithdrawalStatusDTO {
+  goatId: string;
+  referenceDate?: string;
+  hasActiveMilkWithdrawal: boolean;
+  hasActiveMeatWithdrawal: boolean;
+  milkWithdrawal?: HealthWithdrawalOriginDTO | null;
+  meatWithdrawal?: HealthWithdrawalOriginDTO | null;
 }

--- a/src/Pages/dashboard/FarmDashboardPage.tsx
+++ b/src/Pages/dashboard/FarmDashboardPage.tsx
@@ -116,6 +116,20 @@ const buildAgendaEntries = (healthAlerts: HealthAlertsDTO | null): FarmAgendaEnt
   });
 
   return [
+    ...(healthAlerts.milkWithdrawalTop || []).map((item) => ({
+      title: "Carência de leite ativa",
+      goatId: item.goatId,
+      scheduledDate: item.withdrawalEndDate,
+      badge: "Carência leite",
+      tone: "overdue" as const,
+    })),
+    ...(healthAlerts.meatWithdrawalTop || []).map((item) => ({
+      title: "Carência de carne ativa",
+      goatId: item.goatId,
+      scheduledDate: item.withdrawalEndDate,
+      badge: "Carência carne",
+      tone: "upcoming" as const,
+    })),
     ...healthAlerts.dueTodayTop.map((event) => mapEvent(event, "Hoje", "today")),
     ...healthAlerts.overdueTop.map((event) => mapEvent(event, "Atrasado", "overdue")),
     ...healthAlerts.upcomingTop.map((event) => mapEvent(event, "Próximo", "upcoming")),
@@ -133,6 +147,8 @@ const buildAttentionItems = (data: FarmDashboardData | null): string[] => {
   const dueToday = data.healthAlerts?.dueTodayCount ?? 0;
   const overdue = data.healthAlerts?.overdueCount ?? 0;
   const upcoming = data.healthAlerts?.upcomingCount ?? 0;
+  const milkWithdrawal = data.healthAlerts?.activeMilkWithdrawalCount ?? 0;
+  const meatWithdrawal = data.healthAlerts?.activeMeatWithdrawalCount ?? 0;
   const inactive = data.herdSummary?.inactive ?? 0;
   const sold = data.herdSummary?.sold ?? 0;
   const deceased = data.herdSummary?.deceased ?? 0;
@@ -158,6 +174,18 @@ const buildAttentionItems = (data: FarmDashboardData | null): string[] => {
   if (overdue > 0) {
     items.push(
       `${formatCount(overdue)} evento${overdue === 1 ? "" : "s"} sanitário${overdue === 1 ? "" : "s"} atrasado${overdue === 1 ? "" : "s"}.`
+    );
+  }
+
+  if (milkWithdrawal > 0) {
+    items.push(
+      `${formatCount(milkWithdrawal)} animal${milkWithdrawal === 1 ? "" : "is"} em carência de leite ativa.`
+    );
+  }
+
+  if (meatWithdrawal > 0) {
+    items.push(
+      `${formatCount(meatWithdrawal)} animal${meatWithdrawal === 1 ? "" : "is"} em carência de carne ativa.`
     );
   }
 
@@ -199,16 +227,24 @@ export function FarmDashboardPageView({
   const healthDueToday = data?.healthAlerts?.dueTodayCount ?? 0;
   const healthOverdue = data?.healthAlerts?.overdueCount ?? 0;
   const healthUpcoming = data?.healthAlerts?.upcomingCount ?? 0;
+  const healthMilkWithdrawal = data?.healthAlerts?.activeMilkWithdrawalCount ?? 0;
+  const healthMeatWithdrawal = data?.healthAlerts?.activeMeatWithdrawalCount ?? 0;
   const reproductionHigh =
     data?.reproductionAlerts?.alerts?.filter((item) => item.daysOverdue > 0).length ?? 0;
   const reproductionMedium = Math.max(reproductionPending - reproductionHigh, 0);
   const lactationHigh =
     data?.lactationAlerts?.alerts?.filter((item) => item.daysOverdue > 0).length ?? 0;
   const lactationMedium = Math.max(lactationPending - lactationHigh, 0);
-  const highSeverityCount = reproductionHigh + lactationHigh + healthOverdue;
-  const mediumSeverityCount = reproductionMedium + lactationMedium + healthDueToday;
+  const highSeverityCount = reproductionHigh + lactationHigh + healthOverdue + healthMilkWithdrawal;
+  const mediumSeverityCount = reproductionMedium + lactationMedium + healthDueToday + healthMeatWithdrawal;
   const lowSeverityCount = healthUpcoming;
-  const totalAttention = reproductionPending + lactationPending + healthDueToday + healthOverdue;
+  const totalAttention =
+    reproductionPending +
+    lactationPending +
+    healthDueToday +
+    healthOverdue +
+    healthMilkWithdrawal +
+    healthMeatWithdrawal;
   const agendaEntries = useMemo(() => buildAgendaEntries(data?.healthAlerts ?? null), [data?.healthAlerts]);
   const attentionItems = useMemo(() => buildAttentionItems(data), [data]);
   const breeds = herdSummary?.breeds?.slice(0, 3) ?? [];

--- a/src/Pages/health/HealthEventDetailPage.tsx
+++ b/src/Pages/health/HealthEventDetailPage.tsx
@@ -27,11 +27,11 @@ export default function HealthEventDetailPage() {
   const [showReopenModal, setShowReopenModal] = useState(false);
 
   const EVENT_TYPE_LABELS: Record<string, string> = {
-    [HealthEventType.VACINA]: "Vacinação",
-    [HealthEventType.VERMIFUGACAO]: "Vermifugação",
-    [HealthEventType.MEDICACAO]: "Medicação",
+    [HealthEventType.VACINA]: "VacinaÃ§Ã£o",
+    [HealthEventType.VERMIFUGACAO]: "VermifugaÃ§Ã£o",
+    [HealthEventType.MEDICACAO]: "MedicaÃ§Ã£o",
     [HealthEventType.PROCEDIMENTO]: "Procedimento",
-    [HealthEventType.DOENCA]: "Doença/Ocorrência",
+    [HealthEventType.DOENCA]: "DoenÃ§a/OcorrÃªncia",
   };
 
   const STATUS_LABELS: Record<string, string> = {
@@ -58,8 +58,8 @@ export default function HealthEventDetailPage() {
     try {
       setLoading(true);
 
-      // Executa requisições em paralelo para maior eficiência e robustez
-      // Assumimos que o goatId da URL é o ID correto para a API
+      // Executa requisiÃ§Ãµes em paralelo para maior eficiÃªncia e robustez
+      // Assumimos que o goatId da URL Ã© o ID correto para a API
       const goatPromise = fetchGoatById(Number(farmId), goatId)
         .catch(() => {
           return null;
@@ -81,8 +81,8 @@ export default function HealthEventDetailPage() {
       setEvent(eventData);
       setFarmData(farmResult);
       
-      // Cabra é opcional para exibir o evento, mas útil para o contexto
-      // Se falhou ao carregar cabra, podemos tentar usar dados do evento se disponíveis, ou deixar null
+      // Cabra Ã© opcional para exibir o evento, mas Ãºtil para o contexto
+      // Se falhou ao carregar cabra, podemos tentar usar dados do evento se disponÃ­veis, ou deixar null
     } catch (error: unknown) {
       const status = typeof error === "object" && error !== null && "response" in error
         ? (error as { response?: { status?: number } }).response?.status
@@ -90,7 +90,7 @@ export default function HealthEventDetailPage() {
       if (status === 403) {
         toast.error("Acesso negado.");
       } else if (status === 404) {
-        toast.error("Evento não encontrado.");
+        toast.error("Evento nÃ£o encontrado.");
       } else {
         toast.error("Erro ao carregar detalhes do evento.");
       }
@@ -154,7 +154,7 @@ export default function HealthEventDetailPage() {
         ? (error as { response?: { status?: number } }).response?.status
         : undefined;
       if (status === 403) {
-        toast.error("Você não tem permissão para reabrir este evento.");
+        toast.error("VocÃª nÃ£o tem permissÃ£o para reabrir este evento.");
       } else {
         toast.error("Erro ao reabrir evento.");
       }
@@ -183,6 +183,8 @@ export default function HealthEventDetailPage() {
     tokenPayload?.userId && farmData?.ownerId && tokenPayload.userId === farmData.ownerId
   );
   const isFarmOwner = isFarmOwnerRole && isResourceOwner;
+  const hasMilkWithdrawal = Boolean(event?.milkWithdrawalEndDate || event?.milkWithdrawalActive);
+  const hasMeatWithdrawal = Boolean(event?.meatWithdrawalEndDate || event?.meatWithdrawalActive);
 
   // Use PermissionService logic via helper or explicit check to ensure stability
   const canReopen = (isAdmin || isFarmOwner) && isDoneOrCanceled;
@@ -193,8 +195,8 @@ export default function HealthEventDetailPage() {
   if (!event) return (
     <div className="module-empty">
       <div className="alert alert-warning">
-        <h4>Evento não encontrado</h4>
-        <p>Não foi possível carregar os detalhes do evento.</p>
+        <h4>Evento nÃ£o encontrado</h4>
+        <p>NÃ£o foi possÃ­vel carregar os detalhes do evento.</p>
         <button className="btn btn-primary mt-3" onClick={() => navigate(-1)}>Voltar</button>
       </div>
     </div>
@@ -271,13 +273,13 @@ export default function HealthEventDetailPage() {
             </div>
 
             <div className="col-md-12">
-                <label className="text-muted small">Título</label>
+                <label className="text-muted small">TÃ­tulo</label>
                 <div className="fw-bold fs-5">{event.title}</div>
             </div>
 
             {event.description && (
                 <div className="col-md-12">
-                    <label className="text-muted small">Descrição</label>
+                    <label className="text-muted small">DescriÃ§Ã£o</label>
                     <p className="mb-0">{event.description}</p>
                 </div>
             )}
@@ -295,7 +297,7 @@ export default function HealthEventDetailPage() {
                     )}
                     {event.activeIngredient && (
                         <div className="col-md-6">
-                            <label className="text-muted small">Princípio Ativo</label>
+                            <label className="text-muted small">PrincÃ­pio Ativo</label>
                             <div className="fw-bold">{event.activeIngredient}</div>
                         </div>
                     )}
@@ -319,14 +321,30 @@ export default function HealthEventDetailPage() {
                     )}
                      {event.withdrawalMilkDays !== undefined && (
                         <div className="col-md-3">
-                            <label className="text-muted small">Carência Leite</label>
+                            <label className="text-muted small">CarÃªncia Leite</label>
                             <div className="fw-bold">{event.withdrawalMilkDays} dias</div>
                         </div>
                     )}
                      {event.withdrawalMeatDays !== undefined && (
                         <div className="col-md-3">
-                            <label className="text-muted small">Carência Carne</label>
+                            <label className="text-muted small">CarÃªncia Carne</label>
                             <div className="fw-bold">{event.withdrawalMeatDays} dias</div>
+                        </div>
+                    )}
+                    {hasMilkWithdrawal && (
+                        <div className="col-md-6">
+                            <label className="text-muted small">Status carencia de leite</label>
+                            <div className="fw-bold">
+                                {event.milkWithdrawalActive ? "Ativa" : "Encerrada"}{event.milkWithdrawalEndDate ? ` ate ${formatLocalDatePtBR(event.milkWithdrawalEndDate)}` : ""}
+                            </div>
+                        </div>
+                    )}
+                    {hasMeatWithdrawal && (
+                        <div className="col-md-6">
+                            <label className="text-muted small">Status carencia de carne</label>
+                            <div className="fw-bold">
+                                {event.meatWithdrawalActive ? "Ativa" : "Encerrada"}{event.meatWithdrawalEndDate ? ` ate ${formatLocalDatePtBR(event.meatWithdrawalEndDate)}` : ""}
+                            </div>
                         </div>
                     )}
                 </>
@@ -335,16 +353,16 @@ export default function HealthEventDetailPage() {
             {/* Execution Details */}
             {normalizedStatus !== HealthEventStatus.AGENDADO && (
                 <>
-                     <div className="col-12 mt-4"><h6 className="text-muted border-bottom pb-2">Execução / Finalização</h6></div>
+                     <div className="col-12 mt-4"><h6 className="text-muted border-bottom pb-2">ExecuÃ§Ã£o / FinalizaÃ§Ã£o</h6></div>
                      {event.performedAt && (
                         <div className="col-md-6">
-                            <label className="text-muted small">Data Realização</label>
+                            <label className="text-muted small">Data RealizaÃ§Ã£o</label>
                             <div className="fw-bold">{new Date(event.performedAt).toLocaleString()}</div>
                         </div>
                      )}
                      {event.responsible && (
                         <div className="col-md-6">
-                            <label className="text-muted small">Responsável</label>
+                            <label className="text-muted small">ResponsÃ¡vel</label>
                             <div className="fw-bold">{event.responsible}</div>
                         </div>
                      )}
@@ -353,7 +371,7 @@ export default function HealthEventDetailPage() {
 
             {event.notes && (
                 <div className="col-md-12 mt-3">
-                    <label className="text-muted small">Observações / Notas</label>
+                    <label className="text-muted small">ObservaÃ§Ãµes / Notas</label>
                     <p className="mb-0 bg-light p-2 rounded">{event.notes}</p>
                 </div>
             )}

--- a/src/Pages/health/components/FarmHealthAlertsPanel.css
+++ b/src/Pages/health/components/FarmHealthAlertsPanel.css
@@ -36,6 +36,15 @@
   box-shadow: 0 4px 8px rgba(0,0,0,0.1);
 }
 
+.alert-summary-card--static {
+  cursor: default;
+}
+
+.alert-summary-card--static:hover {
+  transform: none;
+  box-shadow: none;
+}
+
 .summary-count {
   font-size: 2.5rem;
   font-weight: 700;
@@ -67,6 +76,18 @@
   background-color: #ffebee;
   color: #b71c1c;
   border-color: #ffcdd2;
+}
+
+.card-withdrawal-milk {
+  background-color: #fff7ed;
+  color: #9a3412;
+  border-color: #fed7aa;
+}
+
+.card-withdrawal-meat {
+  background-color: #faf5ff;
+  color: #7c3aed;
+  border-color: #ddd6fe;
 }
 
 /* Lists Grid */
@@ -108,6 +129,18 @@
 
 .alert-list-item:hover {
   background-color: #f8f9fa;
+}
+
+.alert-list-item--withdrawal {
+  border-left: 4px solid transparent;
+}
+
+.alert-list-item--milk {
+  border-left-color: #ea580c;
+}
+
+.alert-list-item--meat {
+  border-left-color: #7c3aed;
 }
 
 .alert-item-overdue {

--- a/src/Pages/health/components/FarmHealthAlertsPanel.tsx
+++ b/src/Pages/health/components/FarmHealthAlertsPanel.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { HealthAlertsDTO } from "../../../Models/HealthAlertsDTO";
+import { HealthAlertsDTO, WithdrawalAlertItemDTO } from "../../../Models/HealthAlertsDTO";
 import { HealthEventResponseDTO } from "../../../Models/HealthDTOs";
 import { formatLocalDatePtBR } from "../../../utils/localDate";
 import { HEALTH_EVENT_TYPE_LABELS } from "../healthLabels";
@@ -25,12 +25,12 @@ export default function FarmHealthAlertsPanel({
 
   if (!alerts) {
     return (
-        <div className="farm-health-alerts-panel">
-            <div className="alert alert-warning w-100 text-center">
-                <i className="fa-solid fa-triangle-exclamation me-2"></i>
-                Não foi possível carregar o painel de alertas.
-            </div>
+      <div className="farm-health-alerts-panel">
+        <div className="alert alert-warning w-100 text-center">
+          <i className="fa-solid fa-triangle-exclamation me-2"></i>
+          Nao foi possivel carregar o painel de alertas.
         </div>
+      </div>
     );
   }
 
@@ -56,7 +56,45 @@ export default function FarmHealthAlertsPanel({
                 <span className="alert-item-goat">Cabra: {event.goatId}</span>
               </div>
               <div className="alert-item-footer">
-                 <HealthStatusBadge status={event.status} overdue={event.overdue} />
+                <HealthStatusBadge status={event.status} overdue={event.overdue} />
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+
+  const renderWithdrawalList = (
+    title: string,
+    items: WithdrawalAlertItemDTO[],
+    emptyMsg: string,
+    tone: "milk" | "meat"
+  ) => (
+    <div className="alert-list-column">
+      <h4 className="alert-list-title">{title}</h4>
+      <div className="alert-list-items">
+        {items.length === 0 ? (
+          <p className="alert-list-empty">{emptyMsg}</p>
+        ) : (
+          items.slice(0, 5).map((item) => (
+            <div
+              key={`${tone}-${item.eventId}`}
+              className={`alert-list-item alert-list-item--withdrawal alert-list-item--${tone}`}
+              onClick={() => onNavigateToDetail(item.goatId, item.eventId)}
+            >
+              <div className="alert-item-header">
+                <span className="alert-item-type">{tone === "milk" ? "Carencia leite" : "Carencia carne"}</span>
+                <span className="alert-item-date">{formatLocalDatePtBR(item.withdrawalEndDate)}</span>
+              </div>
+              <div className="alert-item-body">
+                <strong>{item.productName || item.title || "Tratamento sanitario"}</strong>
+                <span className="alert-item-goat">Cabra: {item.goatId}</span>
+                <span className="alert-item-goat">
+                  {item.daysRemaining === 0
+                    ? "Ultimo dia de carencia"
+                    : `${item.daysRemaining} dia(s) restante(s)`}
+                </span>
               </div>
             </div>
           ))
@@ -67,7 +105,6 @@ export default function FarmHealthAlertsPanel({
 
   return (
     <div className="farm-health-alerts-panel">
-      {/* Summary Cards */}
       <div className="alerts-summary-grid">
         <div className="alert-summary-card card-today" onClick={() => onFilterChange("today")}>
           <div className="summary-count">{alerts.dueTodayCount}</div>
@@ -75,19 +112,28 @@ export default function FarmHealthAlertsPanel({
         </div>
         <div className="alert-summary-card card-upcoming" onClick={() => onFilterChange("upcoming")}>
           <div className="summary-count">{alerts.upcomingCount}</div>
-          <div className="summary-label">Próximos 7 dias</div>
+          <div className="summary-label">Proximos 7 dias</div>
         </div>
         <div className="alert-summary-card card-overdue" onClick={() => onFilterChange("overdue")}>
           <div className="summary-count">{alerts.overdueCount}</div>
           <div className="summary-label">Atrasados</div>
         </div>
+        <div className="alert-summary-card card-withdrawal-milk alert-summary-card--static">
+          <div className="summary-count">{alerts.activeMilkWithdrawalCount}</div>
+          <div className="summary-label">Carencia de leite</div>
+        </div>
+        <div className="alert-summary-card card-withdrawal-meat alert-summary-card--static">
+          <div className="summary-count">{alerts.activeMeatWithdrawalCount}</div>
+          <div className="summary-label">Carencia de carne</div>
+        </div>
       </div>
 
-      {/* Top 5 Lists */}
       <div className="alerts-lists-grid">
         {renderCompactList("Para Hoje", alerts.dueTodayTop, "Nenhum evento para hoje")}
-        {renderCompactList("Próximos Dias", alerts.upcomingTop, "Nenhum evento próximo")}
+        {renderCompactList("Proximos Dias", alerts.upcomingTop, "Nenhum evento proximo")}
         {renderCompactList("Atrasados", alerts.overdueTop, "Nenhum evento atrasado")}
+        {renderWithdrawalList("Carencia de leite ativa", alerts.milkWithdrawalTop || [], "Nenhum animal com carencia de leite ativa", "milk")}
+        {renderWithdrawalList("Carencia de carne ativa", alerts.meatWithdrawalTop || [], "Nenhum animal com carencia de carne ativa", "meat")}
       </div>
     </div>
   );

--- a/src/Pages/health/farmOperationalAgenda.ts
+++ b/src/Pages/health/farmOperationalAgenda.ts
@@ -1,4 +1,4 @@
-﻿import { HealthAlertsDTO } from "../../Models/HealthAlertsDTO";
+import { HealthAlertsDTO, WithdrawalAlertItemDTO } from "../../Models/HealthAlertsDTO";
 import { HealthEventResponseDTO } from "../../Models/HealthDTOs";
 import { LactationDryOffAlertResponseDTO } from "../../Models/LactationDTOs";
 import { PregnancyDiagnosisAlertResponseDTO } from "../../Models/ReproductionDTOs";
@@ -62,12 +62,13 @@ function getPriority(item: FarmOperationalAgendaItem): number {
 function toHealthItems(farmId: number, alerts: HealthAlertsDTO | null): FarmOperationalAgendaItem[] {
   if (!alerts || Number.isNaN(farmId)) return [];
 
-  const seen = new Set<number>();
+  const seen = new Set<string>();
   const items: FarmOperationalAgendaItem[] = [];
 
   const pushEvent = (event: HealthEventResponseDTO, source: "due" | "upcoming" | "overdue") => {
-    if (seen.has(event.id) || !isValidDate(event.scheduledDate)) return;
-    seen.add(event.id);
+    const key = `event-${event.id}`;
+    if (seen.has(key) || !isValidDate(event.scheduledDate)) return;
+    seen.add(key);
 
     const sourceDescription = source === "overdue"
       ? "Evento sanitário em atraso"
@@ -88,9 +89,29 @@ function toHealthItems(farmId: number, alerts: HealthAlertsDTO | null): FarmOper
     });
   };
 
+  const pushWithdrawal = (item: WithdrawalAlertItemDTO, type: "milk" | "meat") => {
+    const key = `withdrawal-${type}-${item.eventId}`;
+    if (seen.has(key) || !isValidDate(item.withdrawalEndDate)) return;
+    seen.add(key);
+
+    items.push({
+      id: `health-withdrawal-${type}-${item.eventId}`,
+      source: "health",
+      sourceLabel: SOURCE_LABELS.health,
+      title: type === "milk" ? "Carência de leite ativa" : "Carência de carne ativa",
+      description: `Cabra ${item.goatId} · bloqueio até ${formatDate(item.withdrawalEndDate)}`,
+      goatId: item.goatId,
+      date: item.withdrawalEndDate,
+      href: `/app/goatfarms/${farmId}/goats/${encodeURIComponent(item.goatId)}/health/${item.eventId}`,
+      overdue: false
+    });
+  };
+
   alerts.overdueTop.forEach((event) => pushEvent(event, "overdue"));
   alerts.dueTodayTop.forEach((event) => pushEvent(event, "due"));
   alerts.upcomingTop.forEach((event) => pushEvent(event, "upcoming"));
+  (alerts.milkWithdrawalTop || []).forEach((item) => pushWithdrawal(item, "milk"));
+  (alerts.meatWithdrawalTop || []).forEach((item) => pushWithdrawal(item, "meat"));
 
   return items;
 }
@@ -163,10 +184,17 @@ export function buildFarmOperationalAgenda(
       (healthAlerts?.dueTodayCount ?? 0) +
       (healthAlerts?.upcomingCount ?? 0) +
       (healthAlerts?.overdueCount ?? 0) +
+      (healthAlerts?.activeMilkWithdrawalCount ?? 0) +
+      (healthAlerts?.activeMeatWithdrawalCount ?? 0) +
       (pregnancyAlerts?.totalPending ?? 0) +
       (dryOffAlerts?.totalPending ?? 0),
     counts: {
-      health: (healthAlerts?.dueTodayCount ?? 0) + (healthAlerts?.upcomingCount ?? 0) + (healthAlerts?.overdueCount ?? 0),
+      health:
+        (healthAlerts?.dueTodayCount ?? 0) +
+        (healthAlerts?.upcomingCount ?? 0) +
+        (healthAlerts?.overdueCount ?? 0) +
+        (healthAlerts?.activeMilkWithdrawalCount ?? 0) +
+        (healthAlerts?.activeMeatWithdrawalCount ?? 0),
       reproduction: pregnancyAlerts?.totalPending ?? 0,
       lactation: dryOffAlerts?.totalPending ?? 0
     },

--- a/src/Pages/lactation/MilkProductionPage.tsx
+++ b/src/Pages/lactation/MilkProductionPage.tsx
@@ -2,8 +2,9 @@
 import { useNavigate, useParams } from "react-router-dom";
 import { toast } from "react-toastify";
 import PageHeader from "../../Components/pages-headers/PageHeader";
-import { Button, Card, EmptyState, LoadingState, Modal, Table } from "../../Components/ui";
+import { Alert, Button, Card, EmptyState, LoadingState, Modal, Table } from "../../Components/ui";
 import { fetchGoatById } from "../../api/GoatAPI/goat";
+import { healthAPI } from "../../api/GoatFarmAPI/health";
 import {
   cancelMilkProduction,
   createMilkProduction,
@@ -13,6 +14,7 @@ import {
 } from "../../api/GoatFarmAPI/milkProduction";
 import { useFarmPermissions } from "../../Hooks/useFarmPermissions";
 import { usePermissions } from "../../Hooks/usePermissions";
+import type { GoatWithdrawalStatusDTO } from "../../Models/HealthDTOs";
 import type {
   MilkProductionRequestDTO,
   MilkProductionResponseDTO,
@@ -86,6 +88,7 @@ export default function MilkProductionPage() {
   const permissions = usePermissions();
 
   const [goat, setGoat] = useState<GoatResponseDTO | null>(null);
+  const [withdrawalStatus, setWithdrawalStatus] = useState<GoatWithdrawalStatusDTO | null>(null);
   const [productions, setProductions] = useState<MilkProductionResponseDTO[]>([]);
   const [loading, setLoading] = useState(true);
   const [page, setPage] = useState(0);
@@ -121,6 +124,7 @@ export default function MilkProductionPage() {
   const { canManageMilkProduction } = useFarmPermissions(farmIdNumber);
   const canManage = permissions.isAdmin() || canManageMilkProduction;
   const isEditingCanceled = editing?.status === "CANCELED";
+  const isMilkWithdrawalBlocked = Boolean(withdrawalStatus?.hasActiveMilkWithdrawal);
 
   const stats = useMemo(() => {
     const total = productions.reduce((sum, item) => sum + Number(item.volumeLiters || 0), 0);
@@ -132,7 +136,7 @@ export default function MilkProductionPage() {
     if (!farmId || !goatId || Number.isNaN(farmIdNumber)) return;
     try {
       setLoading(true);
-      const [list, goatData] = await Promise.all([
+      const [list, goatData, withdrawalData] = await Promise.all([
         listMilkProductions(farmIdNumber, goatId, {
           page: pageOverride,
           size: 10,
@@ -142,12 +146,14 @@ export default function MilkProductionPage() {
           includeCanceled: filters.includeCanceled || undefined,
         }),
         fetchGoatById(farmIdNumber, goatId).catch(() => null),
+        healthAPI.getWithdrawalStatus(farmIdNumber, goatId).catch(() => null),
       ]);
 
       setProductions(list.content || []);
       setTotalPages(list.totalPages || 0);
       setTotalElements(list.totalElements || 0);
       if (goatData) setGoat(goatData);
+      setWithdrawalStatus(withdrawalData);
     } catch (error) {
       console.error("Erro ao carregar produção de leite", error);
       const parsed = parseApiError(error);
@@ -201,6 +207,12 @@ export default function MilkProductionPage() {
   };
 
   const openCreate = () => {
+    if (isMilkWithdrawalBlocked && withdrawalStatus?.milkWithdrawal) {
+      toast.error(
+        `Leite bloqueado por carencia ativa ate ${formatDate(withdrawalStatus.milkWithdrawal.withdrawalEndDate)}.`
+      );
+      return;
+    }
     if (!canManage) {
       toast.error("Sem permissão para esta ação.");
       return;
@@ -386,6 +398,11 @@ export default function MilkProductionPage() {
       </section>
 
       <section className="lactation-panel-grid">
+        {isMilkWithdrawalBlocked && withdrawalStatus?.milkWithdrawal ? (
+          <Alert variant="warning" title="Carencia sanitaria ativa">
+            O leite deste animal esta bloqueado ate {formatDate(withdrawalStatus.milkWithdrawal.withdrawalEndDate)} por {withdrawalStatus.milkWithdrawal.productName || withdrawalStatus.milkWithdrawal.title || "tratamento sanitario"}.
+          </Alert>
+        ) : null}
         <Card className="lactation-panel lactation-panel--soft">
           <span className="lactation-panel__eyebrow">
             {productions.length === 0 ? "Primeiros passos" : "Visão geral"}
@@ -436,8 +453,14 @@ export default function MilkProductionPage() {
               <Button
                 variant="primary"
                 onClick={openCreate}
-                disabled={!canManage}
-                title={!canManage ? "Sem permissão para registrar produção." : ""}
+                disabled={!canManage || isMilkWithdrawalBlocked}
+                title={
+                  isMilkWithdrawalBlocked
+                    ? "Bloqueado por carencia sanitaria ativa."
+                    : !canManage
+                      ? "Sem permissão para registrar produção."
+                      : ""
+                }
               >
                 <i className="fa-solid fa-plus" aria-hidden="true"></i> Registrar produção
               </Button>

--- a/src/api/GoatFarmAPI/health.ts
+++ b/src/api/GoatFarmAPI/health.ts
@@ -6,6 +6,7 @@ import {
   HealthEventDoneRequestDTO, 
   HealthEventCancelRequestDTO,
   HealthEventResponseDTO,
+  GoatWithdrawalStatusDTO,
   HealthEventType,
   HealthEventStatus
 } from "../../Models/HealthDTOs";
@@ -30,6 +31,19 @@ export const healthAPI = {
       method: "GET",
       url: `/goatfarms/${farmId}/health-events/alerts`,
       params: { windowDays }
+    };
+    return requestBackEnd(config).then(res => res.data);
+  },
+
+  getWithdrawalStatus: async (
+    farmId: number,
+    goatId: string,
+    referenceDate?: string
+  ): Promise<GoatWithdrawalStatusDTO> => {
+    const config: AxiosRequestConfig = {
+      method: "GET",
+      url: `/goatfarms/${farmId}/goats/${goatId}/health-events/withdrawal-status`,
+      params: referenceDate ? { referenceDate } : undefined
     };
     return requestBackEnd(config).then(res => res.data);
   },

--- a/src/api/GoatFarmAPI/health.withdrawal.test.ts
+++ b/src/api/GoatFarmAPI/health.withdrawal.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { requestBackEnd } from "../../utils/request";
+import { healthAPI } from "./health";
+
+vi.mock("../../utils/request", () => ({
+  requestBackEnd: vi.fn()
+}));
+
+describe("Health API withdrawal status", () => {
+  const mockedRequest = vi.mocked(requestBackEnd);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("requests withdrawal status using the canonical route", async () => {
+    mockedRequest.mockResolvedValueOnce({
+      data: {
+        goatId: "QAT03281450",
+        referenceDate: "2026-03-29",
+        hasActiveMilkWithdrawal: true,
+        hasActiveMeatWithdrawal: true,
+        milkWithdrawal: {
+          eventId: 13,
+          title: "Tratamento QA carencia",
+          productName: "Produto QA Carencia",
+          withdrawalEndDate: "2026-03-31"
+        },
+        meatWithdrawal: {
+          eventId: 13,
+          title: "Tratamento QA carencia",
+          productName: "Produto QA Carencia",
+          withdrawalEndDate: "2026-03-31"
+        }
+      }
+    });
+
+    const result = await healthAPI.getWithdrawalStatus(17, "QAT03281450", "2026-03-29");
+
+    expect(mockedRequest).toHaveBeenCalledWith({
+      method: "GET",
+      url: "/goatfarms/17/goats/QAT03281450/health-events/withdrawal-status",
+      params: { referenceDate: "2026-03-29" }
+    });
+    expect(result.hasActiveMilkWithdrawal).toBe(true);
+    expect(result.milkWithdrawal?.withdrawalEndDate).toBe("2026-03-31");
+  });
+
+  it("omits referenceDate when it is not provided", async () => {
+    mockedRequest.mockResolvedValueOnce({
+      data: {
+        goatId: "TSTKID2602",
+        referenceDate: "2026-03-29",
+        hasActiveMilkWithdrawal: false,
+        hasActiveMeatWithdrawal: false,
+        milkWithdrawal: null,
+        meatWithdrawal: null
+      }
+    });
+
+    const result = await healthAPI.getWithdrawalStatus(17, "TSTKID2602");
+
+    expect(mockedRequest).toHaveBeenCalledWith({
+      method: "GET",
+      url: "/goatfarms/17/goats/TSTKID2602/health-events/withdrawal-status",
+      params: undefined
+    });
+    expect(result.hasActiveMilkWithdrawal).toBe(false);
+    expect(result.hasActiveMeatWithdrawal).toBe(false);
+  });
+});

--- a/src/services/alerts/providers/HealthAlertProvider.test.ts
+++ b/src/services/alerts/providers/HealthAlertProvider.test.ts
@@ -20,25 +20,31 @@ describe("HealthAlertProvider", () => {
       dueTodayCount: 2,
       upcomingCount: 3,
       overdueCount: 1,
+      activeMilkWithdrawalCount: 1,
+      activeMeatWithdrawalCount: 2,
       dueTodayTop: [],
       upcomingTop: [],
-      overdueTop: []
+      overdueTop: [],
+      milkWithdrawalTop: [],
+      meatWithdrawalTop: []
     });
 
     const summary = await HealthAlertProvider.getSummary(4);
 
     expect(summary).toEqual({
-      count: 6,
+      count: 9,
       headline: "1 atrasado(s)",
       worstOverdueDays: 1
     });
   });
 
-  it("maps list with source/severity/priority", async () => {
+  it("maps list with withdrawal alerts before health agenda items", async () => {
     mockedGetAlerts.mockResolvedValueOnce({
       dueTodayCount: 1,
       upcomingCount: 1,
       overdueCount: 1,
+      activeMilkWithdrawalCount: 1,
+      activeMeatWithdrawalCount: 1,
       dueTodayTop: [
         {
           id: 2,
@@ -74,29 +80,46 @@ describe("HealthAlertProvider", () => {
           scheduledDate: "2026-03-10",
           overdue: true
         }
+      ],
+      milkWithdrawalTop: [
+        {
+          eventId: 21,
+          goatId: "GOAT-MILK",
+          title: "Tratamento de mastite",
+          productName: "Antibiotico A",
+          withdrawalEndDate: "2026-03-18",
+          daysRemaining: 3
+        }
+      ],
+      meatWithdrawalTop: [
+        {
+          eventId: 22,
+          goatId: "GOAT-MEAT",
+          title: "Tratamento clinico",
+          productName: "Antiinflamatorio B",
+          withdrawalEndDate: "2026-03-20",
+          daysRemaining: 5
+        }
       ]
     });
 
     const list = await HealthAlertProvider.getList?.(4);
 
-    expect(list).toHaveLength(3);
+    expect(list).toHaveLength(5);
     expect(list?.[0]).toMatchObject({
-      id: "health-1-overdue",
+      id: "health-withdrawal-milk-21",
       source: "health",
       severity: "high",
-      priority: 350
+      priority: 420
     });
     expect(list?.[1]).toMatchObject({
-      id: "health-2-due_today",
+      id: "health-withdrawal-meat-22",
       source: "health",
       severity: "medium",
-      priority: 240
+      priority: 280
     });
     expect(list?.[2]).toMatchObject({
-      id: "health-3-upcoming",
-      source: "health",
-      severity: "low",
-      priority: 120
+      id: "health-1-overdue"
     });
   });
 

--- a/src/services/alerts/providers/HealthAlertProvider.ts
+++ b/src/services/alerts/providers/HealthAlertProvider.ts
@@ -1,5 +1,6 @@
-﻿import { AlertItem, AlertProvider, AlertSummary } from "../AlertRegistry";
+import { AlertItem, AlertProvider, AlertSummary } from "../AlertRegistry";
 import { healthAPI } from "../../../api/GoatFarmAPI/health";
+import type { WithdrawalAlertItemDTO } from "../../../Models/HealthAlertsDTO";
 import type { HealthEventResponseDTO } from "../../../Models/HealthDTOs";
 
 function toHealthItem(
@@ -31,6 +32,25 @@ function toHealthItem(
   };
 }
 
+function toWithdrawalItem(
+  farmId: number,
+  item: WithdrawalAlertItemDTO,
+  withdrawalType: "milk" | "meat"
+): AlertItem {
+  return {
+    id: `health-withdrawal-${withdrawalType}-${item.eventId}`,
+    source: "health",
+    title: withdrawalType === "milk" ? "Carencia de leite ativa" : "Carencia de carne ativa",
+    description: `Cabra ${item.goatId} · bloqueio ate ${item.withdrawalEndDate}`,
+    date: item.withdrawalEndDate,
+    severity: withdrawalType === "milk" ? "high" : "medium",
+    priority: withdrawalType === "milk" ? 420 : 280,
+    goatId: item.goatId,
+    link: `/app/goatfarms/${farmId}/goats/${item.goatId}/health/${item.eventId}`,
+    actionLabel: "Ver tratamento"
+  };
+}
+
 export const HealthAlertProvider: AlertProvider = {
   key: "health_agenda",
   label: "Agenda Sanitaria",
@@ -42,11 +62,17 @@ export const HealthAlertProvider: AlertProvider = {
       const overdueCount = data.overdueCount || 0;
       const dueTodayCount = data.dueTodayCount || 0;
       const upcomingCount = data.upcomingCount || 0;
-      const count = overdueCount + dueTodayCount + upcomingCount;
+      const milkWithdrawalCount = data.activeMilkWithdrawalCount || 0;
+      const meatWithdrawalCount = data.activeMeatWithdrawalCount || 0;
+      const count = overdueCount + dueTodayCount + upcomingCount + milkWithdrawalCount + meatWithdrawalCount;
 
       let headline: string | undefined;
       if (overdueCount > 0) {
         headline = `${overdueCount} atrasado(s)`;
+      } else if (milkWithdrawalCount > 0) {
+        headline = `${milkWithdrawalCount} em carencia de leite`;
+      } else if (meatWithdrawalCount > 0) {
+        headline = `${meatWithdrawalCount} em carencia de carne`;
       } else if (dueTodayCount > 0) {
         headline = `${dueTodayCount} para hoje`;
       } else if (upcomingCount > 0) {
@@ -69,6 +95,8 @@ export const HealthAlertProvider: AlertProvider = {
       const data = await healthAPI.getAlerts(farmId);
 
       return [
+        ...(data.milkWithdrawalTop || []).map((item) => toWithdrawalItem(farmId, item, "milk")),
+        ...(data.meatWithdrawalTop || []).map((item) => toWithdrawalItem(farmId, item, "meat")),
         ...(data.overdueTop || []).map((event) => toHealthItem(farmId, event, "overdue")),
         ...(data.dueTodayTop || []).map((event) => toHealthItem(farmId, event, "due_today")),
         ...(data.upcomingTop || []).map((event) => toHealthItem(farmId, event, "upcoming"))


### PR DESCRIPTION
## Summary
- surface active withdrawal counts and items in farm health alerts and dashboard attention
- show withdrawal status in health event detail and goat operational history
- reflect milk withdrawal blocking in the milk production UI and add focused tests

## Validation
- npm test -- --run
- npm run lint
- npm run build
- npm run test:e2e
- runtime Playwright smoke on farm 17 covering farm alerts, health event detail, goat detail and milk production block UI
