### PR TITLE
Fix: surface withdrawal production snapshots

### DIFF
--- a/src/Models/MilkProductionDTOs.ts
+++ b/src/Models/MilkProductionDTOs.ts
@@ -20,6 +20,10 @@ export interface MilkProductionResponseDTO {
   volumeLiters: number;
   notes?: string | null;
   status: MilkProductionStatus;
+  recordedDuringMilkWithdrawal: boolean;
+  milkWithdrawalEventId?: number | null;
+  milkWithdrawalEndDate?: string | null;
+  milkWithdrawalSource?: string | null;
   canceledAt?: string | null;
   canceledReason?: string | null;
 }

--- a/src/Pages/lactation/MilkProductionPage.tsx
+++ b/src/Pages/lactation/MilkProductionPage.tsx
@@ -124,7 +124,7 @@ export default function MilkProductionPage() {
   const { canManageMilkProduction } = useFarmPermissions(farmIdNumber);
   const canManage = permissions.isAdmin() || canManageMilkProduction;
   const isEditingCanceled = editing?.status === "CANCELED";
-  const isMilkWithdrawalBlocked = Boolean(withdrawalStatus?.hasActiveMilkWithdrawal);
+  const hasCurrentMilkWithdrawal = Boolean(withdrawalStatus?.hasActiveMilkWithdrawal);
 
   const stats = useMemo(() => {
     const total = productions.reduce((sum, item) => sum + Number(item.volumeLiters || 0), 0);
@@ -207,12 +207,6 @@ export default function MilkProductionPage() {
   };
 
   const openCreate = () => {
-    if (isMilkWithdrawalBlocked && withdrawalStatus?.milkWithdrawal) {
-      toast.error(
-        `Leite bloqueado por carencia ativa ate ${formatDate(withdrawalStatus.milkWithdrawal.withdrawalEndDate)}.`
-      );
-      return;
-    }
     if (!canManage) {
       toast.error("Sem permissão para esta ação.");
       return;
@@ -296,8 +290,14 @@ export default function MilkProductionPage() {
           volumeLiters: Number(form.volumeLiters),
           notes: form.notes || undefined,
         };
-        await createMilkProduction(farmIdNumber, goatId, payload);
-        toast.success("Produção registrada.");
+        const created = await createMilkProduction(farmIdNumber, goatId, payload);
+        if (created.recordedDuringMilkWithdrawal) {
+          toast.success(
+            `Produção registrada em carência até ${formatDate(created.milkWithdrawalEndDate)}. O volume segue no histórico, mas exige restrição sanitária de uso.`
+          );
+        } else {
+          toast.success("Produção registrada.");
+        }
         setShowFormModal(false);
         resetForm();
         setPage(0);
@@ -398,9 +398,9 @@ export default function MilkProductionPage() {
       </section>
 
       <section className="lactation-panel-grid">
-        {isMilkWithdrawalBlocked && withdrawalStatus?.milkWithdrawal ? (
+        {hasCurrentMilkWithdrawal && withdrawalStatus?.milkWithdrawal ? (
           <Alert variant="warning" title="Carencia sanitaria ativa">
-            O leite deste animal esta bloqueado ate {formatDate(withdrawalStatus.milkWithdrawal.withdrawalEndDate)} por {withdrawalStatus.milkWithdrawal.productName || withdrawalStatus.milkWithdrawal.title || "tratamento sanitario"}.
+            Este animal está em carência de leite até {formatDate(withdrawalStatus.milkWithdrawal.withdrawalEndDate)} por {withdrawalStatus.milkWithdrawal.productName || withdrawalStatus.milkWithdrawal.title || "tratamento sanitario"}. A produção pode continuar sendo registrada para controle zootécnico, mas deve permanecer restrita para uso comercial.
           </Alert>
         ) : null}
         <Card className="lactation-panel lactation-panel--soft">
@@ -453,13 +453,9 @@ export default function MilkProductionPage() {
               <Button
                 variant="primary"
                 onClick={openCreate}
-                disabled={!canManage || isMilkWithdrawalBlocked}
+                disabled={!canManage}
                 title={
-                  isMilkWithdrawalBlocked
-                    ? "Bloqueado por carencia sanitaria ativa."
-                    : !canManage
-                      ? "Sem permissão para registrar produção."
-                      : ""
+                  !canManage ? "Sem permissão para registrar produção." : ""
                 }
               >
                 <i className="fa-solid fa-plus" aria-hidden="true"></i> Registrar produção
@@ -571,13 +567,20 @@ export default function MilkProductionPage() {
                     <td>{shifts.find((s) => s.value === item.shift)?.label || item.shift}</td>
                     <td>{formatVolume(item.volumeLiters)}</td>
                     <td>
-                      <span
-                        className={`milk-status-badge ${
-                          isCanceled ? "milk-status-badge--canceled" : "milk-status-badge--active"
-                        }`}
-                      >
-                        {statusLabels[item.status] || item.status}
-                      </span>
+                      <div className="milk-status-stack">
+                        <span
+                          className={`milk-status-badge ${
+                            isCanceled ? "milk-status-badge--canceled" : "milk-status-badge--active"
+                          }`}
+                        >
+                          {statusLabels[item.status] || item.status}
+                        </span>
+                        {item.recordedDuringMilkWithdrawal ? (
+                          <span className="milk-status-badge milk-status-badge--withdrawal">
+                            Em carencia
+                          </span>
+                        ) : null}
+                      </div>
                     </td>
                     <td>{item.notes || "-"}</td>
                     <td className="milk-actions">
@@ -676,6 +679,16 @@ export default function MilkProductionPage() {
         {submitError && <p className="text-danger">{submitError}</p>}
         {isEditingCanceled && (
           <div className="milk-canceled-banner">Registro cancelado. Edição bloqueada.</div>
+        )}
+        {!editing && hasCurrentMilkWithdrawal && withdrawalStatus?.milkWithdrawal && (
+          <p className="milk-withdrawal-note">
+            Esta ordenha será registrada em carência até{" "}
+            {formatDate(withdrawalStatus.milkWithdrawal.withdrawalEndDate)} por{" "}
+            {withdrawalStatus.milkWithdrawal.productName ||
+              withdrawalStatus.milkWithdrawal.title ||
+              "tratamento sanitario"}
+            . O volume seguirá no histórico, mas não deve ser usado comercialmente.
+          </p>
         )}
         <div className="milk-form-grid">
           <div>
@@ -826,6 +839,10 @@ export default function MilkProductionPage() {
                 </p>
               </div>
               <div>
+                <label>Produzido em carência</label>
+                <p>{detail.recordedDuringMilkWithdrawal ? "Sim" : "Não"}</p>
+              </div>
+              <div>
                 <label>Data</label>
                 <p>{formatDate(detail.date)}</p>
               </div>
@@ -840,6 +857,14 @@ export default function MilkProductionPage() {
               <div>
                 <label>Cancelado em</label>
                 <p>{formatDateTime(detail.canceledAt)}</p>
+              </div>
+              <div>
+                <label>Carência até</label>
+                <p>{formatDate(detail.milkWithdrawalEndDate)}</p>
+              </div>
+              <div className="milk-detail-full">
+                <label>Origem sanitária</label>
+                <p>{detail.milkWithdrawalSource || "-"}</p>
               </div>
               <div className="milk-detail-full">
                 <label>Motivo do cancelamento</label>

--- a/src/Pages/lactation/milkProductionPage.css
+++ b/src/Pages/lactation/milkProductionPage.css
@@ -101,6 +101,17 @@
   background: #fee2e2;
 }
 
+.milk-status-badge--withdrawal {
+  color: #92400e;
+  background: #fef3c7;
+}
+
+.milk-status-stack {
+  display: flex;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+}
+
 .milk-row-canceled {
   background: rgba(239, 68, 68, 0.05);
 }
@@ -156,6 +167,16 @@
   color: #9f1239;
   border-radius: 12px;
   padding: 0.7rem 0.85rem;
+  margin-bottom: 1rem;
+  font-weight: 600;
+}
+
+.milk-withdrawal-note {
+  border: 1px solid #fcd34d;
+  background: #fffbeb;
+  color: #92400e;
+  border-radius: 12px;
+  padding: 0.75rem 0.85rem;
   margin-bottom: 1rem;
   font-weight: 600;
 }

--- a/src/api/GoatFarmAPI/milkProduction.withdrawal.test.ts
+++ b/src/api/GoatFarmAPI/milkProduction.withdrawal.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { requestBackEnd } from "../../utils/request";
+import { createMilkProduction, listMilkProductions } from "./milkProduction";
+
+vi.mock("../../utils/request", () => ({
+  requestBackEnd: {
+    post: vi.fn(),
+    get: vi.fn(),
+  },
+}));
+
+describe("Milk production withdrawal snapshot API", () => {
+  const mockedPost = vi.mocked(requestBackEnd.post);
+  const mockedGet = vi.mocked(requestBackEnd.get);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the withdrawal snapshot when a production is recorded during withdrawal", async () => {
+    mockedPost.mockResolvedValueOnce({
+      data: {
+        id: 91,
+        date: "2026-03-29",
+        shift: "MORNING",
+        volumeLiters: 1.25,
+        status: "ACTIVE",
+        recordedDuringMilkWithdrawal: true,
+        milkWithdrawalEventId: 13,
+        milkWithdrawalEndDate: "2026-03-31",
+        milkWithdrawalSource: "Produto QA Carencia",
+      },
+    });
+
+    const result = await createMilkProduction(17, "QAT03281450", {
+      date: "2026-03-29",
+      shift: "MORNING",
+      volumeLiters: 1.25,
+      notes: "Ordenha em carencia",
+    });
+
+    expect(mockedPost).toHaveBeenCalledWith(
+      "/goatfarms/17/goats/QAT03281450/milk-productions",
+      {
+        date: "2026-03-29",
+        shift: "MORNING",
+        volumeLiters: 1.25,
+        notes: "Ordenha em carencia",
+      }
+    );
+    expect(result.recordedDuringMilkWithdrawal).toBe(true);
+    expect(result.milkWithdrawalEndDate).toBe("2026-03-31");
+    expect(result.milkWithdrawalSource).toBe("Produto QA Carencia");
+  });
+
+  it("keeps the withdrawal snapshot in the list response", async () => {
+    mockedGet.mockResolvedValueOnce({
+      data: {
+        content: [
+          {
+            id: 91,
+            date: "2026-03-29",
+            shift: "MORNING",
+            volumeLiters: 1.25,
+            status: "ACTIVE",
+            recordedDuringMilkWithdrawal: true,
+            milkWithdrawalEventId: 13,
+            milkWithdrawalEndDate: "2026-03-31",
+            milkWithdrawalSource: "Produto QA Carencia",
+          },
+        ],
+        totalElements: 1,
+        totalPages: 1,
+        size: 10,
+        number: 0,
+      },
+    });
+
+    const result = await listMilkProductions(17, "QAT03281450", {
+      page: 0,
+      size: 10,
+      dateFrom: "2026-03-01",
+      dateTo: "2026-03-31",
+    });
+
+    expect(mockedGet).toHaveBeenCalledWith(
+      "/goatfarms/17/goats/QAT03281450/milk-productions",
+      expect.objectContaining({
+        params: expect.any(URLSearchParams),
+      })
+    );
+    expect(result.content[0].recordedDuringMilkWithdrawal).toBe(true);
+    expect(result.content[0].milkWithdrawalEventId).toBe(13);
+  });
+});


### PR DESCRIPTION
## Resumo
- permitir o registro visual da ordenha durante carencia com alerta forte
- mostrar badge e detalhes do snapshot sanitario no historico de leite
- cobrir o DTO novo no teste da API de milk production

## Validacao
- npm test -- --run src/api/GoatFarmAPI/milkProduction.withdrawal.test.ts
- npm test -- --run
- npm run lint
- npm run build
- npm run test:e2e
- smoke visual real em http://127.0.0.1:5173/app/goatfarms/17/goats/QAT03281450/milk-productions