### PR TITLE
Feat: add farm consolidated milk production flow

### DIFF
--- a/src/Models/FarmMilkProductionDTOs.ts
+++ b/src/Models/FarmMilkProductionDTOs.ts
@@ -1,0 +1,51 @@
+export interface FarmMilkProductionUpsertRequestDTO {
+  totalProduced: number;
+  withdrawalProduced?: number | null;
+  marketableProduced?: number | null;
+  notes?: string;
+}
+
+export interface FarmMilkProductionDailySummaryDTO {
+  productionDate: string;
+  registered: boolean;
+  totalProduced: number;
+  withdrawalProduced: number;
+  marketableProduced: number;
+  notes?: string | null;
+  updatedAt?: string | null;
+}
+
+export interface FarmMilkProductionMonthlyDayItemDTO {
+  productionDate: string;
+  totalProduced: number;
+  withdrawalProduced: number;
+  marketableProduced: number;
+  notes?: string | null;
+}
+
+export interface FarmMilkProductionMonthlySummaryDTO {
+  year: number;
+  month: number;
+  totalProduced: number;
+  withdrawalProduced: number;
+  marketableProduced: number;
+  daysRegistered: number;
+  dailyRecords: FarmMilkProductionMonthlyDayItemDTO[];
+}
+
+export interface FarmMilkProductionAnnualMonthItemDTO {
+  month: number;
+  totalProduced: number;
+  withdrawalProduced: number;
+  marketableProduced: number;
+  daysRegistered: number;
+}
+
+export interface FarmMilkProductionAnnualSummaryDTO {
+  year: number;
+  totalProduced: number;
+  withdrawalProduced: number;
+  marketableProduced: number;
+  daysRegistered: number;
+  monthlyRecords: FarmMilkProductionAnnualMonthItemDTO[];
+}

--- a/src/Pages/dashboard/FarmDashboardPage.tsx
+++ b/src/Pages/dashboard/FarmDashboardPage.tsx
@@ -21,6 +21,7 @@ import {
   buildFarmGoatsPath,
   buildFarmHealthAgendaPath,
   buildFarmInventoryPath,
+  buildFarmMilkConsolidatedPath,
 } from "../../utils/appRoutes";
 import { getApiErrorMessage, parseApiError } from "../../utils/apiError";
 import "./FarmDashboardPage.css";
@@ -320,6 +321,13 @@ export function FarmDashboardPageView({
       tone: "secondary",
     },
     {
+      title: "Leite consolidado",
+      description: "Registre a producao operacional diaria da fazenda e acompanhe volumes total, restrito e liberado.",
+      icon: "fa-solid fa-jug-detergent",
+      to: buildFarmMilkConsolidatedPath(safeFarmId),
+      tone: "secondary",
+    },
+    {
       title: "Rebanho",
       description: "Acesse a lista de animais da fazenda e siga para os módulos por cabra quando precisar.",
       icon: "fa-solid fa-tractor",
@@ -343,6 +351,11 @@ export function FarmDashboardPageView({
       label: "Estoque",
       to: buildFarmInventoryPath(safeFarmId),
       icon: "fa-solid fa-boxes-stacked",
+    },
+    {
+      label: "Leite consolidado",
+      to: buildFarmMilkConsolidatedPath(safeFarmId),
+      icon: "fa-solid fa-jug-detergent",
     },
     {
       label: "Alertas",

--- a/src/Pages/lactation/FarmMilkProductionPage.test.tsx
+++ b/src/Pages/lactation/FarmMilkProductionPage.test.tsx
@@ -1,0 +1,187 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import FarmMilkProductionPage from "./FarmMilkProductionPage";
+import { getGoatFarmById } from "../../api/GoatFarmAPI/goatFarm";
+import {
+  getFarmMilkProductionAnnualSummary,
+  getFarmMilkProductionDailySummary,
+  getFarmMilkProductionMonthlySummary,
+  upsertFarmMilkProductionDaily,
+} from "../../api/GoatFarmAPI/farmMilkProduction";
+
+vi.mock("../../api/GoatFarmAPI/goatFarm", () => ({
+  getGoatFarmById: vi.fn(),
+}));
+
+vi.mock("../../api/GoatFarmAPI/farmMilkProduction", () => ({
+  getFarmMilkProductionAnnualSummary: vi.fn(),
+  getFarmMilkProductionDailySummary: vi.fn(),
+  getFarmMilkProductionMonthlySummary: vi.fn(),
+  upsertFarmMilkProductionDaily: vi.fn(),
+}));
+
+vi.mock("react-toastify", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+const mockedGetFarmById = vi.mocked(getGoatFarmById);
+const mockedGetDaily = vi.mocked(getFarmMilkProductionDailySummary);
+const mockedGetMonthly = vi.mocked(getFarmMilkProductionMonthlySummary);
+const mockedGetAnnual = vi.mocked(getFarmMilkProductionAnnualSummary);
+const mockedUpsert = vi.mocked(upsertFarmMilkProductionDaily);
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function setInputValue(input: HTMLInputElement | HTMLTextAreaElement, value: string) {
+  const descriptor = Object.getOwnPropertyDescriptor(
+    Object.getPrototypeOf(input),
+    "value"
+  );
+  descriptor?.set?.call(input, value);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+describe("FarmMilkProductionPage", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    mockedGetFarmById.mockResolvedValue({
+      id: 17,
+      name: "Capril Teste Fluxo Repro 20260317",
+    } as never);
+    mockedGetDaily.mockResolvedValue({
+      productionDate: "2026-03-30",
+      registered: true,
+      totalProduced: 120,
+      withdrawalProduced: 20,
+      marketableProduced: 100,
+      notes: "Leite em carencia separado",
+      updatedAt: "2026-03-30T10:15:00",
+    } as never);
+    mockedGetMonthly.mockResolvedValue({
+      year: 2026,
+      month: 3,
+      totalProduced: 3600,
+      withdrawalProduced: 300,
+      marketableProduced: 3300,
+      daysRegistered: 30,
+      dailyRecords: [
+        {
+          productionDate: "2026-03-30",
+          totalProduced: 120,
+          withdrawalProduced: 20,
+          marketableProduced: 100,
+          notes: "Leite em carencia separado",
+        },
+      ],
+    } as never);
+    mockedGetAnnual.mockResolvedValue({
+      year: 2026,
+      totalProduced: 12400,
+      withdrawalProduced: 800,
+      marketableProduced: 11600,
+      daysRegistered: 90,
+      monthlyRecords: [
+        {
+          month: 3,
+          totalProduced: 3600,
+          withdrawalProduced: 300,
+          marketableProduced: 3300,
+          daysRegistered: 30,
+        },
+      ],
+    } as never);
+    mockedUpsert.mockResolvedValue({
+      productionDate: "2026-03-30",
+      registered: true,
+      totalProduced: 140,
+      withdrawalProduced: 15,
+      marketableProduced: 125,
+      notes: "Ajuste operacional",
+      updatedAt: "2026-03-30T11:00:00",
+    } as never);
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    mockedGetFarmById.mockReset();
+    mockedGetDaily.mockReset();
+    mockedGetMonthly.mockReset();
+    mockedGetAnnual.mockReset();
+    mockedUpsert.mockReset();
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("renders daily, monthly and annual sections for the farm consolidated production", async () => {
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/app/goatfarms/17/milk-consolidated"]}>
+          <Routes>
+            <Route path="/app/goatfarms/:farmId/milk-consolidated" element={<FarmMilkProductionPage />} />
+          </Routes>
+        </MemoryRouter>
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain("Produção consolidada da fazenda");
+    expect(container.textContent).toContain("Semântica do consolidado");
+    expect(container.textContent).toContain("Visão diária");
+    expect(container.textContent).toContain("Visão mensal");
+    expect(container.textContent).toContain("Visão anual");
+    expect(container.textContent).toContain("120,00 L");
+    expect(container.textContent).toContain("3600,00 L");
+    expect(container.textContent).toContain("300,00 L");
+    expect(container.textContent).toContain("3300,00 L");
+  });
+
+  it("submits the daily consolidated form", async () => {
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/app/goatfarms/17/milk-consolidated"]}>
+          <Routes>
+            <Route path="/app/goatfarms/:farmId/milk-consolidated" element={<FarmMilkProductionPage />} />
+          </Routes>
+        </MemoryRouter>
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const formInputs = container.querySelectorAll(".farm-milk-form input");
+    const textarea = container.querySelector(".farm-milk-form textarea") as HTMLTextAreaElement;
+    const saveButton = Array.from(container.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Salvar dia")
+    ) as HTMLButtonElement;
+
+    await act(async () => {
+      setInputValue(formInputs[1] as HTMLInputElement, "140");
+      setInputValue(formInputs[2] as HTMLInputElement, "15");
+      setInputValue(textarea, "Ajuste operacional");
+      saveButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockedUpsert).toHaveBeenCalledWith(17, expect.any(String), {
+      totalProduced: 140,
+      withdrawalProduced: 15,
+      notes: "Ajuste operacional",
+    });
+  });
+});

--- a/src/Pages/lactation/FarmMilkProductionPage.tsx
+++ b/src/Pages/lactation/FarmMilkProductionPage.tsx
@@ -1,0 +1,484 @@
+﻿import { useEffect, useMemo, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { toast } from "react-toastify";
+import PageHeader from "../../Components/pages-headers/PageHeader";
+import { Alert, Button, Card, EmptyState, LoadingState, Table } from "../../Components/ui";
+import {
+  getFarmMilkProductionAnnualSummary,
+  getFarmMilkProductionDailySummary,
+  getFarmMilkProductionMonthlySummary,
+  upsertFarmMilkProductionDaily,
+} from "../../api/GoatFarmAPI/farmMilkProduction";
+import { getGoatFarmById } from "../../api/GoatFarmAPI/goatFarm";
+import type {
+  FarmMilkProductionAnnualSummaryDTO,
+  FarmMilkProductionDailySummaryDTO,
+  FarmMilkProductionMonthlySummaryDTO,
+} from "../../Models/FarmMilkProductionDTOs";
+import type { GoatFarmDTO } from "../../Models/goatFarm";
+import { buildFarmDashboardPath } from "../../utils/appRoutes";
+import { getApiErrorMessage, parseApiError } from "../../utils/apiError";
+import { getTodayLocalDate } from "../../utils/localDate";
+import "./farmMilkProductionPage.css";
+
+const formatVolume = (value?: number | null) => {
+  if (value === null || value === undefined) return "0,00 L";
+  return `${Number(value).toFixed(2).replace(".", ",")} L`;
+};
+
+const formatDate = (value?: string | null) => {
+  if (!value) return "-";
+  return new Date(`${value}T00:00:00`).toLocaleDateString("pt-BR");
+};
+
+const monthInputDefault = new Date().toISOString().slice(0, 7);
+
+const emptyDaily: FarmMilkProductionDailySummaryDTO = {
+  productionDate: getTodayLocalDate(),
+  registered: false,
+  totalProduced: 0,
+  withdrawalProduced: 0,
+  marketableProduced: 0,
+  notes: "",
+  updatedAt: null,
+};
+
+const emptyMonthly: FarmMilkProductionMonthlySummaryDTO = {
+  year: new Date().getFullYear(),
+  month: new Date().getMonth() + 1,
+  totalProduced: 0,
+  withdrawalProduced: 0,
+  marketableProduced: 0,
+  daysRegistered: 0,
+  dailyRecords: [],
+};
+
+const emptyAnnual: FarmMilkProductionAnnualSummaryDTO = {
+  year: new Date().getFullYear(),
+  totalProduced: 0,
+  withdrawalProduced: 0,
+  marketableProduced: 0,
+  daysRegistered: 0,
+  monthlyRecords: [],
+};
+
+export default function FarmMilkProductionPage() {
+  const { farmId } = useParams<{ farmId: string }>();
+  const navigate = useNavigate();
+  const farmIdNumber = useMemo(() => Number(farmId), [farmId]);
+
+  const [farm, setFarm] = useState<GoatFarmDTO | null>(null);
+  const [selectedDate, setSelectedDate] = useState(getTodayLocalDate());
+  const [selectedMonth, setSelectedMonth] = useState(monthInputDefault);
+  const [selectedYear, setSelectedYear] = useState(new Date().getFullYear());
+
+  const [dailySummary, setDailySummary] = useState<FarmMilkProductionDailySummaryDTO>(emptyDaily);
+  const [monthlySummary, setMonthlySummary] = useState<FarmMilkProductionMonthlySummaryDTO>(emptyMonthly);
+  const [annualSummary, setAnnualSummary] = useState<FarmMilkProductionAnnualSummaryDTO>(emptyAnnual);
+
+  const [form, setForm] = useState({
+    totalProduced: "",
+    withdrawalProduced: "",
+    notes: "",
+  });
+
+  const [loadingFarm, setLoadingFarm] = useState(true);
+  const [loadingDaily, setLoadingDaily] = useState(true);
+  const [loadingMonth, setLoadingMonth] = useState(true);
+  const [loadingYear, setLoadingYear] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [dailyError, setDailyError] = useState("");
+  const [monthError, setMonthError] = useState("");
+  const [yearError, setYearError] = useState("");
+
+  const computedMarketable = useMemo(() => {
+    const total = Number(form.totalProduced || 0);
+    const withdrawal = Number(form.withdrawalProduced || 0);
+    const raw = total - withdrawal;
+    return raw >= 0 ? raw : 0;
+  }, [form.totalProduced, form.withdrawalProduced]);
+
+  useEffect(() => {
+    if (!Number.isFinite(farmIdNumber) || farmIdNumber <= 0) return;
+    let active = true;
+
+    async function loadFarm() {
+      try {
+        setLoadingFarm(true);
+        const result = await getGoatFarmById(farmIdNumber);
+        if (!active) return;
+        setFarm(result);
+      } catch (error) {
+        if (!active) return;
+        toast.error(getApiErrorMessage(parseApiError(error)));
+      } finally {
+        if (active) setLoadingFarm(false);
+      }
+    }
+
+    void loadFarm();
+    return () => {
+      active = false;
+    };
+  }, [farmIdNumber]);
+
+  useEffect(() => {
+    if (!Number.isFinite(farmIdNumber) || farmIdNumber <= 0) return;
+    let active = true;
+
+    async function loadDaily() {
+      try {
+        setLoadingDaily(true);
+        setDailyError("");
+        const result = await getFarmMilkProductionDailySummary(farmIdNumber, selectedDate);
+        if (!active) return;
+        setDailySummary(result);
+        setForm({
+          totalProduced: result.registered ? String(result.totalProduced) : "",
+          withdrawalProduced: result.registered ? String(result.withdrawalProduced) : "",
+          notes: result.notes || "",
+        });
+      } catch (error) {
+        if (!active) return;
+        setDailyError(getApiErrorMessage(parseApiError(error)));
+      } finally {
+        if (active) setLoadingDaily(false);
+      }
+    }
+
+    void loadDaily();
+    return () => {
+      active = false;
+    };
+  }, [farmIdNumber, selectedDate]);
+
+  useEffect(() => {
+    if (!Number.isFinite(farmIdNumber) || farmIdNumber <= 0) return;
+    let active = true;
+
+    async function loadMonthly() {
+      const [year, month] = selectedMonth.split("-").map(Number);
+      try {
+        setLoadingMonth(true);
+        setMonthError("");
+        const result = await getFarmMilkProductionMonthlySummary(farmIdNumber, year, month);
+        if (!active) return;
+        setMonthlySummary(result);
+      } catch (error) {
+        if (!active) return;
+        setMonthError(getApiErrorMessage(parseApiError(error)));
+      } finally {
+        if (active) setLoadingMonth(false);
+      }
+    }
+
+    void loadMonthly();
+    return () => {
+      active = false;
+    };
+  }, [farmIdNumber, selectedMonth]);
+
+  useEffect(() => {
+    if (!Number.isFinite(farmIdNumber) || farmIdNumber <= 0) return;
+    let active = true;
+
+    async function loadAnnual() {
+      try {
+        setLoadingYear(true);
+        setYearError("");
+        const result = await getFarmMilkProductionAnnualSummary(farmIdNumber, selectedYear);
+        if (!active) return;
+        setAnnualSummary(result);
+      } catch (error) {
+        if (!active) return;
+        setYearError(getApiErrorMessage(parseApiError(error)));
+      } finally {
+        if (active) setLoadingYear(false);
+      }
+    }
+
+    void loadAnnual();
+    return () => {
+      active = false;
+    };
+  }, [farmIdNumber, selectedYear]);
+
+  async function handleSubmit() {
+    if (!Number.isFinite(farmIdNumber) || farmIdNumber <= 0) return;
+
+    const total = Number(form.totalProduced);
+    const withdrawal = Number(form.withdrawalProduced || 0);
+
+    if (Number.isNaN(total) || total < 0) {
+      toast.error("Informe o total produzido do dia.");
+      return;
+    }
+    if (Number.isNaN(withdrawal) || withdrawal < 0) {
+      toast.error("Informe um volume restrito válido.");
+      return;
+    }
+    if (withdrawal > total) {
+      toast.error("O volume restrito não pode ser maior que o total produzido.");
+      return;
+    }
+
+    try {
+      setSubmitting(true);
+      const result = await upsertFarmMilkProductionDaily(farmIdNumber, selectedDate, {
+        totalProduced: total,
+        withdrawalProduced: withdrawal,
+        notes: form.notes || undefined,
+      });
+      setDailySummary(result);
+      toast.success("Produção consolidada salva.");
+
+      const [year, month] = selectedMonth.split("-").map(Number);
+      if (year === Number(selectedDate.slice(0, 4)) && month === Number(selectedDate.slice(5, 7))) {
+        const refreshedMonth = await getFarmMilkProductionMonthlySummary(farmIdNumber, year, month);
+        setMonthlySummary(refreshedMonth);
+      }
+      if (selectedYear === Number(selectedDate.slice(0, 4))) {
+        const refreshedYear = await getFarmMilkProductionAnnualSummary(farmIdNumber, selectedYear);
+        setAnnualSummary(refreshedYear);
+      }
+    } catch (error) {
+      toast.error(getApiErrorMessage(parseApiError(error)));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (loadingFarm && !farm) {
+    return <LoadingState label="Carregando produção consolidada da fazenda..." />;
+  }
+
+  return (
+    <div className="farm-milk-page lactation-page">
+      <section className="lactation-page__hero">
+        <PageHeader
+          title={"Produ\u00e7\u00e3o consolidada da fazenda"}
+          subtitle={`${farm?.name || "Fazenda"} · Leitura operacional de leite por dia, mês e ano`}
+          showBackButton
+          backTo={buildFarmDashboardPath(farmIdNumber)}
+          actions={
+            <div className="lactation-page__actions">
+              <Button variant="outline" onClick={() => navigate(buildFarmDashboardPath(farmIdNumber))}>
+                <i className="fa-solid fa-chart-line" aria-hidden="true"></i> Dashboard da fazenda
+              </Button>
+            </div>
+          }
+        />
+      </section>
+
+      <Alert variant="info" title={"Sem\u00e2ntica do consolidado"}>
+        {"A produ\u00e7\u00e3o individual por cabra continua existindo para an\u00e1lise zoot\u00e9cnica. Esta p\u00e1gina registra o consolidado operacional da fazenda, separado entre total registrado, volume restrito por car\u00eancia e volume liberado/comercializ\u00e1vel."}
+      </Alert>
+
+      <section className="farm-milk-grid">
+        <Card
+          className="farm-milk-card"
+          title={"Lan\u00e7amento di\u00e1rio consolidado"}
+          description={"Um registro operacional por fazenda e data, com atualiza\u00e7\u00e3o segura do mesmo dia."}
+        >
+          <div className="farm-milk-form">
+            <label>
+              <span>Data</span>
+              <input type="date" value={selectedDate} max={getTodayLocalDate()} onChange={(event) => setSelectedDate(event.target.value)} />
+            </label>
+            <label>
+              <span>Total produzido (L)</span>
+              <input
+                type="number"
+                min="0"
+                step="0.01"
+                value={form.totalProduced}
+                onChange={(event) => setForm((prev) => ({ ...prev, totalProduced: event.target.value }))}
+              />
+            </label>
+            <label>
+              <span>{"Restrito / em car\u00eancia (L)"}</span>
+              <input
+                type="number"
+                min="0"
+                step="0.01"
+                value={form.withdrawalProduced}
+                onChange={(event) => setForm((prev) => ({ ...prev, withdrawalProduced: event.target.value }))}
+              />
+            </label>
+            <label>
+              <span>{"Liberado / comercializ\u00e1vel (L)"}</span>
+              <input type="number" value={computedMarketable.toFixed(2)} disabled />
+            </label>
+            <label className="farm-milk-form__full">
+              <span>{"Observa\u00e7\u00f5es"}</span>
+              <textarea
+                rows={3}
+                value={form.notes}
+                onChange={(event) => setForm((prev) => ({ ...prev, notes: event.target.value }))}
+              />
+            </label>
+            <div className="farm-milk-form__actions">
+              <Button variant="primary" onClick={() => void handleSubmit()} disabled={submitting}>
+                {submitting ? "Salvando..." : "Salvar dia"}
+              </Button>
+            </div>
+          </div>
+        </Card>
+
+        <Card
+          className="farm-milk-card"
+          title={"Vis\u00e3o di\u00e1ria"}
+          description="Leitura operacional do dia selecionado."
+        >
+          {loadingDaily ? <LoadingState label="Carregando dia..." /> : null}
+          {!loadingDaily && dailyError ? <Alert variant="danger" title="Erro ao carregar o dia">{dailyError}</Alert> : null}
+          {!loadingDaily && !dailyError && (
+            <>
+              <div className="farm-milk-stats">
+                <article className="farm-milk-stat">
+                  <span>Total registrado</span>
+                  <strong>{formatVolume(dailySummary.totalProduced)}</strong>
+                </article>
+                <article className="farm-milk-stat">
+                  <span>Restrito</span>
+                  <strong>{formatVolume(dailySummary.withdrawalProduced)}</strong>
+                </article>
+                <article className="farm-milk-stat">
+                  <span>Liberado</span>
+                  <strong>{formatVolume(dailySummary.marketableProduced)}</strong>
+                </article>
+              </div>
+              <div className="farm-milk-note">
+                <span>Status do dia</span>
+                <strong>{dailySummary.registered ? "Consolidado registrado" : "Nenhum consolidado salvo"}</strong>
+                <p>{dailySummary.notes || "Sem observações para esta data."}</p>
+              </div>
+            </>
+          )}
+        </Card>
+      </section>
+
+      <section className="farm-milk-grid farm-milk-grid--summary">
+        <Card
+          className="farm-milk-card"
+          title={"Vis\u00e3o mensal"}
+          description={"Totaliza os registros di\u00e1rios consolidados do m\u00eas selecionado."}
+        >
+          <div className="farm-milk-toolbar">
+            <label>
+              <span>{"M\u00eas"}</span>
+              <input type="month" value={selectedMonth} onChange={(event) => setSelectedMonth(event.target.value)} />
+            </label>
+          </div>
+          {loadingMonth ? <LoadingState label={"Carregando m\u00eas..."} /> : null}
+          {!loadingMonth && monthError ? <Alert variant="danger" title={"Erro ao carregar o m\u00eas"}>{monthError}</Alert> : null}
+          {!loadingMonth && !monthError && (
+            <>
+              <div className="farm-milk-stats">
+                <article className="farm-milk-stat">
+                  <span>{"Total do m\u00eas"}</span>
+                  <strong>{formatVolume(monthlySummary.totalProduced)}</strong>
+                </article>
+                <article className="farm-milk-stat">
+                  <span>{"Restrito no m\u00eas"}</span>
+                  <strong>{formatVolume(monthlySummary.withdrawalProduced)}</strong>
+                </article>
+                <article className="farm-milk-stat">
+                  <span>{"Liberado no m\u00eas"}</span>
+                  <strong>{formatVolume(monthlySummary.marketableProduced)}</strong>
+                </article>
+              </div>
+              {monthlySummary.dailyRecords.length === 0 ? (
+                <EmptyState title={"Sem consolidado no m\u00eas"} description={"Ainda n\u00e3o h\u00e1 registros di\u00e1rios consolidados para este m\u00eas."} />
+              ) : (
+                <Table>
+                  <thead>
+                    <tr>
+                      <th>Data</th>
+                      <th>Total</th>
+                      <th>Restrito</th>
+                      <th>Liberado</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {monthlySummary.dailyRecords.map((record) => (
+                      <tr key={record.productionDate}>
+                        <td>{formatDate(record.productionDate)}</td>
+                        <td>{formatVolume(record.totalProduced)}</td>
+                        <td>{formatVolume(record.withdrawalProduced)}</td>
+                        <td>{formatVolume(record.marketableProduced)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </Table>
+              )}
+            </>
+          )}
+        </Card>
+
+        <Card
+          className="farm-milk-card"
+          title={"Vis\u00e3o anual"}
+          description="Acumulado do ano, organizado por mês."
+        >
+          <div className="farm-milk-toolbar">
+            <label>
+              <span>Ano</span>
+              <input
+                type="number"
+                min="2020"
+                max="2100"
+                value={selectedYear}
+                onChange={(event) => setSelectedYear(Number(event.target.value))}
+              />
+            </label>
+          </div>
+          {loadingYear ? <LoadingState label="Carregando ano..." /> : null}
+          {!loadingYear && yearError ? <Alert variant="danger" title="Erro ao carregar o ano">{yearError}</Alert> : null}
+          {!loadingYear && !yearError && (
+            <>
+              <div className="farm-milk-stats">
+                <article className="farm-milk-stat">
+                  <span>Total do ano</span>
+                  <strong>{formatVolume(annualSummary.totalProduced)}</strong>
+                </article>
+                <article className="farm-milk-stat">
+                  <span>Restrito no ano</span>
+                  <strong>{formatVolume(annualSummary.withdrawalProduced)}</strong>
+                </article>
+                <article className="farm-milk-stat">
+                  <span>Liberado no ano</span>
+                  <strong>{formatVolume(annualSummary.marketableProduced)}</strong>
+                </article>
+              </div>
+              <Table>
+                <thead>
+                  <tr>
+                    <th>{"M\u00eas"}</th>
+                    <th>Total</th>
+                    <th>Restrito</th>
+                    <th>Liberado</th>
+                    <th>Dias</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {annualSummary.monthlyRecords.map((record) => (
+                    <tr key={record.month}>
+                      <td>{String(record.month).padStart(2, "0")}/{annualSummary.year}</td>
+                      <td>{formatVolume(record.totalProduced)}</td>
+                      <td>{formatVolume(record.withdrawalProduced)}</td>
+                      <td>{formatVolume(record.marketableProduced)}</td>
+                      <td>{record.daysRegistered}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </Table>
+            </>
+          )}
+        </Card>
+      </section>
+    </div>
+  );
+}
+
+

--- a/src/Pages/lactation/MilkProductionPage.tsx
+++ b/src/Pages/lactation/MilkProductionPage.tsx
@@ -24,6 +24,7 @@ import type {
 } from "../../Models/MilkProductionDTOs";
 import type { GoatResponseDTO } from "../../Models/goatResponseDTO";
 import { parseApiError, type ParsedApiError } from "../../utils/apiError";
+import { buildFarmMilkConsolidatedPath } from "../../utils/appRoutes";
 import { formatLocalDatePtBR, getTodayLocalDate } from "../../utils/localDate";
 import "./milkProductionPage.css";
 
@@ -388,6 +389,12 @@ export default function MilkProductionPage() {
             <div className="lactation-page__actions">
               <Button
                 variant="outline"
+                onClick={() => navigate(buildFarmMilkConsolidatedPath(farmIdNumber))}
+              >
+                <i className="fa-solid fa-jug-detergent" aria-hidden="true"></i> Consolidado da fazenda
+              </Button>
+              <Button
+                variant="outline"
                 onClick={() => navigate(`/app/goatfarms/${farmId}/goats/${goatId}/lactations`)}
               >
                 <i className="fa-solid fa-circle-nodes" aria-hidden="true"></i> Lactações
@@ -459,6 +466,12 @@ export default function MilkProductionPage() {
                 }
               >
                 <i className="fa-solid fa-plus" aria-hidden="true"></i> Registrar produção
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() => navigate(buildFarmMilkConsolidatedPath(farmIdNumber))}
+              >
+                <i className="fa-solid fa-jug-detergent" aria-hidden="true"></i> Abrir consolidado
               </Button>
               <Button
                 variant="outline"

--- a/src/Pages/lactation/farmMilkProductionPage.css
+++ b/src/Pages/lactation/farmMilkProductionPage.css
@@ -1,0 +1,123 @@
+.farm-milk-page {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.farm-milk-grid {
+  display: grid;
+  grid-template-columns: 1.1fr 0.9fr;
+  gap: 1.5rem;
+}
+
+.farm-milk-grid--summary {
+  grid-template-columns: 1fr;
+}
+
+.farm-milk-card {
+  border: none;
+  box-shadow: 0 16px 36px rgba(15, 23, 42, 0.05);
+  backdrop-filter: blur(8px);
+}
+
+.farm-milk-form {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.farm-milk-form label,
+.farm-milk-toolbar label {
+  display: grid;
+  gap: 0.45rem;
+  font-size: 0.95rem;
+  color: #64748b;
+}
+
+.farm-milk-form input,
+.farm-milk-form textarea,
+.farm-milk-toolbar input {
+  width: 100%;
+  padding: 0.85rem 0.95rem;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(255, 255, 255, 0.92);
+  color: #0f172a;
+}
+
+.farm-milk-form__full {
+  grid-column: 1 / -1;
+}
+
+.farm-milk-form__actions {
+  grid-column: 1 / -1;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.farm-milk-stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.farm-milk-stat {
+  display: grid;
+  gap: 0.35rem;
+  padding: 1rem 1.1rem;
+  border-radius: 18px;
+  background: linear-gradient(180deg, rgba(236, 253, 245, 0.95), rgba(255, 255, 255, 0.96));
+  border: 1px solid rgba(16, 185, 129, 0.14);
+}
+
+.farm-milk-stat span {
+  color: #64748b;
+  font-size: 0.9rem;
+}
+
+.farm-milk-stat strong {
+  color: #0f172a;
+  font-size: 1.35rem;
+}
+
+.farm-milk-note {
+  padding: 1rem 1.1rem;
+  border-radius: 18px;
+  background: rgba(248, 250, 252, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.farm-milk-note span {
+  display: block;
+  color: #64748b;
+  font-size: 0.9rem;
+  margin-bottom: 0.35rem;
+}
+
+.farm-milk-note strong {
+  display: block;
+  color: #0f172a;
+  margin-bottom: 0.4rem;
+}
+
+.farm-milk-note p {
+  margin: 0;
+  color: #475569;
+}
+
+.farm-milk-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 1rem;
+}
+
+@media (max-width: 1024px) {
+  .farm-milk-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .farm-milk-form,
+  .farm-milk-stats {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/api/GoatFarmAPI/farmMilkProduction.test.ts
+++ b/src/api/GoatFarmAPI/farmMilkProduction.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { requestBackEnd } from "../../utils/request";
+import {
+  getFarmMilkProductionAnnualSummary,
+  getFarmMilkProductionDailySummary,
+  getFarmMilkProductionMonthlySummary,
+  upsertFarmMilkProductionDaily,
+} from "./farmMilkProduction";
+
+vi.mock("../../utils/request", () => ({
+  requestBackEnd: {
+    get: vi.fn(),
+    put: vi.fn(),
+  },
+}));
+
+describe("Farm milk production API", () => {
+  const mockedGet = vi.mocked(requestBackEnd.get);
+  const mockedPut = vi.mocked(requestBackEnd.put);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("upserts the daily consolidated production using the farm milk route", async () => {
+    mockedPut.mockResolvedValueOnce({
+      data: {
+        productionDate: "2026-03-30",
+        registered: true,
+        totalProduced: 120,
+        withdrawalProduced: 20,
+        marketableProduced: 100,
+        notes: "Leite restrito por carencia",
+      },
+    });
+
+    const result = await upsertFarmMilkProductionDaily(17, "2026-03-30", {
+      totalProduced: 120,
+      withdrawalProduced: 20,
+      notes: "Leite restrito por carencia",
+    });
+
+    expect(mockedPut).toHaveBeenCalledWith(
+      "/goatfarms/17/milk-consolidated-productions/2026-03-30",
+      {
+        totalProduced: 120,
+        withdrawalProduced: 20,
+        notes: "Leite restrito por carencia",
+      }
+    );
+    expect(result.marketableProduced).toBe(100);
+  });
+
+  it("loads daily, monthly and annual summaries from the canonical routes", async () => {
+    mockedGet
+      .mockResolvedValueOnce({
+        data: {
+          productionDate: "2026-03-30",
+          registered: true,
+          totalProduced: 120,
+          withdrawalProduced: 20,
+          marketableProduced: 100,
+          notes: null,
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          year: 2026,
+          month: 3,
+          totalProduced: 3600,
+          withdrawalProduced: 300,
+          marketableProduced: 3300,
+          daysRegistered: 30,
+          dailyRecords: [],
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          year: 2026,
+          totalProduced: 12400,
+          withdrawalProduced: 800,
+          marketableProduced: 11600,
+          daysRegistered: 90,
+          monthlyRecords: [],
+        },
+      });
+
+    const daily = await getFarmMilkProductionDailySummary(17, "2026-03-30");
+    const monthly = await getFarmMilkProductionMonthlySummary(17, 2026, 3);
+    const annual = await getFarmMilkProductionAnnualSummary(17, 2026);
+
+    expect(mockedGet).toHaveBeenNthCalledWith(
+      1,
+      "/goatfarms/17/milk-consolidated-productions/daily",
+      { params: { date: "2026-03-30" } }
+    );
+    expect(mockedGet).toHaveBeenNthCalledWith(
+      2,
+      "/goatfarms/17/milk-consolidated-productions/monthly",
+      { params: { year: 2026, month: 3 } }
+    );
+    expect(mockedGet).toHaveBeenNthCalledWith(
+      3,
+      "/goatfarms/17/milk-consolidated-productions/annual",
+      { params: { year: 2026 } }
+    );
+    expect(daily.totalProduced).toBe(120);
+    expect(monthly.daysRegistered).toBe(30);
+    expect(annual.marketableProduced).toBe(11600);
+  });
+});

--- a/src/api/GoatFarmAPI/farmMilkProduction.ts
+++ b/src/api/GoatFarmAPI/farmMilkProduction.ts
@@ -1,0 +1,53 @@
+import { requestBackEnd } from "../../utils/request";
+import type {
+  FarmMilkProductionAnnualSummaryDTO,
+  FarmMilkProductionDailySummaryDTO,
+  FarmMilkProductionMonthlySummaryDTO,
+  FarmMilkProductionUpsertRequestDTO,
+} from "../../Models/FarmMilkProductionDTOs";
+
+const getBaseUrl = (farmId: number) =>
+  `/goatfarms/${farmId}/milk-consolidated-productions`;
+
+export async function upsertFarmMilkProductionDaily(
+  farmId: number,
+  productionDate: string,
+  payload: FarmMilkProductionUpsertRequestDTO
+): Promise<FarmMilkProductionDailySummaryDTO> {
+  const { data } = await requestBackEnd.put(
+    `${getBaseUrl(farmId)}/${productionDate}`,
+    payload
+  );
+  return data;
+}
+
+export async function getFarmMilkProductionDailySummary(
+  farmId: number,
+  date: string
+): Promise<FarmMilkProductionDailySummaryDTO> {
+  const { data } = await requestBackEnd.get(`${getBaseUrl(farmId)}/daily`, {
+    params: { date },
+  });
+  return data;
+}
+
+export async function getFarmMilkProductionMonthlySummary(
+  farmId: number,
+  year: number,
+  month: number
+): Promise<FarmMilkProductionMonthlySummaryDTO> {
+  const { data } = await requestBackEnd.get(`${getBaseUrl(farmId)}/monthly`, {
+    params: { year, month },
+  });
+  return data;
+}
+
+export async function getFarmMilkProductionAnnualSummary(
+  farmId: number,
+  year: number
+): Promise<FarmMilkProductionAnnualSummaryDTO> {
+  const { data } = await requestBackEnd.get(`${getBaseUrl(farmId)}/annual`, {
+    params: { year },
+  });
+  return data;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -39,6 +39,7 @@ import Logout from "./routes/PrivateRoute";
 
 // Pages for Lactation and Reproduction
 import LactationPage from "./Pages/lactation/LactationPage";
+import FarmMilkProductionPage from "./Pages/lactation/FarmMilkProductionPage";
 import MilkProductionPage from "./Pages/lactation/MilkProductionPage";
 import ReproductionPage from "./Pages/reproduction/ReproductionPage";
 import GoatGenealogyViewPage from "./Pages/genealogy/GoatGenealogyViewPage";
@@ -141,6 +142,14 @@ const router = createBrowserRouter([
         element: (
           <PrivateRoute roles={[RoleEnum.ROLE_FARM_OWNER, RoleEnum.ROLE_OPERATOR, RoleEnum.ROLE_ADMIN]}>
             <LactationPage />
+          </PrivateRoute>
+        ),
+      },
+      {
+        path: "app/goatfarms/:farmId/milk-consolidated",
+        element: (
+          <PrivateRoute roles={[RoleEnum.ROLE_FARM_OWNER, RoleEnum.ROLE_OPERATOR, RoleEnum.ROLE_ADMIN]}>
+            <FarmMilkProductionPage />
           </PrivateRoute>
         ),
       },

--- a/src/utils/appRoutes.ts
+++ b/src/utils/appRoutes.ts
@@ -10,6 +10,9 @@ export const buildFarmInventoryPath = (farmId: string | number): string =>
 export const buildFarmCommercialPath = (farmId: string | number): string =>
   `/app/goatfarms/${encodePathSegment(farmId)}/commercial`;
 
+export const buildFarmMilkConsolidatedPath = (farmId: string | number): string =>
+  `/app/goatfarms/${encodePathSegment(farmId)}/milk-consolidated`;
+
 export const buildFarmAlertsPath = (farmId: string | number): string =>
   `/app/goatfarms/${encodePathSegment(farmId)}/alerts`;
 


### PR DESCRIPTION
## Resumo
- adiciona a tela de produção consolidada da fazenda no frontend
- integra dashboard e módulo individual de leite
- exibe visões diária, mensal e anual com total, restrito e liberado
- ajusta PT-BR final da página consolidada

## Validação
- npm test -- --run
- npm run lint
- npm run build
- npm run test:e2e
- runtime real em /app/goatfarms/17/milk-consolidated com 205 / 40 / 165 e sem erros de console