### PR TITLE
Fix: refine home closing cta

### DIFF
--- a/src/Pages/home/Home.tsx
+++ b/src/Pages/home/Home.tsx
@@ -184,28 +184,20 @@ export default function Home() {
 
       <section className="home-cta">
         <div className="home-cta-content">
-          <span className="home-cta-badge">
-            <span className="pulse-dot"></span>
-            {"Pronto para evoluir sua gest\u00e3o?"}
-          </span>
-          <h2>
-            {"Organize a fazenda com "}
-            <span className="home-cta-highlight">{"mais clareza"}</span>
-            <br />
-            {"e menos retrabalho."}
-          </h2>
+          <h2>{"Pronto para transformar sua fazenda?"}</h2>
           <p>
-            {
-              "Re\u00fana cadastros, rotinas e indicadores em um ambiente \u00fanico, pensado para o manejo caprino do dia a dia."
-            }
+            {"Junte-se a centenas de produtores que j\u00e1 modernizaram seu manejo com o CapriGestor. Teste gr\u00e1tis por 14 dias."}
           </p>
           <div className="home-cta-actions">
             <Link to="/signup" className="home-cta-primary">
-              {"Criar conta gratuita"}
+              {"Cadastrar minha Fazenda"}
             </Link>
-            <Link to="/fazendas" className="home-cta-secondary">
-              {"Ver fazendas p\u00fablicas"}
-            </Link>
+            <a
+              href="mailto:contato@caprigestor.com.br?subject=Quero%20falar%20com%20um%20consultor%20do%20CapriGestor"
+              className="home-cta-secondary"
+            >
+              {"Falar com um Consultor"}
+            </a>
           </div>
         </div>
       </section>

--- a/src/Pages/home/home.css
+++ b/src/Pages/home/home.css
@@ -372,92 +372,34 @@
 
 .home-cta {
   margin-top: clamp(2.4rem, 4.6vw, 3.75rem);
-  border-radius: 32px;
+  max-width: 860px;
+  margin-inline: auto;
+  border-radius: 28px;
   position: relative;
   overflow: hidden;
-  border: 1px solid rgba(255, 255, 255, 0.15);
-  padding:
-    clamp(1.5rem, 3vw, 2.4rem)
-    clamp(1.5rem, 2.8vw, 2.4rem)
-    clamp(1.5rem, 3vw, 2.4rem)
-    clamp(2.4rem, 5vw, 4.2rem);
+  border: 1px solid rgba(15, 118, 110, 0.08);
+  padding: clamp(2rem, 4vw, 2.75rem) clamp(1.6rem, 4vw, 2.4rem);
   color: #ffffff;
-  background:
-    radial-gradient(circle at -10% -10%, rgba(52, 211, 153, 0.25), transparent 45%),
-    radial-gradient(circle at 110% 110%, rgba(13, 148, 136, 0.4), transparent 50%),
-    linear-gradient(135deg, #064e3b 0%, #022c22 45%, #065f46 100%);
-  box-shadow: 0 32px 64px rgba(15, 23, 42, 0.25);
+  background: linear-gradient(180deg, #285746 0%, #244d3f 100%);
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.16);
 }
 
 .home-cta-content {
-  display: grid;
-  grid-template-columns: minmax(0, 1.35fr) minmax(240px, 0.65fr);
-  grid-template-areas:
-    "badge badge"
-    "title actions"
-    "copy actions";
+  display: flex;
+  flex-direction: column;
   align-items: center;
-  column-gap: clamp(1.25rem, 2vw, 2rem);
-  row-gap: 0.65rem;
-  padding-left: clamp(2rem, 5vw, 4.6rem);
-}
-
-.home-cta-badge {
-  grid-area: badge;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.65rem;
-  justify-self: start;
-  width: fit-content;
-  margin-bottom: 1.2rem;
-  padding: 0.5rem 1.1rem 0.5rem 0.6rem;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.08);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
-  border: 1px solid rgba(255, 255, 255, 0.15);
-  font-size: 0.76rem;
-  font-weight: 800;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.95);
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.15);
-}
-
-.pulse-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: #34d399;
-  box-shadow: 0 0 10px #34d399;
-  position: relative;
-}
-
-.pulse-dot::after {
-  content: "";
-  position: absolute;
-  top: -4px;
-  left: -4px;
-  right: -4px;
-  bottom: -4px;
-  border-radius: 50%;
-  border: 2px solid #34d399;
-  animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
-}
-
-@keyframes pulse {
-  0% { transform: scale(0.5); opacity: 1; }
-  100% { transform: scale(2); opacity: 0; }
+  justify-content: center;
+  text-align: center;
+  gap: 1rem;
 }
 
 .home-cta-content h2 {
-  grid-area: title;
   margin: 0;
-  max-width: 100%;
-  font-size: clamp(2.2rem, 4vw, 3.4rem);
-  line-height: 1.1;
-  font-weight: 900;
-  letter-spacing: -0.04em;
+  max-width: 22ch;
+  font-size: clamp(2.1rem, 3.2vw, 2.75rem);
+  line-height: 1.15;
+  font-weight: 800;
+  letter-spacing: -0.03em;
 }
 
 .home-cta-highlight {
@@ -465,24 +407,22 @@
 }
 
 .home-cta-content p {
-  grid-area: copy;
-  margin: 0.8rem 0 0;
-  max-width: 48ch;
-  font-size: clamp(0.96rem, 1.2vw, 1.08rem);
-  line-height: 1.6;
-  color: rgba(255, 255, 255, 0.86);
+  margin: 0;
+  max-width: 56ch;
+  font-size: clamp(1rem, 1.2vw, 1.08rem);
+  line-height: 1.55;
+  color: rgba(255, 255, 255, 0.74);
 }
 
 .home-cta-actions {
-  grid-area: actions;
   display: flex;
   flex-direction: row;
-  flex-wrap: wrap;
-  gap: 1rem;
-  margin-top: 0;
-  width: 100%;
-  justify-self: end;
-  align-self: center;
+  flex-wrap: nowrap;
+  gap: 0.85rem;
+  margin-top: 0.35rem;
+  width: auto;
+  justify-content: center;
+  align-items: center;
 }
 
 .home-cta-primary,
@@ -490,49 +430,41 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-height: 54px;
-  padding: 0 1.6rem;
-  border-radius: 100px;
+  min-height: 48px;
+  padding: 0 1.55rem;
+  border-radius: 10px;
   text-decoration: none;
-  font-weight: 800;
-  font-size: 0.96rem;
-  flex: 1;
-  min-width: 220px;
+  font-weight: 700;
+  font-size: 0.98rem;
+  min-width: 210px;
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .home-cta-primary {
-  background: #ffffff;
-  color: #022c22;
+  background: #3ddc84;
+  color: #ffffff;
+  box-shadow: none;
 }
 
 .home-cta-secondary {
-  background: rgba(255, 255, 255, 0.1);
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
-  color: #ffffff;
-  border: 1px solid rgba(255, 255, 255, 0.25);
+  background: #ffffff;
+  color: #475569;
+  border: 1px solid rgba(226, 232, 240, 0.9);
 }
 
 .home-cta-primary:hover,
 .home-cta-primary:focus-visible {
-  transform: translateY(-2px) scale(1.02);
-  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.2), 0 0 20px rgba(52, 211, 153, 0.4);
+  transform: translateY(-1px);
+  background: #31c973;
+  box-shadow: 0 10px 22px rgba(61, 220, 132, 0.22);
+}
+
+.home-cta-secondary:hover,
+.home-cta-secondary:focus-visible {
   background: #f8fafc;
-}
-
-.home-cta-secondary:hover,
-.home-cta-secondary:focus-visible {
-  background: rgba(255, 255, 255, 0.2);
-  border-color: rgba(255, 255, 255, 0.6);
-  transform: translateY(-2px);
-  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.15);
-}
-
-.home-cta-secondary:hover,
-.home-cta-secondary:focus-visible {
-  background: rgba(255, 255, 255, 0.08);
-  border-color: rgba(255, 255, 255, 0.96);
+  border-color: rgba(203, 213, 225, 0.95);
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.08);
 }
 
 @media (max-width: 960px) {
@@ -592,6 +524,16 @@
   .home-hero-main-img {
     aspect-ratio: 1.1 / 1;
     border-radius: 22px;
+  }
+
+  .home-cta {
+    max-width: none;
+    border-radius: 24px;
+  }
+
+  .home-cta-content h2,
+  .home-cta-content p {
+    max-width: none;
   }
 
   .home-hero-floating-card {


### PR DESCRIPTION
## Summary
- align the home closing CTA card with the approved composition
- center the content and simplify the surface to a dark green premium block
- keep the primary CTA for signup and use a coherent mailto contact action for the consultant CTA

## Validation
- npm run build
- npm test -- --run src/Pages/home/Home.test.tsx
- runtime check on / with consoleErrors = 0
