### PR TITLE
Chore: add frontend docker packaging for production deploy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.github
+.husky
+node_modules
+dist
+test-results
+.tmp-lighthouse
+.tmp-playwright
+logs
+*.log
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# syntax=docker/dockerfile:1.7
+
+FROM node:22-bookworm-slim AS build
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+RUN npm install --no-save @rollup/rollup-linux-x64-gnu
+
+COPY . .
+
+ARG VITE_API_BASE_URL
+ARG VITE_ENABLE_DEPRECATED_API_FALLBACK=false
+
+ENV VITE_API_BASE_URL=${VITE_API_BASE_URL}
+ENV VITE_ENABLE_DEPRECATED_API_FALLBACK=${VITE_ENABLE_DEPRECATED_API_FALLBACK}
+
+RUN npm run build
+
+FROM nginx:1.27-alpine
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist /usr/share/nginx/html
+
+EXPOSE 80

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,29 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location /api/ {
+        proxy_pass http://backend:8080/api/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /actuator/health {
+        proxy_pass http://backend:8080/actuator/health;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## Summary
- add frontend Docker packaging for production deploy
- add nginx SPA config with backend proxy support
- add docker ignore for clean production image builds

## Validation
- docker build --build-arg VITE_API_BASE_URL=https://app.seu-dominio.com -t caprigestor-frontend:predeploy-check .