### PR TITLE
Fix: block public actuator fallback in deploy nginx

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -5,8 +5,16 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
-    location /api/ {
-        proxy_pass http://backend:8080/api/;
+    location = /actuator {
+        return 403;
+    }
+
+    location ^~ /actuator/ {
+        return 403;
+    }
+
+    location = /actuator/health {
+        proxy_pass http://backend:8080/actuator/health;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -14,8 +22,8 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    location /actuator/health {
-        proxy_pass http://backend:8080/actuator/health;
+    location /api/ {
+        proxy_pass http://backend:8080/api/;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Summary
- block /actuator and /actuator/ at the frontend nginx layer
- keep /actuator/health proxied for closed smoke and host-level health checks

## Validation
- docker build --build-arg VITE_API_BASE_URL=https://app.seu-dominio.com -t caprigestor-frontend:cutover-hardening-check .
- runtime check with a backend upstream alias showing /actuator = 403